### PR TITLE
release: Address flakiness in rsync task in cap deploy (#380)

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -50,3 +50,7 @@ Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
 
 set :rbenv_type, :user
 set :rbenv_ruby, '2.6.6'
+
+
+# for local precompile, we have a timeout error sometimes, add a longer timeout
+set :rsync_cmd, "rsync -av --delete --timeout 300"                  # default: "rsync -av --delete"


### PR DESCRIPTION

* add rsync timeout 300 seconds

Co-authored-by: donrestarone <shashikejayatunge@gmail.co>