### PR TITLE
[Bug fix] set forum notification email origin explicitly

### DIFF
--- a/app/mailers/simple_discussion/user_mailer.rb
+++ b/app/mailers/simple_discussion/user_mailer.rb
@@ -1,0 +1,29 @@
+class SimpleDiscussion::UserMailer < ApplicationMailer
+  # You can set the default `from` address in ApplicationMailer
+
+  helper SimpleDiscussion::ForumPostsHelper
+  helper SimpleDiscussion::Engine.routes.url_helpers
+
+  def new_thread(forum_thread, recipient)
+    @forum_thread = forum_thread
+    @forum_post = forum_thread.forum_posts.first
+    @recipient = recipient
+    mail(
+      from: "#{forum_thread.user.name} <#{forum_thread.user.email}>",
+      to: "#{@recipient.name} <#{@recipient.email}>",
+      subject: @forum_thread.title
+    )
+  end
+
+  def new_post(forum_post, recipient)
+    @forum_post = forum_post
+    @forum_thread = forum_post.forum_thread
+    @recipient = recipient
+    
+    mail(
+      from: "#{forum_post.user.name} <#{forum_post.user.email}>",
+      to: "#{@recipient.name} <#{@recipient.email}>",
+      subject: "New post in #{@forum_thread.title}"
+    )
+  end
+end


### PR DESCRIPTION
prevent defaulting to application mailer from address, set it in the simple_discussion engine instead
(#420)