### PR TITLE
[Feature] Add api plugin subdomain events (#433)

### DIFF
--- a/app/controllers/comfy/admin/web_settings_controller.rb
+++ b/app/controllers/comfy/admin/web_settings_controller.rb
@@ -37,6 +37,7 @@ class Comfy::Admin::WebSettingsController < Comfy::Admin::Cms::BaseController
       :ember_enabled,
       :graphql_enabled,
       :web_console_enabled,
+      :api_plugin_events_enabled,
       :after_sign_in_path,
       :after_sign_up_path
     )

--- a/app/controllers/simple_discussion/forum_posts_controller.rb
+++ b/app/controllers/simple_discussion/forum_posts_controller.rb
@@ -11,6 +11,7 @@ class SimpleDiscussion::ForumPostsController < SimpleDiscussion::ApplicationCont
 
     if @forum_post.save
       SimpleDiscussion::ForumPostNotificationJob.perform_later(@forum_post)
+      ApiNamespace::Plugin::V1::SubdomainEventsService.new(@forum_post).track_event
       redirect_to simple_discussion.forum_thread_path(@forum_thread, anchor: "forum_post_#{@forum_post.id}")
     else
       render template: "simple_discussion/forum_threads/show"

--- a/app/controllers/simple_discussion/forum_threads_controller.rb
+++ b/app/controllers/simple_discussion/forum_threads_controller.rb
@@ -45,6 +45,7 @@ class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationCo
 
     if @forum_thread.save
       SimpleDiscussion::ForumThreadNotificationJob.perform_later(@forum_thread)
+      ApiNamespace::Plugin::V1::SubdomainEventsService.new(@forum_thread).track_event
       redirect_to simple_discussion.forum_thread_path(@forum_thread)
     else
       render action: :new

--- a/app/mailboxes/e_mailbox.rb
+++ b/app/mailboxes/e_mailbox.rb
@@ -19,6 +19,7 @@ class EMailbox < ApplicationMailbox
             from: mail.from.join(', '),
             attachments: (attachments + multipart_attached).map{ |a| a[:blob] }
           )
+          ApiNamespace::Plugin::V1::SubdomainEventsService.new(message).track_event
         else
           # this is a bounce (came up to the correct subdomain, but nonexistant local name)
         end

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -42,6 +42,13 @@ class ApiNamespace < ApplicationRecord
   has_many :error_api_actions, dependent: :destroy
   accepts_nested_attributes_for :error_api_actions, allow_destroy: true
 
+  REGISTERED_PLUGINS = {
+    subdomain_events: {
+      slug: 'subdomain_events',
+      version: 1,
+    }
+  }
+
   def update_api_form
     if has_form == '1'
       if api_form.present? 

--- a/app/services/api_namespace/plugin/v1/subdomain_events_service.rb
+++ b/app/services/api_namespace/plugin/v1/subdomain_events_service.rb
@@ -1,0 +1,39 @@
+class ApiNamespace::Plugin::V1::SubdomainEventsService
+  def initialize(object)
+    @object = object
+  end
+
+  def track_event
+    return if !Subdomain.current.api_plugin_events_enabled
+    api_namespace = ApiNamespace.find_by(slug: ApiNamespace::REGISTERED_PLUGINS[:subdomain_events][:slug], version: ApiNamespace::REGISTERED_PLUGINS[:subdomain_events][:version])
+    # to-do this should not be an issue. see https://github.com/restarone/violet_rails/issues/327
+    normalized_props = api_namespace.properties.class == Hash ? api_namespace.properties : JSON.parse(api_namespace.properties)
+    api_properties = normalized_props.deep_symbolize_keys    
+    object_type = @object.class.to_s
+    domain_with_fallback = Apartment::Tenant.current != 'public' ? Subdomain.current.name : Apartment::Tenant.current
+    resource_properties = {
+      model: {
+        record_id: @object.id,
+        record_type: object_type
+      }
+    }
+    case object_type
+    when 'Message'
+      # to-do plug in validations, make sure the same message doesnt have 2 events created after it 
+      resource_properties[:representation] = {
+        body: "New Email @ #{domain_with_fallback}.#{ENV['APP_HOST']} - from: #{@object.from}"
+      }
+    when 'ForumThread'
+      created_by_user = @object.user
+      resource_properties[:representation] = {
+        body: "New Forum Thread @ #{domain_with_fallback}.#{ENV['APP_HOST']} - created by: #{created_by_user.name} (#{created_by_user.email})"
+      }
+    when 'ForumPost'
+      created_by_user = @object.user
+      resource_properties[:representation] = {
+        body: "New Forum Post @ #{domain_with_fallback}.#{ENV['APP_HOST']} - created by: #{created_by_user.name} (#{created_by_user.email})"
+      }
+    end
+    ApiResourceSpawnJob.perform_async(api_namespace.id, resource_properties)
+  end
+end

--- a/app/sidekiq/api_resource_spawn_job.rb
+++ b/app/sidekiq/api_resource_spawn_job.rb
@@ -1,0 +1,11 @@
+class ApiResourceSpawnJob
+  include Sidekiq::Job
+
+  def perform(api_namespace_id, json = {})
+    api_namespace = ApiNamespace.find(api_namespace_id)
+    api_resource = api_namespace.api_resources.create!(
+      properties: json
+    )
+    api_namespace.executed_api_actions.each{|action| action.execute_action}
+  end
+end

--- a/app/views/comfy/admin/web_settings/_form.haml
+++ b/app/views/comfy/admin/web_settings/_form.haml
@@ -30,7 +30,7 @@
 
 .my-5
   %strong
-    Extensions
+    Core Extensions
 .form-group
   %label
     Blog:
@@ -53,6 +53,14 @@
   %label
     Web console (experimental):
   = f.check_box :web_console_enabled
+
+.my-5
+  %strong
+    API Extensions
+.form-group
+  %label
+    Subdomain Events (subdomain/event v1):
+  = f.check_box :api_plugin_events_enabled
 
 
 .my-5

--- a/db/migrate/20220420153229_add_plugin_subdomain_events_to_api.rb
+++ b/db/migrate/20220420153229_add_plugin_subdomain_events_to_api.rb
@@ -1,0 +1,34 @@
+class AddPluginSubdomainEventsToApi < ActiveRecord::Migration[6.1]
+  def change
+    # docs: https://github.com/restarone/violet_rails/issues/430
+    ApiNamespace.create!(
+      name: 'subdomain/event',
+      slug: 'subdomain_events',
+      version: 1,
+      requires_authentication: true,
+      namespace_type: 'create-read-update-delete',
+      properties: {
+        model_definition: {
+          record_id: {
+            type: "integer",
+            validations: {
+              allow_blank: false,
+              primary_key: true,
+              unique: true
+            }
+          },
+          record_type: {
+            type: "string",
+            validations: {
+              allow_blank: false
+            }
+          }
+        }
+      }
+    )
+
+    change_table :subdomains do |t|
+      t.boolean :api_plugin_events_enabled, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -464,6 +464,7 @@ ActiveRecord::Schema.define(version: 2022_04_22_003307) do
     t.boolean "ember_enabled", default: false
     t.boolean "graphql_enabled", default: false
     t.boolean "web_console_enabled", default: false
+    t.boolean "api_plugin_events_enabled", default: false
     t.string "after_sign_up_path"
     t.string "after_sign_in_path"
     t.index ["deleted_at"], name: "index_subdomains_on_deleted_at"

--- a/test/controllers/admin/comfy/api_resources_controller_test.rb
+++ b/test/controllers/admin/comfy/api_resources_controller_test.rb
@@ -45,13 +45,13 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
 
   test "should show api_resource" do
     sign_in(@user)
-    get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: ApiResource.last.id)
+    get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
     assert_response :success
   end
 
   test "should get edit" do
     sign_in(@user)
-    get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: ApiResource.last.id)
+    get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
     assert_response :success
   end
 

--- a/test/fixtures/api_actions.yml
+++ b/test/fixtures/api_actions.yml
@@ -89,5 +89,16 @@ error_api_action_two:
   redirect_url: '/'
   api_namespace: one
 
+create_api_action_plugin_subdomain_events:
+  type: CreateApiAction
+  action_type: send_web_request
+  include_api_resource_data: true
+  payload_mapping: >
+    {
+      "content": "#{self.representation.body}"
+    }
+  request_url: "http://www.example.com/success"
+  api_namespace: plugin_subdomain_events
+  http_method: post
 
 

--- a/test/fixtures/api_namespaces.yml
+++ b/test/fixtures/api_namespaces.yml
@@ -44,3 +44,28 @@ array_namespace:
   requires_authentication: false
   namespace_type: create-read-update-delete
 
+plugin_subdomain_events:
+  name: subdomain/subdomain_events
+  slug: subdomain_events
+  version: 1
+  requires_authentication: true
+  namespace_type: create-read-update-delete
+  properties:  >
+    {
+      "model_definition": {
+        "record_id": {
+          "type": "integer",
+          "validations": {
+            "allow_blank": false,
+            "primary_key": true,
+            "unique": true
+          }
+        },
+        "record_type": {
+          "type": "string",
+          "validations": {
+            "allow_blank": false
+          }
+        }
+      }
+    }

--- a/test/fixtures/api_resources.yml
+++ b/test/fixtures/api_resources.yml
@@ -23,3 +23,16 @@ two:
 user:
   api_namespace: users
   properties: {first_name: "Don", last_name: "Restarone"}
+
+plugin_subdomain_message_event:
+  api_namespace: plugin_subdomain_events
+  properties:  >
+    {
+      "model": {
+        "record_id": 1,
+        "record_type": "Message"
+      },
+      "representation": {
+        "body": "<h1>Hello</h1>"
+      }
+    }

--- a/test/models/api_namespace_test.rb
+++ b/test/models/api_namespace_test.rb
@@ -1,7 +1,38 @@
 require "test_helper"
 
 class ApiNamespaceTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @subdomain = subdomains(:public)
+    @subdomain.update(api_plugin_events_enabled: true)
+    @subdomain_events_api = api_namespaces(:plugin_subdomain_events)
+    @subdomain_events_api.api_resources.destroy_all
+    @message_thread = message_threads(:public)
+    @message = @message_thread.messages.create!(content: "Hello")
+    Sidekiq::Testing.fake!
+  end
+
+  test "plugin: subdomain/subdomain_events -> tracks message creation by creating ApiResource" do
+    service = ApiNamespace::Plugin::V1::SubdomainEventsService.new(@message)
+    assert_difference "ApiResource.count", +1 do      
+      service.track_event
+      Sidekiq::Worker.drain_all
+    end
+    resource = @subdomain_events_api.api_resources.reload.last
+    model =  resource.properties["model"]
+    representation =  resource.properties["representation"]
+    assert_equal ["model", "representation"].sort, resource.properties.keys.sort
+    assert_equal ["record_id", "record_type"].sort, model.keys.sort
+    assert_equal model["record_type"].constantize, Message
+    assert model["record_type"].constantize.send(:find, model["record_id"])
+    assert_equal representation["body"].class, String
+  end
+
+  test "plugin: subdomain/subdomain_events -> tracks message creation by creating ApiResource & running actions" do
+    service = ApiNamespace::Plugin::V1::SubdomainEventsService.new(@message)
+    assert_difference "ApiResource.count", +1 do      
+      service.track_event
+      Sidekiq::Worker.drain_all
+    end
+    assert_equal @subdomain_events_api.executed_api_actions.first.reload.lifecycle_stage, 'failed'
+  end
 end


### PR DESCRIPTION
feature request: https://github.com/restarone/violet_rails/issues/430

* add basic fixture for plugin_subdomain_events
* 
* basic implementation + test to verify that it doesnt work when it shouldnt

* hook into emailbox to create notification when emails are received

* execute create api actions

* api action payload mapping issue

* fix nesting

* add trackability to forum + add more tests

* fix tests by using the api action execution correctly

* add more assertions and be more picky about the plugin version

* refactor

Co-authored-by: donrestarone <shashikejayatunge@gmail.co>