### PR TITLE
[bug fix] fix canonical user permissions after subdomain creation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,11 +38,16 @@ class User < ApplicationRecord
   ]
 
   FULL_PERMISSIONS = {
+    can_access_admin: true,
     can_manage_web: true,
     can_manage_email: true,
     can_manage_users: true,
     can_manage_blog: true,
-    can_manage_api: true
+    can_manage_api: true,
+    can_manage_subdomain_settings: true,
+    can_manage_api: true,
+    can_view_restricted_pages: true,
+    moderator: true
   }
 
   SESSION_TIMEOUT = [

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,13 +1,9 @@
-
-User.create!(
+user = User.create!(
   email: 'violet@rails.com', 
   password: '123456', 
   password_confirmation: '123456', 
   global_admin: true, 
-  confirmed_at: Time.now,
-  can_manage_web: true,
-  can_manage_email: true,
-  can_manage_users: true,
-  can_manage_blog: true
+  confirmed_at: Time.now
 )
+user.update!(User::FULL_PERMISSIONS)
 Subdomain.unsafe_bootstrap_www_subdomain


### PR DESCRIPTION

* fix broken seeds

* update full user permissions object with newly introduced permissions so canonical users don't get locked out

Co-authored-by: donrestarone <shashikejayatunge@gmail.co>