### PR TITLE
Prevent multiple api clients from running at the same time

### DIFF
--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -45,7 +45,10 @@ class ExternalApiClient < ApplicationRecord
   end
 
   def run
+    # prevent triggering if its not enabled or the status is error (means that the custom model definition raised an error and it bubbled up)
     return false if !self.enabled || self.status == ExternalApiClient::STATUSES[:error]
+    # prevent race conditions, if a client is running already-- dont run
+    return false if self.status == ExternalApiClient::STATUSES[:running]
     ExternalApiClientJob.perform_async(self.id)
   end
 

--- a/app/sidekiq/external_api_client_job.rb
+++ b/app/sidekiq/external_api_client_job.rb
@@ -32,8 +32,9 @@ class ExternalApiClientJob
           }
         )
       end
+    else
+      # if run successfully we stop the job until the next invocation
+      external_api_client.update(status: ExternalApiClient::STATUSES[:stopped])
     end
-    # after all set to stopped
-    external_api_client.update(status: ExternalApiClient::STATUSES[:stopped])
   end
 end

--- a/app/sidekiq/external_api_client_job.rb
+++ b/app/sidekiq/external_api_client_job.rb
@@ -33,5 +33,7 @@ class ExternalApiClientJob
         )
       end
     end
+    # after all set to stopped
+    external_api_client.update(status: ExternalApiClient::STATUSES[:stopped])
   end
 end

--- a/test/controllers/admin/comfy/external_api_clients_controller_test.rb
+++ b/test/controllers/admin/comfy/external_api_clients_controller_test.rb
@@ -15,7 +15,6 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test "should allow #start" do
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
-    previous_state = @external_api_client.reload
     get start_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
     assert_response :redirect
     Sidekiq::Worker.drain_all

--- a/test/models/external_api_client_test.rb
+++ b/test/models/external_api_client_test.rb
@@ -4,6 +4,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
   setup do
     @external_api_client = external_api_clients(:test)
     Sidekiq::Testing.fake!
+    @external_api_client.update!(status: ExternalApiClient::STATUSES[:sleeping])
   end
 
   test "returns false if not enabled" do
@@ -20,6 +21,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     assert @external_api_client.retry_in_seconds == 0
     error_message = "Gateway unavailable"
     @external_api_client.evaluated_model_definition.any_instance.stubs(:start).raises(StandardError, error_message)
+    
     assert_changes "@external_api_client.reload.status" do
       @external_api_client.run
       Sidekiq::Worker.drain_all


### PR DESCRIPTION
Prevent multiple api clients from running at the same time