### PR TITLE
[bug fix release request] Prevent multiple api clients from running at the same time,  switch forum over from using activejob to sidekiq

### DIFF
--- a/app/controllers/simple_discussion/forum_posts_controller.rb
+++ b/app/controllers/simple_discussion/forum_posts_controller.rb
@@ -10,7 +10,7 @@ class SimpleDiscussion::ForumPostsController < SimpleDiscussion::ApplicationCont
     @forum_post.user_id = current_user.id
 
     if @forum_post.save
-      SimpleDiscussion::ForumPostNotificationJob.perform_later(@forum_post)
+      ForumPostNotificationJob.perform_async(@forum_post.id)
       ApiNamespace::Plugin::V1::SubdomainEventsService.new(@forum_post).track_event
       redirect_to simple_discussion.forum_thread_path(@forum_thread, anchor: "forum_post_#{@forum_post.id}")
     else

--- a/app/controllers/simple_discussion/forum_threads_controller.rb
+++ b/app/controllers/simple_discussion/forum_threads_controller.rb
@@ -44,7 +44,7 @@ class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationCo
     @forum_thread.forum_posts.each { |post| post.user_id = current_user.id }
 
     if @forum_thread.save
-      SimpleDiscussion::ForumThreadNotificationJob.perform_later(@forum_thread)
+      ForumThreadNotificationJob.perform_async(@forum_thread.id)
       ApiNamespace::Plugin::V1::SubdomainEventsService.new(@forum_thread).track_event
       redirect_to simple_discussion.forum_thread_path(@forum_thread)
     else

--- a/app/jobs/forum_post_notification_job.rb
+++ b/app/jobs/forum_post_notification_job.rb
@@ -1,0 +1,44 @@
+class ForumPostNotificationJob
+  include SimpleDiscussion::Engine.routes.url_helpers
+  include Sidekiq::Job
+
+  def perform(forum_post_id)
+    forum_post = ForumPost.find(forum_post_id)
+    send_emails(forum_post) if SimpleDiscussion.send_email_notifications
+    send_webhook(forum_post) if SimpleDiscussion.send_slack_notifications
+  end
+
+  def send_emails(forum_post)
+    forum_thread = forum_post.forum_thread
+    users = forum_thread.subscribed_users - [forum_post.user]
+    users.each do |user|
+      SimpleDiscussion::UserMailer.new_post(forum_post, user).deliver_now
+    end
+  end
+
+  def send_webhook(forum_post)
+    slack_webhook_url = Rails.application.secrets.simple_discussion_slack_url
+    return if slack_webhook_url.blank?
+
+    forum_thread = forum_post.forum_thread
+    payload = {
+      fallback: "#{forum_post.user.name} replied to <#{forum_thread_url(forum_thread, anchor: ActionView::RecordIdentifier.dom_id(forum_post))}|#{forum_thread.title}>",
+      pretext: "#{forum_post.user.name} replied to <#{forum_thread_url(forum_thread, anchor: ActionView::RecordIdentifier.dom_id(forum_post))}|#{forum_thread.title}>",
+      fields: [
+        {
+          title: "Thread",
+          value: forum_thread.title,
+          short: true
+        },
+        {
+          title: "Posted By",
+          value: forum_post.user.name,
+          short: true
+        }
+      ],
+      ts: forum_post.created_at.to_i
+    }
+
+    SimpleDiscussion::Slack.new(slack_webhook_url).post(payload)
+  end
+end

--- a/app/jobs/forum_thread_notification_job.rb
+++ b/app/jobs/forum_thread_notification_job.rb
@@ -1,0 +1,42 @@
+class ForumThreadNotificationJob
+  include SimpleDiscussion::Engine.routes.url_helpers
+  include Sidekiq::Job
+
+  def perform(forum_thread_id)
+    forum_thread = ForumThread.find(forum_thread_id)
+    send_emails(forum_thread) if SimpleDiscussion.send_email_notifications
+    send_webhook(forum_thread) if SimpleDiscussion.send_slack_notifications
+  end
+
+  def send_emails(forum_thread)
+    forum_thread.notify_users.each do |user|
+      SimpleDiscussion::UserMailer.new_thread(forum_thread, user).deliver_now
+    end
+  end
+
+  def send_webhook(forum_thread)
+    slack_webhook_url = Rails.application.secrets.simple_discussion_slack_url
+    return if slack_webhook_url.blank?
+
+    forum_post = forum_thread.forum_posts.first
+    payload = {
+      fallback: "A new discussion was started: <#{forum_thread_url(forum_thread, anchor: ActionView::RecordIdentifier.dom_id(forum_post))}|#{forum_thread.title}>",
+      pretext: "A new discussion was started: <#{forum_thread_url(forum_thread, anchor: ActionView::RecordIdentifier.dom_id(forum_post))}|#{forum_thread.title}>",
+      fields: [
+        {
+          title: "Thread",
+          value: forum_thread.title,
+          short: true
+        },
+        {
+          title: "Posted By",
+          value: forum_post.user.name,
+          short: true
+        }
+      ],
+      ts: forum_post.created_at.to_i
+    }
+
+    SimpleDiscussion::Slack.new(slack_webhook_url).post(payload)
+  end
+end

--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -40,8 +40,21 @@ class ExternalApiClient < ApplicationRecord
 
   validates :drive_every, inclusion: { in: ExternalApiClient::DRIVE_INTERVALS.keys.map(&:to_s) }, allow_blank: true, allow_nil: true
 
-  def self.cron_jobs(interval)
-    ExternalApiClient.where(drive_strategy: ExternalApiClient::DRIVE_STRATEGIES[:cron], drive_every: interval)
+  def self.cron_jobs
+    intervals = ExternalApiClient.pluck(:drive_every).compact
+    runnable_external_api_clients = []
+    ExternalApiClient.where(drive_strategy: ExternalApiClient::DRIVE_STRATEGIES[:cron]).each do |external_api_client|
+      if !external_api_client.last_run_at
+        runnable_external_api_clients << external_api_client
+        next
+      end
+      last_run = ExternalApiClient::DRIVE_INTERVALS[external_api_client.drive_every.to_sym]
+      if external_api_client.last_run_at < Time.at(eval("#{last_run}.ago"))
+        runnable_external_api_clients << external_api_client
+      end
+      next
+    end
+    return runnable_external_api_clients
   end
 
   def run

--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -45,7 +45,10 @@ class ExternalApiClient < ApplicationRecord
   end
 
   def run
+    # prevent triggering if its not enabled or the status is error (means that the custom model definition raised an error and it bubbled up)
     return false if !self.enabled || self.status == ExternalApiClient::STATUSES[:error]
+    # prevent race conditions, if a client is running already-- dont run
+    return false if self.status == ExternalApiClient::STATUSES[:running]
     ExternalApiClientJob.perform_async(self.id)
   end
 

--- a/app/sidekiq/api_resource_spawn_job.rb
+++ b/app/sidekiq/api_resource_spawn_job.rb
@@ -7,6 +7,6 @@ class ApiResourceSpawnJob
       # convert back to hash because sidekiq doesnt like taking a hash as an argument-- it prefers json instead
       properties: JSON.parse(json_string).to_h
     )
-    api_namespace.executed_api_actions.each{|action| action.execute_action}
+    api_resource.api_actions.each{|action| action.execute_action}
   end
 end

--- a/app/sidekiq/external_api_client_job.rb
+++ b/app/sidekiq/external_api_client_job.rb
@@ -3,6 +3,7 @@ class ExternalApiClientJob
 
   def perform(id)
     external_api_client = ExternalApiClient.find_by(id: id)
+    external_api_client.update(last_run_at: Time.now)
     external_api_interface = external_api_client.evaluated_model_definition
     external_api_client_runner = external_api_interface.new(external_api_client: external_api_client)
     retries = nil

--- a/app/sidekiq/external_api_client_job.rb
+++ b/app/sidekiq/external_api_client_job.rb
@@ -34,7 +34,7 @@ class ExternalApiClientJob
       end
     else
       # if run successfully we stop the job until the next invocation
-      external_api_client.update(status: ExternalApiClient::STATUSES[:stopped])
+      external_api_client.stop
     end
   end
 end

--- a/app/sidekiq/external_api_client_job.rb
+++ b/app/sidekiq/external_api_client_job.rb
@@ -32,6 +32,9 @@ class ExternalApiClientJob
           }
         )
       end
+    else
+      # if run successfully we stop the job until the next invocation
+      external_api_client.update(status: ExternalApiClient::STATUSES[:stopped])
     end
   end
 end

--- a/app/views/comfy/admin/external_api_clients/show.html.haml
+++ b/app/views/comfy/admin/external_api_clients/show.html.haml
@@ -36,6 +36,9 @@
   %b Max requests/minute:
   = @external_api_client.max_requests_per_minute
 %p
+  %b Last run at:
+  = @external_api_client.last_run_at
+%p
   %b Current requests/minute:
   = @external_api_client.current_requests_per_minute
 %p
@@ -44,6 +47,9 @@
 %p
   %b Current workers:
   = @external_api_client.current_workers
+%p
+  %b Current retries:
+  = @external_api_client.retries
 %p
   %b Retry in seconds:
   = @external_api_client.retry_in_seconds

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,79 +27,9 @@ every 12.hours do
   rake "maintenance:clear_old_ahoy_visits"
 end
 
-
-
-# external API client cron jobs
-# ideally we can do something like this in the future
-# ExternalApiClient::DRIVE_INTERVALS.keys.each do |key|
-#   every eval(ExternalApiClient::DRIVE_INTERVALS[key]) do
-#     rake "external_api_client:drive_cron_jobs CRON_INTERVAL=#{key}"
-#   end
-# end
 every 1.minute do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=every_minute"
+  rake "external_api_client:drive_cron_jobs"
 end
-
-every 5.minutes do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=five_minutes"
-end
-
-every 10.minutes do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=ten_minutes"
-end
-
-every 30.minutes do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=thirty_minutes"
-end
-
-every 1.hour do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=every_hour"
-end
-
-every 3.hours do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=three_hours"
-end
-
-every 6.hours do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=six_hours"
-end
-
-every 12.hours do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=twelve_hours"
-end
-
-every 1.day do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=one_day"
-end
-
-every 1.week do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=one_week"
-end
-
-every 2.weeks do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=two_weeks"
-end
-
-every 1.month do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=one_month"
-end
-
-every 3.months do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=three_months"
-end
-
-every 6.months do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=six_months"
-end
-
-every 1.year do
-  rake "external_api_client:drive_cron_jobs CRON_INTERVAL=one_year"
-end
-#  end
-
-
-
-
 
 every 1.day do
   rake "report:send_analytics_report"

--- a/db/migrate/20220430125538_add_last_run_to_external_api_client.rb
+++ b/db/migrate/20220430125538_add_last_run_to_external_api_client.rb
@@ -1,0 +1,7 @@
+class AddLastRunToExternalApiClient < ActiveRecord::Migration[6.1]
+  def change
+    change_table :external_api_clients do |t|
+      t.datetime :last_run_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_23_235433) do
+ActiveRecord::Schema.define(version: 2022_04_30_125538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,6 +335,7 @@ ActiveRecord::Schema.define(version: 2022_04_23_235433) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "drive_every"
+    t.datetime "last_run_at"
     t.index ["api_namespace_id"], name: "index_external_api_clients_on_api_namespace_id"
   end
 

--- a/lib/tasks/external_api_client.rake
+++ b/lib/tasks/external_api_client.rake
@@ -2,10 +2,9 @@ namespace :external_api_client do
   desc "tasks for connecting to external systems (anything backed by ExternalApiClient"
   
   task :drive_cron_jobs => [:environment] do |t, args|
-    Subdomain.all.to_a.push(Subdomain.new(name: 'public')).each do |subdomain|
+    Subdomain.all.each do |subdomain|
       Apartment::Tenant.switch subdomain.name do
-        # ENV['CRON_INTERVAL'] is passed by schedule.rb
-        external_api_clients = ExternalApiClient.cron_jobs(ENV['CRON_INTERVAL'])
+        external_api_clients = ExternalApiClient.cron_jobs
         p "**running #{external_api_clients.size} ExternalApiClient cron jobs for #{subdomain.name}** @ #{Time.now}"
         external_api_clients.each do |external_api_client|
           external_api_client.run

--- a/test/controllers/admin/comfy/external_api_clients_controller_test.rb
+++ b/test/controllers/admin/comfy/external_api_clients_controller_test.rb
@@ -15,7 +15,6 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test "should allow #start" do
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
-    previous_state = @external_api_client.reload
     get start_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
     assert_response :redirect
     Sidekiq::Worker.drain_all

--- a/test/models/external_api_client_test.rb
+++ b/test/models/external_api_client_test.rb
@@ -4,6 +4,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
   setup do
     @external_api_client = external_api_clients(:test)
     Sidekiq::Testing.fake!
+    @external_api_client.update!(status: ExternalApiClient::STATUSES[:sleeping])
   end
 
   test "returns false if not enabled" do
@@ -20,6 +21,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     assert @external_api_client.retry_in_seconds == 0
     error_message = "Gateway unavailable"
     @external_api_client.evaluated_model_definition.any_instance.stubs(:start).raises(StandardError, error_message)
+    
     assert_changes "@external_api_client.reload.status" do
       @external_api_client.run
       Sidekiq::Worker.drain_all

--- a/test/tasks/external_api_client_cron_job_test.rb
+++ b/test/tasks/external_api_client_cron_job_test.rb
@@ -16,11 +16,10 @@ class ExternalApiClientCronJobTest < ActiveSupport::TestCase
   test 'invoke task for running external api client tasks' do
     error_msg = 'error!'
     @external_api_client.evaluated_model_definition.any_instance.stubs(:start).raises(StandardError, error_msg)
-    # passed by schedule.rb
-    ENV['CRON_INTERVAL'] = @external_api_client.drive_every
     refute @external_api_client.reload.error_message
     Rake::Task["external_api_client:drive_cron_jobs"].invoke
     Sidekiq::Worker.drain_all
     assert_equal @external_api_client.reload.error_message, error_msg
+    assert @external_api_client.last_run_at
   end
 end


### PR DESCRIPTION
* add early return to prevent external api client job from spawning if another is running
* prevent overlapping cronjobs from running by cleaning up schedule.rb (we have a externalApiClient job discovery system that pools every minute now)
* switch forum over from using activejob to sidekiq (we need to phase out activejob since a lot of the flakiness is coming from that system). 
* fix multiple actions firing from subdomain events plugin