### PR TITLE
[release candidate] non renderable fields in API form, custom API action, Ahoy.js (+ add to exception notification), Allow analytics query via GQL, correct scoping in ApiNamespace

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,8 @@ class ApplicationController < ActionController::Base
 
   def prepare_exception_notifier
     request.env["exception_notifier.exception_data"] = {
-      current_user: current_user
+      current_user: current_user,
+      current_visit: current_visit
     }
   end
 end

--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -86,7 +86,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
-      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email,:custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
+      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email,:custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy, :method_definition]
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,

--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -10,6 +10,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
   # GET /api_resources/1 or /api_resources/1.json
   def show
+    handle_custom_actions if @custom_actions.present?
     handle_redirection if @redirect_action.present?
   end
 
@@ -28,6 +29,8 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
     respond_to do |format|
       if @api_resource.save
+        handle_custom_actions if @custom_actions.present?
+
         format.html { redirect_to api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully created." }
         format.json { render :show, status: :created, location: @api_resource }
       else
@@ -42,7 +45,9 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
   def update
     respond_to do |format|
       if @api_resource.update(api_resource_params)
-        format.html {  handle_redirection }
+        handle_custom_actions if @custom_actions.present?
+
+        format.html { handle_redirection }
         format.json { render :show, status: :ok, location: @api_resource }
       else
         execute_error_actions
@@ -55,6 +60,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
   # DELETE /api_resources/1 or /api_resources/1.json
   def destroy
     @api_resource.destroy
+    handle_custom_actions if @custom_actions.present?
     respond_to do |format|
       format.html { redirect_to api_namespace_resources_url(api_namespace_id: @api_namespace.id), notice: "Api resource was successfully destroyed." }
       format.json { head :no_content }

--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -10,9 +10,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
   # GET /api_resources/1 or /api_resources/1.json
   def show
-    handle_custom_actions if @custom_actions.present?
-    handle_serve_file_action if @serve_file_action.present?
-    handle_redirection if @redirect_action.present?
+    execute_api_actions
   end
 
   # GET /api_resources/new
@@ -31,18 +29,12 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
     respond_to do |format|
       if @api_resource.save
         load_api_actions_from_api_resource
-        handle_custom_actions if @custom_actions.present?
-        handle_serve_file_action if @serve_file_action.present?
-        # TO DO: this needs to be handled as well
-        # handle_redirection if @redirect_action.present?
+        execute_api_actions
 
-        format.html {
-          if @redirect_action.present?
-            handle_redirection
-          else
-            redirect_to api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully created."
-          end
-        }
+        # Preventing double render error
+        return if @redirect_action.present?
+
+        format.html { redirect_to api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully created." }
         format.json { render :show, status: :created, location: @api_resource }
       else
         execute_error_actions
@@ -56,10 +48,12 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
   def update
     respond_to do |format|
       if @api_resource.update(api_resource_params)
-        handle_custom_actions if @custom_actions.present?
-        handle_serve_file_action if @serve_file_action.present?
+        execute_api_actions
 
-        format.html { handle_redirection }
+        # Preventing double render error
+        return if @redirect_action.present?
+
+        format.html { redirect_to edit_api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully updates." }
         format.json { render :show, status: :ok, location: @api_resource }
       else
         execute_error_actions

--- a/app/controllers/comfy/admin/external_api_clients_controller.rb
+++ b/app/controllers/comfy/admin/external_api_clients_controller.rb
@@ -5,7 +5,7 @@ class Comfy::Admin::ExternalApiClientsController < Comfy::Admin::Cms::BaseContro
   
     # GET /api_clients or /api_clients.json
     def index
-      @external_api_clients = ExternalApiClient.all
+      @external_api_clients = @api_namespace.external_api_clients
     end
   
     # GET /api_clients/1 or /api_clients/1.json

--- a/app/controllers/comfy/admin/web_settings_controller.rb
+++ b/app/controllers/comfy/admin/web_settings_controller.rb
@@ -40,7 +40,8 @@ class Comfy::Admin::WebSettingsController < Comfy::Admin::Cms::BaseController
       :web_console_enabled,
       :api_plugin_events_enabled,
       :after_sign_in_path,
-      :after_sign_up_path
+      :after_sign_up_path,
+      :allow_external_analytics_query
     )
   end
 end

--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -11,26 +11,42 @@ module ApiActionable
 
 
   def check_for_custom_actions
-    @custom_actions = @api_namespace.send(api_action_name).where(action_type: 'custom_action')
+    @custom_actions = if @api_resource.present?
+                        @api_resource.send(api_action_name).where(action_type: 'custom_action', lifecycle_stage: 'initialized')
+                      else
+                        @api_namespace.send(api_action_name).where(action_type: 'custom_action')
+                      end
+
   end
 
   def check_for_redirect_action
-    @redirect_action = @api_namespace.send(api_action_name).where(action_type: 'redirect').last
+    @redirect_action = if @api_resource.present?
+                          @api_resource.send(api_action_name).where(action_type: 'redirect', lifecycle_stage: 'initialized').last
+                        else
+                          @api_namespace.send(api_action_name).where(action_type: 'redirect').last
+                        end
   end
 
   def check_for_serve_file_action
-    serve_file_action = @api_namespace.send(api_action_name).where(action_type: 'serve_file').last
-    return if serve_file_action.nil?
+    @serve_file_action = if @api_resource.present?
+                            @api_resource.send(api_action_name).where(action_type: 'serve_file', lifecycle_stage: 'initialized').last
+                          else
+                            @api_namespace.send(api_action_name).where(action_type: 'serve_file').last
+                          end
+  end
 
-    serve_file_action.update(lifecycle_stage: 'executing')
-    file_id = helpers.file_id_from_snippet(serve_file_action.file_snippet)
+  def handle_serve_file_action
+    return if @serve_file_action.nil?
+
+    @serve_file_action.update(lifecycle_stage: 'executing')
+    file_id = helpers.file_id_from_snippet(@serve_file_action.file_snippet)
     file = Comfy::Cms::File.find(file_id)
     if params[:action] == 'show' && @redirect_action.nil?
       flash.now[:file_url] = rails_blob_url(file.attachment)
     else
       flash[:file_url] = rails_blob_url(file.attachment)
     end
-    serve_file_action.update(lifecycle_stage: 'complete', lifecycle_message: "label: #{file.label} id: #{file.id} mime_type: #{file.attachment.content_type}")
+    @serve_file_action.update(lifecycle_stage: 'complete', lifecycle_message: "label: #{file.label} id: #{file.id} mime_type: #{file.attachment.content_type}")
   end
 
   def handle_custom_actions
@@ -41,9 +57,9 @@ module ApiActionable
           custom_api_action = CustomApiAction.new
 
           eval("def custom_api_action.run_custom_action(api_action: , api_namespace:, api_resource: , current_visit: , current_user: nil); #{custom_action.method_definition};end;")
-          custom_api_action.run_custom_action(api_action: custom_action, api_namespace: @api_namespace, api_resource: @api_resource, current_visit: current_visit, current_user: current_user)
-
-          custom_action.update(lifecycle_stage: 'complete', lifecycle_message: "everything went well")
+          response = custom_api_action.run_custom_action(api_action: custom_action, api_namespace: @api_namespace, api_resource: @api_resource, current_visit: current_visit, current_user: current_user)
+          response = response.present? ? response.as_json : "everything went well."
+          custom_action.update(lifecycle_stage: 'complete', lifecycle_message: response)
         rescue => e
           custom_action.update(lifecycle_stage: 'failed', lifecycle_message: e.message)
           execute_error_actions
@@ -109,5 +125,11 @@ module ApiActionable
     @api_namespace.send(action_name).each do |action|
       @api_resource.send(action_name).create(action.attributes.merge(custom_message: action.custom_message.to_s).except("id", "created_at", "updated_at", "api_namespace_id"))
     end
+  end
+
+  def load_api_actions_from_api_resource
+    @custom_actions = @api_resource.send(api_action_name).where(action_type: 'custom_action', lifecycle_stage: 'initialized') if @custom_actions.present?
+    @redirect_action = @api_resource.send(api_action_name).where(action_type: 'redirect', lifecycle_stage: 'initialized').last if @redirect_action.present?
+    @serve_file_action = @api_resource.send(api_action_name).where(action_type: 'serve_file', lifecycle_stage: 'initialized').last if @serve_file_action.present?
   end
 end

--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -2,12 +2,17 @@ module ApiActionable
   extend ActiveSupport::Concern
   included do
     before_action :initialize_api_actions, only: [:update, :show, :destroy]
+    before_action :check_for_custom_actions, only: [:create, :update, :show, :destroy]
     before_action :check_for_redirect_action, only: [:create, :update, :show, :destroy]
     after_action :execute_api_actions, only: [:show, :create, :update, :destroy]
     before_action :check_for_serve_file_action, only: [:show, :create, :update, :destroy]
     rescue_from StandardError, with: :handle_error
   end
 
+
+  def check_for_custom_actions
+    @custom_actions = @api_namespace.send(api_action_name).where(action_type: 'custom_action')
+  end
 
   def check_for_redirect_action
     @redirect_action = @api_namespace.send(api_action_name).where(action_type: 'redirect').last
@@ -26,6 +31,27 @@ module ApiActionable
       flash[:file_url] = rails_blob_url(file.attachment)
     end
     serve_file_action.update(lifecycle_stage: 'complete', lifecycle_message: "label: #{file.label} id: #{file.id} mime_type: #{file.attachment.content_type}")
+  end
+
+  def handle_custom_actions
+    flash[:notice] = @api_namespace.api_form.success_message
+    if @custom_actions.present?
+      @custom_actions.each do |custom_action|
+        begin
+          custom_api_action = CustomApiAction.new
+
+          eval("def custom_api_action.run_custom_action(api_action: , api_namespace:, api_resource: , current_visit: , current_user: nil); #{custom_action.method_definition};end;")
+          custom_api_action.run_custom_action(api_action: custom_action, api_namespace: @api_namespace, api_resource: @api_resource, current_visit: current_visit, current_user: current_user)
+
+          custom_action.update(lifecycle_stage: 'complete', lifecycle_message: "everything went well")
+        rescue => e
+          custom_action.update(lifecycle_stage: 'failed', lifecycle_message: e.message)
+          execute_error_actions
+
+          raise
+        end
+      end
+    end
   end
 
   def handle_redirection
@@ -64,7 +90,7 @@ module ApiActionable
 
     if redirect_action
       redirect_action.update(lifecycle_stage: 'complete', lifecycle_message: redirect_action.redirect_url)
-      redirect_to redirect_action.redirect_url and return 
+      redirect_to redirect_action.redirect_url and return
     end
   end
 

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -1,12 +1,13 @@
 class ResourceController < ApplicationController
   before_action :load_api_namespace
-  
+
   include ApiActionable
 
   def create
     @api_resource = @api_namespace.api_resources.new(resource_params)
     if @api_namespace&.api_form&.show_recaptcha
       if verify_recaptcha(model: @api_resource) && @api_resource.save
+        handle_custom_actions
         handle_redirection
       else
         execute_error_actions
@@ -14,6 +15,7 @@ class ResourceController < ApplicationController
         redirect_back(fallback_location: root_path)
       end
     elsif @api_resource.save
+      handle_custom_actions
       handle_redirection
     else
       execute_error_actions
@@ -21,7 +23,7 @@ class ResourceController < ApplicationController
       redirect_back(fallback_location: root_path)
     end
   end
-  
+
   private
 
   def load_api_namespace
@@ -36,7 +38,7 @@ class ResourceController < ApplicationController
       end
     end
   end
-  
+
   def resource_params
     params.require(:data).permit(properties: {}, non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :_destroy])
   end

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -8,9 +8,7 @@ class ResourceController < ApplicationController
     if @api_namespace&.api_form&.show_recaptcha
       if verify_recaptcha(model: @api_resource) && @api_resource.save
         load_api_actions_from_api_resource
-        handle_custom_actions
-        handle_serve_file_action
-        handle_redirection
+        execute_api_actions
       else
         execute_error_actions
         flash[:error] = @api_resource.errors.full_messages.to_sentence
@@ -18,9 +16,7 @@ class ResourceController < ApplicationController
       end
     elsif @api_resource.save
       load_api_actions_from_api_resource
-      handle_custom_actions
-      handle_serve_file_action
-      handle_redirection
+      execute_api_actions
     else
       execute_error_actions
       flash[:error] = @api_namespace.api_form.failure_message if @api_namespace.api_form.present?

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -7,7 +7,9 @@ class ResourceController < ApplicationController
     @api_resource = @api_namespace.api_resources.new(resource_params)
     if @api_namespace&.api_form&.show_recaptcha
       if verify_recaptcha(model: @api_resource) && @api_resource.save
+        load_api_actions_from_api_resource
         handle_custom_actions
+        handle_serve_file_action
         handle_redirection
       else
         execute_error_actions
@@ -15,7 +17,9 @@ class ResourceController < ApplicationController
         redirect_back(fallback_location: root_path)
       end
     elsif @api_resource.save
+      load_api_actions_from_api_resource
       handle_custom_actions
+      handle_serve_file_action
       handle_redirection
     else
       execute_error_actions

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -26,14 +26,18 @@ class ResourceController < ApplicationController
 
   def load_api_namespace
     @api_namespace = ApiNamespace.find_by(id: params[:api_namespace_id])
+    parse_incoming_resource_parameters
   end
-  
-  def resource_params
+
+  def parse_incoming_resource_parameters
     @api_namespace.properties.each do |key, value|
       if value.class.to_s == 'Hash'
         params[:data][:properties][key] = JSON.parse params[:data][:properties][key]
       end
     end
+  end
+  
+  def resource_params
     params.require(:data).permit(properties: {}, non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :_destroy])
   end
 end

--- a/app/graphql/types/ahoy/event_names_type.rb
+++ b/app/graphql/types/ahoy/event_names_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  class Ahoy::EventNamesType < Types::BaseObject
+
+    field :name, String
+
+    def self.authorized?(object, context)
+      if Subdomain.current.allow_external_analytics_query
+        return true
+      end
+      return false
+    end
+  end
+end

--- a/app/graphql/types/ahoy/events_type.rb
+++ b/app/graphql/types/ahoy/events_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  class Ahoy::EventsType < Types::BaseObject
+    field :id, ID, null: false
+    field :visit_id, Integer
+    field :user_id, Integer
+    field :name, String
+    field :properties, GraphQL::Types::JSON
+    field :time, GraphQL::Types::ISO8601DateTime
+
+    def self.authorized?(object, context)
+      if Subdomain.current.allow_external_analytics_query
+        return true
+      end
+      return false
+    end
+  end
+end

--- a/app/graphql/types/ahoy/visits_type.rb
+++ b/app/graphql/types/ahoy/visits_type.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Types
+  class Ahoy::VisitsType < Types::BaseObject
+    field :id, ID, null: false
+    field :visit_token, String
+    field :visitor_token, String
+    field :user_id, Integer
+    field :ip, String
+    field :user_agent, String
+    field :referrer, String
+    field :referring_domain, String
+    field :landing_page, String
+    field :browser, String
+    field :os, String
+    field :device_type, String
+    field :country, String
+    field :region, String
+    field :city, String
+    field :latitude, Float
+    field :longitude, Float
+    field :utm_source, String
+    field :utm_medium, String
+    field :utm_term, String
+    field :utm_content, String
+    field :utm_campaign, String
+    field :app_version, String
+    field :os_version, String
+    field :platform, String
+    field :started_at, GraphQL::Types::ISO8601DateTime
+
+    def self.authorized?(object, context)
+      if Subdomain.current.allow_external_analytics_query
+        return true
+      end
+      return false
+    end
+
+    field :events, [Types::Ahoy::EventsType], null: true do
+      description "Returns a list of Ahoy Events with ordering dimension, order direction, offset and limit"
+      argument :limit, Integer, required: false
+      argument :order_direction, String, required: false
+      argument :order_dimension, String, required: false
+      argument :offset, Integer, required: false
+    end
+  end
+end

--- a/app/graphql/types/api_namespace_type.rb
+++ b/app/graphql/types/api_namespace_type.rb
@@ -24,14 +24,15 @@ module Types
       argument :order_direction, String, required: false
       argument :order_dimension, String, required: false
       argument :offset, Integer, required: false
-    end
 
-    def api_resources(args = {})
-      args[:order_dimension] ||= 'created_at'
-      args[:order_direction] ||= 'desc'
-      args[:limit] ||= 50
-      args[:offset] ||= 0
-      ApiResource.all.order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
+      def resolve(parent, frozen_parameters, context)
+        parameters = { **frozen_parameters }
+        parameters[:order_dimension] ||= 'created_at'
+        parameters[:order_direction] ||= 'desc'
+        parameters[:limit] ||= 50
+        parameters[:offset] ||= 0
+        parent.object.api_resources.order("#{parameters[:order_dimension].underscore} #{parameters[:order_direction]}").limit(parameters[:limit]).offset(parameters[:offset])
+      end
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -19,7 +19,6 @@ module Types
     #     }
     #   }
     # }
-    
     field :api_namespaces, [Types::ApiNamespaceType], null: false do
       description "Returns a list of public ApiNamespaces with ordering dimension, order direction, offset and limit"
       argument :limit, Integer, required: false
@@ -27,6 +26,59 @@ module Types
       argument :order_dimension, String, required: false
       argument :offset, Integer, required: false
       argument :slug, String, required: false
+    end
+
+    # {
+    #   ahoyVisits(limit: 100,orderDirection:"desc", orderDimension: "started_at") {
+    #     id
+    #     ip
+    #     userAgent
+    #     referringDomain
+    #     landingPage
+    #     country
+    #     city
+    #     platform
+    #     events {
+    #       id
+    #       visitId
+    #       userId
+    #       name
+    #       properties
+    #     }
+    #   }
+    # }
+    field :ahoy_visits, [Types::Ahoy::VisitsType], null: false do
+      description "Returns a list of ahoy visits"
+      argument :limit, Integer, required: false
+      argument :order_direction, String, required: false
+      argument :order_dimension, String, required: false
+      argument :offset, Integer, required: false
+    end
+    # {
+    #   ahoyEvents(limit: 100, orderDirection:"desc", orderDimension: "time", name: "comfy-cms-page-visit") {
+    #     id
+    #     visitId
+    #     name
+    #     properties
+    #     time
+    #   }
+    # }
+    field :ahoy_events, [Types::Ahoy::EventsType], null: false do
+      description "Returns a list of ahoy events"
+      argument :limit, Integer, required: false
+      argument :order_direction, String, required: false
+      argument :order_dimension, String, required: false
+      argument :offset, Integer, required: false
+
+      argument :name, String, required: false
+    end
+    # {
+    #   ahoyEventNames {
+    #     name
+    #   }
+    # }
+    field :ahoy_event_names, [Types::Ahoy::EventNamesType], null: false do
+      description "Returns all the ahoy event names that are being used in the system"
     end
     
     def api_namespaces(args = {})
@@ -40,6 +92,31 @@ module Types
       else
         return ApiNamespace.where(requires_authentication: false).order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
       end
+    end
+
+    def ahoy_visits(args = {})
+      args[:order_dimension] ||= 'started_at'
+      args[:order_direction] ||= 'desc'
+      args[:limit] ||= 50
+      args[:offset] ||= 0
+      # the trailing :: is required to look for this namespace at the top level instead of in Types:: 
+      return ::Ahoy::Visit.all.includes(:events).order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
+    end
+
+    def ahoy_events(args = {})
+      args[:order_dimension] ||= 'time'
+      args[:order_direction] ||= 'desc'
+      args[:limit] ||= 50
+      args[:offset] ||= 0
+      if args[:name]
+        return ::Ahoy::Event.where(name: args[:name]).order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
+      else
+        return ::Ahoy::Event.all.order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
+      end
+    end
+
+    def ahoy_event_names
+      return ::Ahoy::Event.distinct.pluck(:name).map{|name| {name: name} }
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
   def execute_actions(resource, class_name)
     api_actions = resource.send(class_name)
     api_actions.each do |api_action|
-      api_action.execute_action unless api_action.serve_file? || api_action.redirect?
+      api_action.execute_action unless api_action.serve_file? || api_action.redirect? || api_action.custom_action?
     end
   end
 

--- a/app/javascript/packs/comfy/admin/cms.js
+++ b/app/javascript/packs/comfy/admin/cms.js
@@ -20,7 +20,7 @@ function initializeSortable(containerId) {
 
 function resetIndex(containerId) {
     $("#" + containerId)
-      .children()
+      .children('.form-container')
       .each(function (index) {
         $(this)
           .find(".position_field").val(index)

--- a/app/models/api_action.rb
+++ b/app/models/api_action.rb
@@ -12,6 +12,8 @@ class ApiAction < ApplicationRecord
 
   HTTP_METHODS = ['get', 'post', 'patch', 'put', 'delete']
 
+  EXECUTION_ORDER = ['serve_file', 'redirect', 'send_email', 'send_web_request', 'custom_action']
+
   default_scope { order(position: 'ASC') }
 
   ransacker :action_type, formatter: proc {|v| action_types[v]}

--- a/app/models/api_form.rb
+++ b/app/models/api_form.rb
@@ -12,4 +12,8 @@ class ApiForm < ApplicationRecord
     datetime: 'datetime-local',
     tel: 'tel'
   }
+
+  def is_field_renderable?(field)
+    properties.dig(field.to_s, 'renderable').nil? || properties.dig(field.to_s, 'renderable') == '1'
+  end
 end

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -3,7 +3,7 @@ class ApiResource < ApplicationRecord
 
   belongs_to :api_namespace
 
-  before_create :initialize_api_actions
+  before_create :initialize_api_actions, :inject_inherited_properties
 
   validate :presence_of_required_properties
 
@@ -44,6 +44,20 @@ class ApiResource < ApplicationRecord
     properties.each do |key, value|
       if api_namespace.api_form.properties.dig(key,"required") == '1' && !value.present?
         errors.add(:properties, "#{key} is required")
+      end
+    end
+  end
+
+  private
+
+  def inject_inherited_properties
+    # you can make certain primitive properties (inherited from the parent API namespace) non renderable, in these cases we have to populate the values
+    # to - do write test
+    return if !api_namespace&.api_form&.properties
+    api_form_properties = api_namespace.api_form.properties
+    api_namespace.properties.each do |key, value|
+      if api_form_properties[key]['renderable'] == '0'
+        self.properties[key] =  api_namespace.properties[key]
       end
     end
   end

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -1,6 +1,8 @@
 class ApiResource < ApplicationRecord
   include JsonbFieldsParsable
 
+  after_initialize :inherit_properties_from_parent
+
   belongs_to :api_namespace
 
   before_create :initialize_api_actions, :inject_inherited_properties
@@ -49,6 +51,12 @@ class ApiResource < ApplicationRecord
   end
 
   private
+
+  def inherit_properties_from_parent
+    return unless self.properties.nil?
+
+    self.properties = api_namespace&.properties
+  end
 
   def inject_inherited_properties
     # you can make certain primitive properties (inherited from the parent API namespace) non renderable, in these cases we have to populate the values

--- a/app/models/custom_api_action.rb
+++ b/app/models/custom_api_action.rb
@@ -1,0 +1,5 @@
+class CustomApiAction
+  def run_custom_action(api_action: , api_namespace:, api_resource: , current_visit: , current_user: nil)
+    raise "not implemented error"
+  end
+end

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -45,7 +45,10 @@
       .form-group
         = label_tag 'Bearer Token'
         = text_field_tag "api_namespace[#{type}_attributes][#{index}][bearer_token]", resource.bearer_token, { class: "form-control form-control-sm" }
-
+    .custom_action.col-12{style: "#{'display:none' unless resource.action_type == 'custom_action'}", id: "custom_action_fields_#{type}_#{index}"}
+      .form-group
+        = label_tag 'Method Definition'
+        = text_area_tag "api_namespace[#{type}_attributes][#{index}][method_definition]", resource.method_definition, { class: "form-control form-control-sm" }
 
   = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][_destroy]", false ,{id: "api_action_form_destroy_field_#{type}_#{index}"}
   = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][position]", resource.position ,{class: "position_field"}

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -51,7 +51,7 @@
         = text_area_tag "api_namespace[#{type}_attributes][#{index}][method_definition]", resource.method_definition, { class: "form-control form-control-sm" }
 
   = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][_destroy]", false ,{id: "api_action_form_destroy_field_#{type}_#{index}"}
-  = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][position]", resource.position ,{class: "position_field"}
+  = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][position]", index ,{class: "position_field"}
 
 :javascript
 

--- a/app/views/comfy/admin/api_actions/action_workflow.html.haml
+++ b/app/views/comfy/admin/api_actions/action_workflow.html.haml
@@ -14,7 +14,7 @@
     - ApiAction.children.each do |subclass|
       .mb-5
         .h5.mb-3
-          Trigger Event: 
+          Trigger Event:
           = subclass.split('_api_actions').first
         .form-group{id: "#{subclass}_forms", class: "js-sortable"}
           = f.fields_for subclass, @api_namespace.send(subclass) do |ff|
@@ -37,6 +37,8 @@
       $("#serve_file_fields_" + type + '_' + index).show();
     } else if (fieldType === 'send_web_request') {
       $("#serve_web_request_fields_" + type + '_' + index).show();
+    } else if (fieldType === 'custom_action') {
+      $("#custom_action_fields_" + type + '_' + index).show();
     }
   }
 
@@ -45,6 +47,7 @@
     $("#redirect_fields_" + type + '_'  + index).hide();
     $("#serve_file_fields_" + type + '_' + index).hide();
     $("#serve_web_request_fields_" + type + '_' + index).hide();
+    $("#custom_action_fields_" + type + '_' + index).hide();
   }
 
   function removeForm(form_id, destroy_field_id) {
@@ -54,7 +57,7 @@
 
   function appendApiActionForm(type) {
     var index = $("#" + `${type}_forms > .form-container`).length
-    var url = "#{new_api_action_path()}" + `?index=${index}&type=${type}` 
+    var url = "#{new_api_action_path()}" + `?index=${index}&type=${type}`
     $.ajax({
       url: url ,
       type: 'GET',
@@ -63,4 +66,3 @@
       success: function(response) {}
     });
   }
-  

--- a/app/views/comfy/admin/api_actions/show.html.haml
+++ b/app/views/comfy/admin/api_actions/show.html.haml
@@ -11,9 +11,9 @@
         = @api_action.request_url
       .col-12.d-flex.mb-3
         .mr-3
-          Payload: 
+          Payload:
         = @api_action.payload_mapping
-    
+
     - if @api_action.action_type == 'redirect'
       .col-12.d-flex.mb-3
         .mr-3
@@ -44,6 +44,12 @@
         - url = rails_blob_url(Comfy::Cms::File.find(file_id_from_snippet(@api_action.file_snippet)).attachment)
         = link_to url, url
 
+    - if @api_action.action_type == 'custom_action'
+      .col-12.d-flex.mb-3
+        .mr-3
+          Custom Action:
+        = @api_action.method_definition
+
     - if @api_action.api_resource.present?
       .col-12.d-flex.mb-3
         .mr-3
@@ -54,4 +60,3 @@
         .mr-3
           Lifecycle Message:
         = @api_action.lifecycle_message
-    

--- a/app/views/comfy/admin/api_forms/_form.html.haml
+++ b/app/views/comfy/admin/api_forms/_form.html.haml
@@ -83,6 +83,10 @@
                 .form-group.col-12
                   = a.label :required, 'Required:', class: 'mr-4'
                   = a.check_box :required, checked: properties[key]["required"] == "1"
+
+                .form-group.col-12
+                  = a.label :renderable, 'Renderable', class: 'mr-4'
+                  = a.check_box :renderable, checked: @api_form.is_field_renderable?(key)
       
       - @api_namespace.non_primitive_properties.each do |prop|
         .col-12.col-md-4.mb-4

--- a/app/views/comfy/admin/api_forms/_render.haml
+++ b/app/views/comfy/admin/api_forms/_render.haml
@@ -6,9 +6,10 @@
   .form-group
     - properties.each do |key, value|
       = f.fields_for :properties do |fff|
-        .form-group{class: "vr-#{key}"}
-          = fff.label key, form_properties[key]["label"]
-          = map_form_field(fff, key, value, form_properties)
+        - if @api_form.is_field_renderable?(key)
+          .form-group{class: "vr-#{key}"}
+            = fff.label key, form_properties[key]["label"]
+            = map_form_field(fff, key, value, form_properties)
     - @api_namespace.non_primitive_properties.each_with_index do |property, index|
       = fields_for "data[non_primitive_properties_attributes][#{index}]", property do |ff|
         .form-group{class: "vr-#{ff.object.label}"}

--- a/app/views/comfy/admin/web_settings/_form.haml
+++ b/app/views/comfy/admin/web_settings/_form.haml
@@ -53,6 +53,12 @@
   %label
     Graphql (experimental):
   = f.check_box :graphql_enabled
+
+.form-group
+  %label
+    Allow external analytics querying (experimental):
+  = f.check_box :allow_external_analytics_query
+
 .form-group
   %label
     Web console (experimental):

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # ahoy analytics
+  mount Ahoy::Engine => "/ahoy", as: :my_ahoy
+
   # to query CMS pages
   post '/query', to: 'search#query'
   # to query the rest of the system

--- a/db/migrate/20220513034804_add_method_definition_to_api_actions.rb
+++ b/db/migrate/20220513034804_add_method_definition_to_api_actions.rb
@@ -1,5 +1,5 @@
 class AddMethodDefinitionToApiActions < ActiveRecord::Migration[6.1]
   def change
-    add_column :api_actions, :method_definition, :text, default: "# You have access to vaiables: api_action, api_namespace, api_resource, current_visit, current_user\n# Write your custom code here\nraise 'not implemented error'"
+    add_column :api_actions, :method_definition, :text, default: "# You have access to variables: api_action, api_namespace, api_resource, current_visit, current_user\n# Write your custom code here\nraise 'not implemented error'"
   end
 end

--- a/db/migrate/20220513034804_add_method_definition_to_api_actions.rb
+++ b/db/migrate/20220513034804_add_method_definition_to_api_actions.rb
@@ -1,0 +1,5 @@
+class AddMethodDefinitionToApiActions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_actions, :method_definition, :text, default: "# You have access to vaiables: api_action, api_namespace, api_resource, current_visit, current_user\n# Write your custom code here\nraise 'not implemented error'"
+  end
+end

--- a/db/migrate/20220514215146_add_allow_external_analytics_query_to_subdomain.rb
+++ b/db/migrate/20220514215146_add_allow_external_analytics_query_to_subdomain.rb
@@ -1,0 +1,7 @@
+class AddAllowExternalAnalyticsQueryToSubdomain < ActiveRecord::Migration[6.1]
+  def change
+    change_table :subdomains do |t|
+      t.boolean :allow_external_analytics_query, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_03_151800) do
+ActiveRecord::Schema.define(version: 2022_05_13_034804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2022_05_03_151800) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "custom_headers"
     t.string "http_method"
+    t.text "method_definition", default: "# You have access to vaiables: api_action, api_namespace, api_resource, current_visit, current_user\n# Write your custom code here\nraise 'not implemented error'"
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end
@@ -463,13 +464,13 @@ ActiveRecord::Schema.define(version: 2022_05_03_151800) do
     t.string "purge_visits_every", default: "never"
     t.string "analytics_report_frequency", default: "never"
     t.datetime "analytics_report_last_sent"
-    t.boolean "tracking_enabled", default: false
     t.boolean "ember_enabled", default: false
     t.boolean "graphql_enabled", default: false
     t.boolean "web_console_enabled", default: false
-    t.boolean "api_plugin_events_enabled", default: false
     t.string "after_sign_up_path"
     t.string "after_sign_in_path"
+    t.boolean "api_plugin_events_enabled", default: false
+    t.boolean "tracking_enabled", default: false
     t.index ["deleted_at"], name: "index_subdomains_on_deleted_at"
     t.index ["name"], name: "index_subdomains_on_name"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2022_05_14_215146) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "custom_headers"
     t.string "http_method"
-    t.text "method_definition", default: "# You have access to vaiables: api_action, api_namespace, api_resource, current_visit, current_user\n# Write your custom code here\nraise 'not implemented error'"
+    t.text "method_definition", default: "# You have access to variables: api_action, api_namespace, api_resource, current_visit, current_user\n# Write your custom code here\nraise 'not implemented error'"
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_13_034804) do
+ActiveRecord::Schema.define(version: 2022_05_14_215146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -469,6 +469,7 @@ ActiveRecord::Schema.define(version: 2022_05_13_034804) do
     t.boolean "web_console_enabled", default: false
     t.string "after_sign_up_path"
     t.string "after_sign_in_path"
+    t.boolean "allow_external_analytics_query", default: false
     t.boolean "api_plugin_events_enabled", default: false
     t.boolean "tracking_enabled", default: false
     t.index ["deleted_at"], name: "index_subdomains_on_deleted_at"

--- a/test/controllers/admin/comfy/api_resources_controller_test.rb
+++ b/test/controllers/admin/comfy/api_resources_controller_test.rb
@@ -35,12 +35,16 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test "should create api_resource" do
     sign_in(@user)
     payload_as_stringified_json = "{\"age\":26,\"alive\":true,\"last_name\":\"Teng\",\"first_name\":\"Jennifer\"}"
+
+    redirect_action = @api_namespace.create_api_actions.where(action_type: 'redirect').last
+    redirect_action.update(redirect_url: '/')
+
     assert_difference('ApiResource.count') do
       post api_namespace_resources_url(api_namespace_id: @api_namespace.id), params: { api_resource: { properties: payload_as_stringified_json } }
     end
     assert ApiResource.last.properties
     assert_equal JSON.parse(payload_as_stringified_json).symbolize_keys.keys, ApiResource.last.properties.symbolize_keys.keys
-    assert_redirected_to api_namespace_resource_path(api_namespace_id: @api_namespace.id, id: ApiResource.last.id)
+    assert_redirected_to redirect_action.redirect_url
   end
 
   test "should show api_resource" do

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -48,12 +48,16 @@ class GraphqlControllerTest < ActionDispatch::IntegrationTest
     post '/graphql', params: { query: query_string }
     json_response = JSON.parse(@response.body)
     assert_equal ["data"], json_response.keys
+  end
 
+  test "[if enabled] query public API Namespaces with nested apiResources" do
     query_string = "{ apiNamespaces(orderDirection: \"desc\", orderDimension: \"updatedAt\") { id apiResources { id } } }"
     post '/graphql', params: { query: query_string }
     json_response = JSON.parse(@response.body)
     assert_equal ["data"], json_response.keys
+  end
 
+  test "[if enabled] query public API Namespaces with nested apiResources with sorting" do
     query_string = "{ apiNamespaces { id apiResources(orderDirection: \"desc\", orderDimension: \"updatedAt\") { id } } }"
     post '/graphql', params: { query: query_string }
     json_response = JSON.parse(@response.body)

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -60,6 +60,69 @@ class GraphqlControllerTest < ActionDispatch::IntegrationTest
     assert_equal ["data"], json_response.keys
   end
 
+  test "[if enabled] && [if subdomain allows analytics query via API] allows ahoy visit query" do
+    @subdomain.update(allow_external_analytics_query: true)
+    get root_url
+    Ahoy::Visit.first.events.create
+    query_string = "{ ahoyVisits { id ip events { id } } }"
+    post '/graphql', params: { query: query_string }
+    json_response = JSON.parse(@response.body)
+    assert_equal ["data"], json_response.keys
+    assert_equal ["ahoyVisits"], json_response["data"].keys
+  end
+
+  test "[if enabled] && [if subdomain disallows analytics query via API] raises error for ahoy visit query" do
+    @subdomain.update(allow_external_analytics_query: false)
+    get root_url
+    Ahoy::Visit.first.events.create
+    query_string = "{ ahoyVisits { id ip events { id } } }"
+    post '/graphql', params: { query: query_string }
+    json_response = JSON.parse(@response.body)
+    assert_nil json_response["data"]
+  end
+
+  test "[if enabled] && [if subdomain allows analytics query via API] allows ahoy event query" do
+    @subdomain.update(allow_external_analytics_query: true)
+    get root_url
+    Ahoy::Visit.first.events.create
+    query_string = "{ ahoyEvents { id visitId } }"
+    post '/graphql', params: { query: query_string }
+    json_response = JSON.parse(@response.body)
+    assert_equal ["data"], json_response.keys
+    assert_equal ["ahoyEvents"], json_response["data"].keys
+  end
+
+  test "[if enabled] && [if subdomain disallows analytics query via API] raises error for ahoy event query" do
+    @subdomain.update(allow_external_analytics_query: false)
+    get root_url
+    Ahoy::Visit.first.events.create
+    query_string = "{ ahoyEvents { id visitId } }"
+    post '/graphql', params: { query: query_string }
+    json_response = JSON.parse(@response.body)
+    assert_nil json_response["data"]
+  end
+
+  test "[if enabled] && [if subdomain allows analytics query via API] allows ahoy event names query" do
+    @subdomain.update(allow_external_analytics_query: true)
+    get root_url
+    Ahoy::Visit.first.events.create(name: 'foo')
+    query_string = "{ ahoyEventNames { name } }"
+    post '/graphql', params: { query: query_string }
+    json_response = JSON.parse(@response.body)
+    assert_equal ["data"], json_response.keys
+    assert_equal ["ahoyEventNames"], json_response["data"].keys
+  end
+
+  test "[if enabled] && [if subdomain disallows analytics query via API] raises error for ahoy event names query" do
+    @subdomain.update(allow_external_analytics_query: false)
+    get root_url
+    Ahoy::Visit.first.events.create(name: 'foo')
+    query_string = "{ ahoyEventNames { name } }"
+    post '/graphql', params: { query: query_string }
+    json_response = JSON.parse(@response.body)
+    assert_nil json_response["data"]
+  end
+
   test "[not enabled] presents error" do
     @subdomain.update(graphql_enabled: false)
     query_string = "{ apiNamespaces { id } }"

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -285,8 +285,8 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'complete', action.lifecycle_stage
     end
 
-    assert_equal api_namespace.as_json.to_s, api_resource.create_api_actions.first.lifecycle_message
-    assert_equal api_resource.as_json.to_s, api_resource.create_api_actions.second.lifecycle_message
+    assert_equal api_namespace.as_json.to_json, api_resource.create_api_actions.first.lifecycle_message
+    assert_equal api_resource.as_json.to_json, api_resource.create_api_actions.second.lifecycle_message
   end
 
   test 'should allow #create and the custom actions (sending emails) should be executed in the order that is defined with other api_actions' do
@@ -336,11 +336,81 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       assert_equal 'complete', action.lifecycle_stage
     end
 
+    # At first, email is sent to 'custom_action_3@restarone.com' through send_email_action
+    assert_includes ActionMailer::Base.deliveries.first.to, "custom_action_3@restarone.com"
+
     # According to the order of custom_api_actions, the emails should be sent to email-addresses in the order: 1) custom_action_0@restarone.com   2) custom_action_1@restarone.com  3) custom_action_2@restarone.com
-    # At the end, email is sent to 'custom_action_3@restarone.com' through send_email_action
-    4.times.each do |n|
-      assert_includes ActionMailer::Base.deliveries[n].to, "custom_action_#{ n }@restarone.com"
+    3.times.each do |n|
+      assert_includes ActionMailer::Base.deliveries[n+1].to, "custom_action_#{ n }@restarone.com"
     end
+  end
+
+  test 'should allow #create and the api_actions should be executed in the defined order in ApiAction.EXECUTION_ORDER' do
+    api_namespace = api_namespaces(:three)
+    api_namespace.api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Test', 'type_validation': 'tel'}})
+    custom_api_action_1 = api_actions(:create_custom_api_action_three)
+    custom_api_action_1.update!(position: 0, method_definition: "User.invite!({email: 'custom_action_0@restarone.com'}, current_user)")
+
+    custom_custom_action_2 = api_actions(:create_custom_api_action_three).dup
+    custom_custom_action_2.method_definition = "User.invite!({email: 'custom_action_1@restarone.com'}, current_user)"
+    custom_custom_action_2.position = 4
+    custom_custom_action_2.save!
+
+    send_email_action = api_actions(:create_custom_api_action_three).dup
+    send_email_action.action_type = "send_email"
+    send_email_action.email = "custom_action_3@restarone.com"
+    send_email_action.position = 1
+    send_email_action.save!
+
+    redirect_action = api_actions(:create_custom_api_action_three).dup
+    redirect_action.action_type = "redirect"
+    redirect_action.redirect_url = "/"
+    redirect_action.position = 2
+    redirect_action.save!
+
+    send_web_request_action = api_actions(:create_api_action_three).dup
+    send_web_request_action.api_namespace_id = api_namespace.id
+    send_web_request_action.api_resource_id = nil
+    send_web_request_action.position = 3
+    send_web_request_action.save!
+
+    site = Comfy::Cms::Site.first
+    file = site.files.create(
+      label:        "test",
+      description:  "test file",
+      file:         fixture_file_upload("fixture_image.png", "image/jpeg")
+    )
+
+    serve_file_action = api_actions(:create_custom_api_action_three).dup
+    serve_file_action.action_type = "serve_file"
+    serve_file_action.file_snippet = "{{ cms:file_link #{file.id} }}"
+    serve_file_action.position = 2
+    serve_file_action.save!
+
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "api_namespace.api_resources.count", +1 do
+      # Total 2 Custom Action & 1 Send-Email Action. Each sends an email.
+      assert_difference "ActionMailer::Base.deliveries.count", +3 do
+        post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+      end
+    end
+
+    assert_redirected_to redirect_action.redirect_url
+
+    api_resource = @controller.view_assigns['api_resource']
+
+    # Different type of ApiActions are executed in the defined order
+    assert_equal ApiAction::EXECUTION_ORDER, api_resource.create_api_actions.reorder(nil).order(updated_at: :asc).pluck(:action_type).uniq
+
+    # Custom Api Action are executed according to their position
+    custom_actions = api_resource.create_api_actions.where(action_type: 'custom_action').reorder(nil)
+    assert_equal custom_actions.order(updated_at: :asc).pluck(:id), custom_actions.order(position: :asc).pluck(:id)
   end
 
 end

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -204,10 +204,143 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    api_resource = @controller.view_assigns['api_resource']
+    # The different triggered actions should be completed
+    api_resource.create_api_actions.each do |action|
+      assert_equal 'complete', action.lifecycle_stage
+    end
+
     # According to the order of custom_api_actions, the users should be created in the order: 1) custom_action_0@restarone.com   2) custom_action_1@restarone.com  3) custom_action_2@restarone.com
     assert User.find_by_email('custom_action_1@restarone.com').created_at > User.find_by_email('custom_action_0@restarone.com').created_at
     assert User.find_by_email('custom_action_1@restarone.com').created_at < User.find_by_email('custom_action_2@restarone.com').created_at
   end
 
+  test 'should allow #create and the custom actions (sending emails) should be executed in the order that is defined' do
+    api_namespace = api_namespaces(:three)
+    api_namespace.api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Test', 'type_validation': 'tel'}})
+    api_action = api_actions(:create_custom_api_action_three)
+    api_action.update!(position: 0, method_definition: "User.invite!({email: 'custom_action_0@restarone.com'}, current_user)")
+
+    2.times.each do |n|
+      new_custom_action = api_actions(:create_custom_api_action_three).dup
+      new_custom_action.method_definition = "User.invite!({email: 'custom_action_#{ n + 1 }@restarone.com'}, current_user)"
+      new_custom_action.position = n + 1
+      new_custom_action.save!
+    end
+
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "api_namespace.api_resources.count", +1 do
+      # Total 3 Custom Action. Each sends an email.
+      assert_difference "ActionMailer::Base.deliveries.count", +3 do
+        post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+      end
+    end
+
+    api_resource = @controller.view_assigns['api_resource']
+    # The different triggered actions should be completed
+    api_resource.create_api_actions.each do |action|
+      assert_equal 'complete', action.lifecycle_stage
+    end
+
+    # According to the order of custom_api_actions, the emails should be sent to email-addresses in the order: 1) custom_action_0@restarone.com   2) custom_action_1@restarone.com  3) custom_action_2@restarone.com
+    3.times.each do |n|
+      assert_includes ActionMailer::Base.deliveries[n].to, "custom_action_#{ n }@restarone.com"
+    end
+  end
+
+  test 'should allow #create and the custom actions (controller context code) should be executed in the order that is defined and save its output as lifecycle_message' do
+    api_namespace = api_namespaces(:three)
+    api_namespace.api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Test', 'type_validation': 'tel'}})
+
+    api_action = api_actions(:create_custom_api_action_three)
+    api_action.update!(position: 0, method_definition: "api_namespace.as_json")
+
+    new_custom_action = api_actions(:create_custom_api_action_three).dup
+    new_custom_action.method_definition = "api_resource.as_json"
+    new_custom_action.position = 1
+    new_custom_action.save!
+
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "api_namespace.api_resources.count", +1 do
+      post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+
+    api_namespace = @controller.view_assigns['api_namespace']
+    api_resource = @controller.view_assigns['api_resource']
+
+    # The different triggered actions should be completed
+    api_resource.create_api_actions.each do |action|
+      assert_equal 'complete', action.lifecycle_stage
+    end
+
+    assert_equal api_namespace.as_json.to_s, api_resource.create_api_actions.first.lifecycle_message
+    assert_equal api_resource.as_json.to_s, api_resource.create_api_actions.second.lifecycle_message
+  end
+
+  test 'should allow #create and the custom actions (sending emails) should be executed in the order that is defined with other api_actions' do
+    api_namespace = api_namespaces(:three)
+    api_namespace.api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Test', 'type_validation': 'tel'}})
+    api_action = api_actions(:create_custom_api_action_three)
+    api_action.update!(position: 0, method_definition: "User.invite!({email: 'custom_action_0@restarone.com'}, current_user)")
+
+    2.times.each do |n|
+      new_custom_action = api_actions(:create_custom_api_action_three).dup
+      new_custom_action.method_definition = "User.invite!({email: 'custom_action_#{ n + 1 }@restarone.com'}, current_user)"
+      new_custom_action.position = n + 1
+      new_custom_action.save!
+    end
+
+    send_email_action = api_actions(:create_custom_api_action_three).dup
+    send_email_action.action_type = "send_email"
+    send_email_action.email = "custom_action_3@restarone.com"
+    send_email_action.position = 3
+    send_email_action.save!
+
+    redirect_action = api_actions(:create_custom_api_action_three).dup
+    redirect_action.action_type = "redirect"
+    redirect_action.redirect_url = "/"
+    redirect_action.position = 4
+    redirect_action.save!
+
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "api_namespace.api_resources.count", +1 do
+      # Total 3 Custom Action & 1 Send-Email Action. Each sends an email.
+      assert_difference "ActionMailer::Base.deliveries.count", +4 do
+        post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+      end
+    end
+
+    assert_redirected_to redirect_action.redirect_url
+
+    api_resource = @controller.view_assigns['api_resource']
+    # The different triggered actions should be completed
+    api_resource.create_api_actions.each do |action|
+      assert_equal 'complete', action.lifecycle_stage
+    end
+
+    # According to the order of custom_api_actions, the emails should be sent to email-addresses in the order: 1) custom_action_0@restarone.com   2) custom_action_1@restarone.com  3) custom_action_2@restarone.com
+    # At the end, email is sent to 'custom_action_3@restarone.com' through send_email_action
+    4.times.each do |n|
+      assert_includes ActionMailer::Base.deliveries[n].to, "custom_action_#{ n }@restarone.com"
+    end
+  end
 
 end

--- a/test/fixtures/api_actions.yml
+++ b/test/fixtures/api_actions.yml
@@ -4,7 +4,7 @@ one:
   type: NewApiAction
   action_type: redirect
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   redirect_url: MyString
   api_namespace: one
 
@@ -12,7 +12,7 @@ two:
   type: NewApiAction
   action_type: redirect
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   redirect_url: MyString
   api_resource: one
 
@@ -20,7 +20,7 @@ three:
   type: NewApiAction
   action_type: send_email
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   email: 'test@rest.com'
   api_resource: one
 
@@ -28,7 +28,7 @@ create_api_action_one:
   type: CreateApiAction
   action_type: redirect
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   redirect_url: MyString
   api_namespace: one
 
@@ -36,8 +36,8 @@ show_api_action_one:
   type: ShowApiAction
   action_type: send_email
   include_api_resource_data: false
-  payload_mapping: 
-  redirect_url: 
+  payload_mapping:
+  redirect_url:
   email: test@restarone.com
   api_namespace: one
 
@@ -45,8 +45,8 @@ create_api_action_two:
   type: CreateApiAction
   action_type: send_email
   include_api_resource_data: false
-  payload_mapping: 
-  redirect_url: 
+  payload_mapping:
+  redirect_url:
   email: test@restarone.com
   api_namespace: one
 
@@ -54,7 +54,7 @@ create_api_action_three:
   type: CreateApiAction
   action_type: send_web_request
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   request_url: "http://www.example.com/success"
   payload_mapping: {"first_name":"test"}
   custom_headers: {"AUTHORIZATION":"SECRET_BEARER_TOKEN"}
@@ -68,7 +68,7 @@ create_api_action_four:
   payload_mapping: {"first_name":"test"}
   custom_headers: {"AUTHORIZATION":"SECRET_BEARER_TOKEN"}
   request_url: "http://www.example.com/error"
-  email: 
+  email:
   api_resource: one
   http_method: post
 
@@ -76,8 +76,8 @@ error_api_action_one:
   type: ErrorApiAction
   action_type: send_email
   include_api_resource_data: false
-  payload_mapping: 
-  redirect_url: 
+  payload_mapping:
+  redirect_url:
   email: test@restarone.com
   api_namespace: one
 
@@ -85,7 +85,7 @@ error_api_action_two:
   type: ErrorApiAction
   action_type: redirect
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   redirect_url: '/'
   api_namespace: one
 
@@ -99,5 +99,13 @@ create_api_action_plugin_subdomain_events:
   request_url: "http://www.example.com/success"
   api_namespace: plugin_subdomain_events
   http_method: post
+
+create_custom_api_action_three:
+  type: CreateApiAction
+  action_type: custom_action
+  include_api_resource_data: false
+  payload_mapping:
+  method_definition: "logger = Logger.new(\"#{Rails.root}/log/api_action_response.log\"); logger.info 'Test log message!'"
+  api_namespace: three
 
 

--- a/test/fixtures/api_forms.yml
+++ b/test/fixtures/api_forms.yml
@@ -24,3 +24,4 @@ three:
   submit_button_label: MyString
   title: MyString
 
+

--- a/test/fixtures/api_forms.yml
+++ b/test/fixtures/api_forms.yml
@@ -24,4 +24,12 @@ three:
   submit_button_label: MyString
   title: MyString
 
+four:
+  properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input' }}
+  api_namespace: three
+  success_message: MyString
+  failure_message: MyString
+  submit_button_label: MyString
+  title: MyString
+
 

--- a/test/fixtures/api_forms.yml
+++ b/test/fixtures/api_forms.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input' }}
+  properties: { 'name': {'label': 'name', 'placeholder': 'Name', 'field_type': 'input' }}
   api_namespace: one
   success_message: MyString
   failure_message: MyString

--- a/test/fixtures/api_namespaces.yml
+++ b/test/fixtures/api_namespaces.yml
@@ -20,6 +20,16 @@ two:
   requires_authentication: false
   namespace_type: create-read-update-delete
 
+three:
+  name: testApi
+  slug: testApi
+  version: 1
+  properties: {
+                "name": "testApi"
+              }
+  requires_authentication: false
+  namespace_type: create-read-update-delete
+
 users:
   name: internal_users
   slug: internal_users

--- a/test/models/api_form_test.rb
+++ b/test/models/api_form_test.rb
@@ -1,7 +1,20 @@
 require "test_helper"
 
 class ApiFormTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "return true if renderable property is nil" do
+    api_form = api_forms(:one)
+    assert api_form.is_field_renderable?('Test')
+  end
+
+  test "return true if renderable property is 1" do
+    api_form = api_forms(:one)
+    api_form.update(properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input', 'renderable': '1' }})
+    assert api_form.is_field_renderable?('Test')
+  end
+
+  test "return false if renderable property is 0" do
+    api_form = api_forms(:one)
+    api_form.update(properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input', 'renderable': '0' }})
+    assert api_form.is_field_renderable?('Test')
+  end
 end

--- a/test/models/api_resource_test.rb
+++ b/test/models/api_resource_test.rb
@@ -1,7 +1,39 @@
 require "test_helper"
 
 class ApiResourceTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "when initialized - inherits parent properties" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
+
+  test "when updated - adheres to type validations enforced by API form" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
+
+  test "when updated - adheres to presence validations enforced by API form" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
+
+  test "when updated - adheres to includes validations enforced by API form" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
+
+  test "when updated - adheres to regex validations enforced by API form" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
+
+  test "when initialized - fires contextual API actions" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
+
+  test "when created - fires contextual API actions" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
+
+  test "when updated - fires contextual API actions" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
+
+  test "when destroyed - fires contextual API actions" do
+    skip('need to add before going GA with API pipelines v0.2')
+  end
 end

--- a/test/models/api_resource_test.rb
+++ b/test/models/api_resource_test.rb
@@ -2,38 +2,20 @@ require "test_helper"
 
 class ApiResourceTest < ActiveSupport::TestCase
   test "when initialized - inherits parent properties" do
-    skip('need to add before going GA with API pipelines v0.2')
-  end
+    api_namespace = api_namespaces(:one)
+    api_resource = ApiResource.new(api_namespace_id: api_namespace.id)
 
-  test "when updated - adheres to type validations enforced by API form" do
-    skip('need to add before going GA with API pipelines v0.2')
+    assert_equal api_resource.properties, api_namespace.properties
   end
 
   test "when updated - adheres to presence validations enforced by API form" do
-    skip('need to add before going GA with API pipelines v0.2')
-  end
+    api_namespace = api_namespaces(:one)
+    api_form = api_forms(:one)
+    api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Name', 'field_type': 'input', 'required': '1' }})
 
-  test "when updated - adheres to includes validations enforced by API form" do
-    skip('need to add before going GA with API pipelines v0.2')
-  end
+    api_resource = ApiResource.create(api_namespace_id: api_namespace.id, properties: {'name': ''})
+    refute api_resource.id
 
-  test "when updated - adheres to regex validations enforced by API form" do
-    skip('need to add before going GA with API pipelines v0.2')
-  end
-
-  test "when initialized - fires contextual API actions" do
-    skip('need to add before going GA with API pipelines v0.2')
-  end
-
-  test "when created - fires contextual API actions" do
-    skip('need to add before going GA with API pipelines v0.2')
-  end
-
-  test "when updated - fires contextual API actions" do
-    skip('need to add before going GA with API pipelines v0.2')
-  end
-
-  test "when destroyed - fires contextual API actions" do
-    skip('need to add before going GA with API pipelines v0.2')
+    assert_includes api_resource.errors.messages[:properties], 'name is required'
   end
 end


### PR DESCRIPTION
# API Data/Automations Pipeline 0.2
This PR represents a best effort at,
1. packaging everything needed for: https://github.com/restarone/violet_rails/issues?q=is%3Aissue+is%3Aopen+label%3A%22API+-+data+pipeline+v2%22
2. Making sure we didn't break anything :)

## so far it includes the following features (in merge order):

1. [Feature] Non-renderable (private) attributes in API Namespace: https://github.com/restarone/violet_rails/issues/526
2. [Feature] Custom API actions: https://github.com/restarone/violet_rails/issues/527
3. [Bug Fix] Correct scoping in External API Clients (before it was showing all External API Clients in the API Namespace/External API Clients view): https://github.com/restarone/violet_rails/pull/572
4. [Feature] Ahoy.js (allows creating tracking events via CMS), add ahoy visit to exception notification): https://github.com/restarone/violet_rails/pull/575
5. [Feature] Allow Ahoy Visits/Events to be queried in GraphQL (gated via Subdomain experiment): https://github.com/restarone/violet_rails/pull/579
6. [Bug Fix] correct scoping in ApiNamespace => children in GQL: https://github.com/restarone/violet_rails/pull/580

## :exclamation: merge blockers

1. [Feature] Non-renderable (private) attributes in API Namespace: https://github.com/restarone/violet_rails/issues/526 -  @Pralish awaiting tests
2. [Feature] Custom API actions: https://github.com/restarone/violet_rails/issues/527 - @alis-khadka awaiting bug fixes


## Non-renderable (private) attributes in API Namespace acceptance criteria: 
when deployed to `staging`, it should
* form submission / api actions work as expected
* non renderable attribute is NOT sent to the client 
* when non-rendarable, the field is not shown / present in the DOM

## Custom API actions acceptance criteria
when deployed to `staging`, it should

1. allow N number of custom actions to be performed (custom action defined in Ruby code)
3. Allow N number of custom actions to be performed in order (along with system provided actions like: redirect, serve file, send email etc)
7. log errors in the response (similar to HTTP action)
8. handle custom actions in the controller context
9. handle custom actions out of the controller context (ie; sending an email)
10. not break existing API action workflows

## Ahoy.js (allows creating tracking events via CMS), add ahoy visit to exception notification)
you can now create tracking events from the CMS!

Given the following code in a script tag: 
``` javascript
ahoy.track("my-event-name-here", {title: " foobar"})
```
you can record your ahoy events and see them created in the Admin UI: 
![Screenshot from 2022-05-15 10-32-23](https://user-images.githubusercontent.com/35935196/168478249-689f8a02-a260-4bac-9291-356d3d34c100.png)

The exception notification looks something like this with ahoy visit included (along with the current user): 
``` txt
An Errno::ENOSPC occurred in forum_threads#create:

  No space left on device - bs_fetch:atomic_write_cache_file:write
  app/controllers/simple_discussion/forum_threads_controller.rb:52:in `create'


-------------------------------
Request:
-------------------------------

... request info

-------------------------------
Session:
-------------------------------
... session info

-------------------------------
Environment:
-------------------------------
.... env info 

-------------------------------
Backtrace:
-------------------------------

 .... backtrace info 

-------------------------------
Data:
-------------------------------

  * data: {:current_user=>
     ...  current user info
   :current_visit=>
    * #<Ahoy::Visit:0x00007f45ec3465a0
     id: 80,
     visit_token: "b936e7bb-4a6c-4beb-aa37-2633c1327de9",
     visitor_token: "fd61ac9b-a17d-4689-ba30-d15630cd5413",
     user_id: 1,
     ip: "142.188.123.22",
     user_agent:
      "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0",
     referrer: nil,
     referring_domain: nil,
     landing_page: "https://pr.restarone.solutions/forum/",
     browser: "Firefox",
     os: "Ubuntu",
     device_type: "Desktop",
     country: "CA",
     region: "Ontario",
     city: "Toronto",
     latitude: 43.7001,
     longitude: -79.4163,
     utm_source: nil,
     utm_medium: nil,
     utm_term: nil,
     utm_content: nil,
     utm_campaign: nil,
     app_version: nil,
     os_version: nil,
     platform: nil,
     started_at: Sun, 15 May 2022 15:08:05.849211000 UTC +00:00>} *
```

## Allow Ahoy Visits/Events to be queried in GraphQL 

When enabled at the subdomain level, you can now query ahoy visits and events: 
![Screenshot from 2022-05-15 11-48-26](https://user-images.githubusercontent.com/35935196/168481652-811a315c-8f91-4f8c-87ab-5e0481fa45ab.png)