### PR TITLE
spike fix order of properties for API Form

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -44,6 +44,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
   def update
     respond_to do |format|
       if @api_namespace.update(api_namespace_params)
+        byebug
         format.html { handle_success_redirect }
         format.json { render :show, status: :ok, location: @api_namespace }
       else

--- a/app/helpers/api_forms_helper.rb
+++ b/app/helpers/api_forms_helper.rb
@@ -10,6 +10,7 @@ module ApiFormsHelper
   end
 
   def map_form_field(form, key, value, form_properties)
+    byebug
     case value.class.to_s
     when 'Array'
       if form_properties[key]['input_type'] == 'radio'

--- a/app/views/comfy/admin/api_forms/_render.haml
+++ b/app/views/comfy/admin/api_forms/_render.haml
@@ -1,10 +1,12 @@
 %link{:crossorigin => "anonymous", :href => "https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.0.0/jsoneditor.css", :integrity => "sha512-Mfp9P5Ln+lF/PmixCJBHUNHXoBKJwKY2i7oZ29iu/mnN47puo0TH/ORb3vgrdkyuBkLaDytv80480FNZxllpyQ==", :referrerpolicy => "no-referrer", :rel => "stylesheet"}/
 %script{:crossorigin => "anonymous", :integrity => "sha512-xEv8uIENS4DGY7Ml/Cv6+sbcPXiRAguIgU8Sv0FCUUdrNC7aRhWbOglm7lnzhnA3spqCr8DnTMTMNFW4jhM8gA==", :referrerpolicy => "no-referrer", :src => "https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.0.0/jsoneditor.js"}
 - properties = @api_namespace.properties.symbolize_keys
+- byebug
 - form_properties = @api_form.properties.symbolize_keys
 = form_for :data, url: api_namespace_resource_index_path(api_namespace_id: @api_namespace.id), method: :post, html: {class: 'violet-cta-form', 'data-type': 'json', multipart: true, id: 'api_form'} do |f|
   .form-group
     - properties.each do |key, value|
+      - byebug
       = f.fields_for :properties do |fff|
         .form-group{class: "vr-#{key}"}
           = fff.label key, form_properties[key]["label"]


### PR DESCRIPTION
https://github.com/restarone/violet_rails/issues/555

@Pralish  @alis-khadka  I have added some helpful breakpoints so yall can debug the above issue: 

when you change the order of the attributes in the API namespace here and hit save -- the breakpoints should get hit: 
![Screenshot from 2022-05-13 22-17-10](https://user-images.githubusercontent.com/35935196/168407220-271a2125-91a2-43d4-8a04-082daf0686cb.png)

