### PR TITLE
[violet rails core] Ability to define a custom API action (ruby method) similar to External Api Client

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -86,7 +86,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
-      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email,:custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
+      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email,:custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy, :method_definition]
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,

--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -10,8 +10,8 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
   # GET /api_resources/1 or /api_resources/1.json
   def show
-    handle_redirection if @redirect_action.present?
     handle_custom_action if @custom_action.present?
+    handle_redirection if @redirect_action.present?
   end
 
   # GET /api_resources/new
@@ -29,6 +29,9 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
     respond_to do |format|
       if @api_resource.save
+        # TO DO: should be done in HTML only?
+        handle_custom_action if @custom_action.present?
+
         format.html { redirect_to api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully created." }
         format.json { render :show, status: :created, location: @api_resource }
       else
@@ -43,7 +46,9 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
   def update
     respond_to do |format|
       if @api_resource.update(api_resource_params)
-        format.html {  handle_redirection }
+        handle_custom_action if @custom_action.present?
+
+        format.html { handle_redirection }
         format.json { render :show, status: :ok, location: @api_resource }
       else
         execute_error_actions
@@ -56,6 +61,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
   # DELETE /api_resources/1 or /api_resources/1.json
   def destroy
     @api_resource.destroy
+    handle_custom_action if @custom_action.present?
     respond_to do |format|
       format.html { redirect_to api_namespace_resources_url(api_namespace_id: @api_namespace.id), notice: "Api resource was successfully destroyed." }
       format.json { head :no_content }

--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -10,7 +10,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
   # GET /api_resources/1 or /api_resources/1.json
   def show
-    handle_custom_action if @custom_action.present?
+    handle_custom_actions if @custom_actions.present?
     handle_redirection if @redirect_action.present?
   end
 
@@ -29,7 +29,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
     respond_to do |format|
       if @api_resource.save
-        handle_custom_action if @custom_action.present?
+        handle_custom_actions if @custom_actions.present?
 
         format.html { redirect_to api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully created." }
         format.json { render :show, status: :created, location: @api_resource }
@@ -45,7 +45,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
   def update
     respond_to do |format|
       if @api_resource.update(api_resource_params)
-        handle_custom_action if @custom_action.present?
+        handle_custom_actions if @custom_actions.present?
 
         format.html { handle_redirection }
         format.json { render :show, status: :ok, location: @api_resource }
@@ -60,7 +60,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
   # DELETE /api_resources/1 or /api_resources/1.json
   def destroy
     @api_resource.destroy
-    handle_custom_action if @custom_action.present?
+    handle_custom_actions if @custom_actions.present?
     respond_to do |format|
       format.html { redirect_to api_namespace_resources_url(api_namespace_id: @api_namespace.id), notice: "Api resource was successfully destroyed." }
       format.json { head :no_content }

--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -29,7 +29,6 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
     respond_to do |format|
       if @api_resource.save
-        # TO DO: should be done in HTML only?
         handle_custom_action if @custom_action.present?
 
         format.html { redirect_to api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully created." }

--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -11,6 +11,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
   # GET /api_resources/1 or /api_resources/1.json
   def show
     handle_redirection if @redirect_action.present?
+    handle_custom_action if @custom_action.present?
   end
 
   # GET /api_resources/new

--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -37,21 +37,18 @@ module ApiActionable
     flash[:notice] = @api_namespace.api_form.success_message
     if @custom_action.present?
       begin
-        custom_api_action == ApiAction::CustomApiAction.new
+        custom_api_action = CustomApiAction.new
 
         eval("def custom_api_action.run_custom_action(api_action: , api_namespace:, api_resource: , current_visit: , current_user: nil); #{@custom_action.method_definition};end;")
-
         response = custom_api_action.run_custom_action(api_action: @custom_action, api_namespace: @api_namespace, api_resource: @api_resource, current_visit: current_visit, current_user: current_user)
 
         # TO DO: what should we use for lifecycle_message
-        self.update(lifecycle_stage: 'complete', lifecycle_message: response.to_s)
+        @custom_action.update(lifecycle_stage: 'complete', lifecycle_message: response.to_s)
       rescue => e
-        self.update(lifecycle_stage: 'failed', lifecycle_message: e.message)
+        @custom_action.update(lifecycle_stage: 'failed', lifecycle_message: e.message)
         execute_error_actions
       end
     end
-
-    #redirect_back(fallback_location: root_path, notice: "Api resource was successfully updated.")
   end
 
   def handle_redirection

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -7,7 +7,7 @@ class ResourceController < ApplicationController
     @api_resource = @api_namespace.api_resources.new(resource_params)
     if @api_namespace&.api_form&.show_recaptcha
       if verify_recaptcha(model: @api_resource) && @api_resource.save
-        handle_custom_action
+        handle_custom_actions
         handle_redirection
       else
         execute_error_actions
@@ -15,7 +15,7 @@ class ResourceController < ApplicationController
         redirect_back(fallback_location: root_path)
       end
     elsif @api_resource.save
-      handle_custom_action
+      handle_custom_actions
       handle_redirection
     else
       execute_error_actions

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ module ApplicationHelper
   def execute_actions(resource, class_name)
     api_actions = resource.send(class_name)
     api_actions.each do |api_action|
-      api_action.execute_action unless api_action.serve_file? || api_action.redirect?
+      api_action.execute_action unless api_action.serve_file? || api_action.redirect? || api_action.custom_action?
     end
   end
 

--- a/app/models/custom_api_action.rb
+++ b/app/models/custom_api_action.rb
@@ -1,0 +1,5 @@
+class ApiAction::CustomApiAction
+  def run_custom_action(api_action: , api_namespace:, api_resource: , current_visit: , current_user: nil)
+    raise "not implemented error"
+  end
+end

--- a/app/models/custom_api_action.rb
+++ b/app/models/custom_api_action.rb
@@ -1,4 +1,4 @@
-class ApiAction::CustomApiAction
+class CustomApiAction
   def run_custom_action(api_action: , api_namespace:, api_resource: , current_visit: , current_user: nil)
     raise "not implemented error"
   end

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -45,7 +45,10 @@
       .form-group
         = label_tag 'Bearer Token'
         = text_field_tag "api_namespace[#{type}_attributes][#{index}][bearer_token]", resource.bearer_token, { class: "form-control form-control-sm" }
-
+    .custom_action.col-12{style: "#{'display:none' unless resource.action_type == 'custom_action'}", id: "custom_action_fields_#{type}_#{index}"}
+      .form-group
+        = label_tag 'Method Definition'
+        = text_area_tag "api_namespace[#{type}_attributes][#{index}][method_definition]", resource.method_definition, { class: "form-control form-control-sm" }
 
   = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][_destroy]", false ,{id: "api_action_form_destroy_field_#{type}_#{index}"}
   = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][position]", resource.position ,{class: "position_field"}

--- a/app/views/comfy/admin/api_actions/action_workflow.html.haml
+++ b/app/views/comfy/admin/api_actions/action_workflow.html.haml
@@ -14,7 +14,7 @@
     - ApiAction.children.each do |subclass|
       .mb-5
         .h5.mb-3
-          Trigger Event: 
+          Trigger Event:
           = subclass.split('_api_actions').first
         .form-group{id: "#{subclass}_forms", class: "js-sortable"}
           = f.fields_for subclass, @api_namespace.send(subclass) do |ff|
@@ -37,6 +37,8 @@
       $("#serve_file_fields_" + type + '_' + index).show();
     } else if (fieldType === 'send_web_request') {
       $("#serve_web_request_fields_" + type + '_' + index).show();
+    } else if (fieldType === 'custom_action') {
+      $("#custom_action_fields_" + type + '_' + index).show();
     }
   }
 
@@ -45,6 +47,7 @@
     $("#redirect_fields_" + type + '_'  + index).hide();
     $("#serve_file_fields_" + type + '_' + index).hide();
     $("#serve_web_request_fields_" + type + '_' + index).hide();
+    $("#custom_action_fields_" + type + '_' + index).hide();
   }
 
   function removeForm(form_id, destroy_field_id) {
@@ -54,7 +57,7 @@
 
   function appendApiActionForm(type) {
     var index = $("#" + `${type}_forms > .form-container`).length
-    var url = "#{new_api_action_path()}" + `?index=${index}&type=${type}` 
+    var url = "#{new_api_action_path()}" + `?index=${index}&type=${type}`
     $.ajax({
       url: url ,
       type: 'GET',
@@ -63,4 +66,3 @@
       success: function(response) {}
     });
   }
-  

--- a/db/migrate/20220513034804_add_method_definition_to_api_actions.rb
+++ b/db/migrate/20220513034804_add_method_definition_to_api_actions.rb
@@ -1,0 +1,5 @@
+class AddMethodDefinitionToApiActions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_actions, :method_definition, :text, default: "ApiAction::CustomApiAction.class_eval do\n\tdef run_custom_action(current_user = nil, current_visit, api_object)\n\t\traise 'not implemented error'\n\tend\nend"
+  end
+end

--- a/db/migrate/20220513034804_add_method_definition_to_api_actions.rb
+++ b/db/migrate/20220513034804_add_method_definition_to_api_actions.rb
@@ -1,5 +1,5 @@
 class AddMethodDefinitionToApiActions < ActiveRecord::Migration[6.1]
   def change
-    add_column :api_actions, :method_definition, :text, default: "ApiAction::CustomApiAction.class_eval do\n\tdef run_custom_action(current_user = nil, current_visit, api_object)\n\t\traise 'not implemented error'\n\tend\nend"
+    add_column :api_actions, :method_definition, :text, default: "# You have access to vaiables: api_action, api_namespace, api_resource, current_visit, current_user\n# Write your custom code here\nraise 'not implemented error'"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2022_05_13_034804) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "custom_headers"
     t.string "http_method"
-    t.text "method_definition", default: "ApiAction::CustomApiAction.class_eval do\n\tdef run_custom_action(current_user = nil, current_visit, api_object)\n\t\traise 'not implemented error'\n\tend\nend"
+    t.text "method_definition", default: "# You have access to vaiables: api_action, api_namespace, api_resource, current_visit, current_user\n# Write your custom code here\nraise 'not implemented error'"
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_03_151800) do
+ActiveRecord::Schema.define(version: 2022_05_13_034804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2022_05_03_151800) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "custom_headers"
     t.string "http_method"
+    t.text "method_definition", default: "ApiAction::CustomApiAction.class_eval do\n\tdef run_custom_action(current_user = nil, current_visit, api_object)\n\t\traise 'not implemented error'\n\tend\nend"
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end
@@ -463,13 +464,13 @@ ActiveRecord::Schema.define(version: 2022_05_03_151800) do
     t.string "purge_visits_every", default: "never"
     t.string "analytics_report_frequency", default: "never"
     t.datetime "analytics_report_last_sent"
-    t.boolean "tracking_enabled", default: false
     t.boolean "ember_enabled", default: false
     t.boolean "graphql_enabled", default: false
     t.boolean "web_console_enabled", default: false
-    t.boolean "api_plugin_events_enabled", default: false
     t.string "after_sign_up_path"
     t.string "after_sign_in_path"
+    t.boolean "api_plugin_events_enabled", default: false
+    t.boolean "tracking_enabled", default: false
     t.index ["deleted_at"], name: "index_subdomains_on_deleted_at"
     t.index ["name"], name: "index_subdomains_on_name"
   end

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -39,12 +39,12 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
           },
           non_primitive_properties_attributes: [
              {
-              label: "image", 
+              label: "image",
               field_type: "file",
               attachment: file,
             },
             {
-              label: "image", 
+              label: "image",
               field_type: "richtext",
               content: "<div>test</div>"
             }
@@ -153,6 +153,28 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     }
     assert_difference "api_namespace.api_resources.count", +1 do
       post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+  end
+
+  test 'should allow #create and the custom action should be executed' do
+    api_namespace = api_namespaces(:one)
+    api_namespace.api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Test', 'type_validation': 'tel'}})
+
+    api_action = api_actions(:create_custom_api_action_one)
+    api_action.update!(method_definition: "User.create!(email: 'contact1@restarone.com', password: '123456', password_confirmation: '123456', confirmed_at: Time.now)")
+
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "api_namespace.api_resources.count", +1 do
+      # Custom Action creates a new user
+      assert_difference "User.count", +1 do
+        post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+      end
     end
   end
 end

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -157,10 +157,9 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should allow #create and the custom action should be executed' do
-    api_namespace = api_namespaces(:one)
+    api_namespace = api_namespaces(:three)
     api_namespace.api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Test', 'type_validation': 'tel'}})
-
-    api_action = api_actions(:create_custom_api_action_one)
+    api_action = api_actions(:create_custom_api_action_three)
     api_action.update!(method_definition: "User.create!(email: 'contact1@restarone.com', password: '123456', password_confirmation: '123456', confirmed_at: Time.now)")
 
     payload = {
@@ -177,4 +176,38 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'should allow #create and the custom action should be executed in the order that is defined' do
+    api_namespace = api_namespaces(:three)
+    api_namespace.api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Test', 'type_validation': 'tel'}})
+    api_action = api_actions(:create_custom_api_action_three)
+    api_action.update!(position: 0, method_definition: "User.create!(email: 'custom_action_0@restarone.com', password: '123456', password_confirmation: '123456', confirmed_at: Time.now)")
+
+    2.times.each do |n|
+      new_custom_action = api_actions(:create_custom_api_action_three).dup
+      new_custom_action.method_definition = "User.create!(email: 'custom_action_#{ n + 1 }@restarone.com', password: '123456', password_confirmation: '123456', confirmed_at: Time.now)"
+      new_custom_action.position = n + 1
+      new_custom_action.save!
+    end
+
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "api_namespace.api_resources.count", +1 do
+      # Total 3 Custom Action. Each creates a new user
+      assert_difference "User.count", +3 do
+        post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+      end
+    end
+
+    # According to the order of custom_api_actions, the users should be created in the order: 1) custom_action_0@restarone.com   2) custom_action_1@restarone.com  3) custom_action_2@restarone.com
+    assert User.find_by_email('custom_action_1@restarone.com').created_at > User.find_by_email('custom_action_0@restarone.com').created_at
+    assert User.find_by_email('custom_action_1@restarone.com').created_at < User.find_by_email('custom_action_2@restarone.com').created_at
+  end
+
+
 end

--- a/test/fixtures/api_actions.yml
+++ b/test/fixtures/api_actions.yml
@@ -4,7 +4,7 @@ one:
   type: NewApiAction
   action_type: redirect
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   redirect_url: MyString
   api_namespace: one
 
@@ -12,7 +12,7 @@ two:
   type: NewApiAction
   action_type: redirect
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   redirect_url: MyString
   api_resource: one
 
@@ -20,7 +20,7 @@ three:
   type: NewApiAction
   action_type: send_email
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   email: 'test@rest.com'
   api_resource: one
 
@@ -28,7 +28,7 @@ create_api_action_one:
   type: CreateApiAction
   action_type: redirect
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   redirect_url: MyString
   api_namespace: one
 
@@ -36,8 +36,8 @@ show_api_action_one:
   type: ShowApiAction
   action_type: send_email
   include_api_resource_data: false
-  payload_mapping: 
-  redirect_url: 
+  payload_mapping:
+  redirect_url:
   email: test@restarone.com
   api_namespace: one
 
@@ -45,8 +45,8 @@ create_api_action_two:
   type: CreateApiAction
   action_type: send_email
   include_api_resource_data: false
-  payload_mapping: 
-  redirect_url: 
+  payload_mapping:
+  redirect_url:
   email: test@restarone.com
   api_namespace: one
 
@@ -54,7 +54,7 @@ create_api_action_three:
   type: CreateApiAction
   action_type: send_web_request
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   request_url: "http://www.example.com/success"
   payload_mapping: {"first_name":"test"}
   custom_headers: {"AUTHORIZATION":"SECRET_BEARER_TOKEN"}
@@ -68,7 +68,7 @@ create_api_action_four:
   payload_mapping: {"first_name":"test"}
   custom_headers: {"AUTHORIZATION":"SECRET_BEARER_TOKEN"}
   request_url: "http://www.example.com/error"
-  email: 
+  email:
   api_resource: one
   http_method: post
 
@@ -76,8 +76,8 @@ error_api_action_one:
   type: ErrorApiAction
   action_type: send_email
   include_api_resource_data: false
-  payload_mapping: 
-  redirect_url: 
+  payload_mapping:
+  redirect_url:
   email: test@restarone.com
   api_namespace: one
 
@@ -85,7 +85,7 @@ error_api_action_two:
   type: ErrorApiAction
   action_type: redirect
   include_api_resource_data: false
-  payload_mapping: 
+  payload_mapping:
   redirect_url: '/'
   api_namespace: one
 
@@ -99,5 +99,13 @@ create_api_action_plugin_subdomain_events:
   request_url: "http://www.example.com/success"
   api_namespace: plugin_subdomain_events
   http_method: post
+
+create_custom_api_action_one:
+  type: CreateApiAction
+  action_type: custom_action
+  include_api_resource_data: false
+  payload_mapping:
+  method_definition: ""
+  api_namespace: one
 
 

--- a/test/fixtures/api_actions.yml
+++ b/test/fixtures/api_actions.yml
@@ -100,12 +100,12 @@ create_api_action_plugin_subdomain_events:
   api_namespace: plugin_subdomain_events
   http_method: post
 
-create_custom_api_action_one:
+create_custom_api_action_three:
   type: CreateApiAction
   action_type: custom_action
   include_api_resource_data: false
   payload_mapping:
-  method_definition: ""
-  api_namespace: one
+  method_definition: "logger = Logger.new(\"#{Rails.root}/log/api_action_response.log\"); logger.info 'Test log message!'"
+  api_namespace: three
 
 

--- a/test/fixtures/api_forms.yml
+++ b/test/fixtures/api_forms.yml
@@ -24,4 +24,12 @@ three:
   submit_button_label: MyString
   title: MyString
 
+four:
+  properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input' }}
+  api_namespace: three
+  success_message: MyString
+  failure_message: MyString
+  submit_button_label: MyString
+  title: MyString
+
 

--- a/test/fixtures/api_namespaces.yml
+++ b/test/fixtures/api_namespaces.yml
@@ -20,6 +20,16 @@ two:
   requires_authentication: false
   namespace_type: create-read-update-delete
 
+three:
+  name: testApi
+  slug: testApi
+  version: 1
+  properties: {
+                "name": "testApi"
+              }
+  requires_authentication: false
+  namespace_type: create-read-update-delete
+
 users:
   name: internal_users
   slug: internal_users


### PR DESCRIPTION
https://github.com/restarone/violet_rails/issues/527

# Acceptance criteria
when deployed to `staging`, it should

1. allow N number of custom actions to be performed 
2. log errors in the response (similar to HTTP action)
3. handle custom actions in the controller context
4. handle custom actions out of the controller context (ie; sending an email)
5. not break existing API action workflows