### PR TITLE
[release candidate] non renderable fields in API form,  Ahoy.js (+ add to exception notification), Allow analytics query via GQL, correct scoping in ApiNamespace

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,8 @@ class ApplicationController < ActionController::Base
 
   def prepare_exception_notifier
     request.env["exception_notifier.exception_data"] = {
-      current_user: current_user
+      current_user: current_user,
+      current_visit: current_visit
     }
   end
 end

--- a/app/controllers/comfy/admin/external_api_clients_controller.rb
+++ b/app/controllers/comfy/admin/external_api_clients_controller.rb
@@ -5,7 +5,7 @@ class Comfy::Admin::ExternalApiClientsController < Comfy::Admin::Cms::BaseContro
   
     # GET /api_clients or /api_clients.json
     def index
-      @external_api_clients = ExternalApiClient.all
+      @external_api_clients = @api_namespace.external_api_clients
     end
   
     # GET /api_clients/1 or /api_clients/1.json

--- a/app/controllers/comfy/admin/web_settings_controller.rb
+++ b/app/controllers/comfy/admin/web_settings_controller.rb
@@ -40,7 +40,8 @@ class Comfy::Admin::WebSettingsController < Comfy::Admin::Cms::BaseController
       :web_console_enabled,
       :api_plugin_events_enabled,
       :after_sign_in_path,
-      :after_sign_up_path
+      :after_sign_up_path,
+      :allow_external_analytics_query
     )
   end
 end

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -26,14 +26,18 @@ class ResourceController < ApplicationController
 
   def load_api_namespace
     @api_namespace = ApiNamespace.find_by(id: params[:api_namespace_id])
+    parse_incoming_resource_parameters
   end
-  
-  def resource_params
+
+  def parse_incoming_resource_parameters
     @api_namespace.properties.each do |key, value|
       if value.class.to_s == 'Hash'
         params[:data][:properties][key] = JSON.parse params[:data][:properties][key]
       end
     end
+  end
+  
+  def resource_params
     params.require(:data).permit(properties: {}, non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :_destroy])
   end
 end

--- a/app/graphql/types/ahoy/event_names_type.rb
+++ b/app/graphql/types/ahoy/event_names_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  class Ahoy::EventNamesType < Types::BaseObject
+
+    field :name, String
+
+    def self.authorized?(object, context)
+      if Subdomain.current.allow_external_analytics_query
+        return true
+      end
+      return false
+    end
+  end
+end

--- a/app/graphql/types/ahoy/events_type.rb
+++ b/app/graphql/types/ahoy/events_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  class Ahoy::EventsType < Types::BaseObject
+    field :id, ID, null: false
+    field :visit_id, Integer
+    field :user_id, Integer
+    field :name, String
+    field :properties, GraphQL::Types::JSON
+    field :time, GraphQL::Types::ISO8601DateTime
+
+    def self.authorized?(object, context)
+      if Subdomain.current.allow_external_analytics_query
+        return true
+      end
+      return false
+    end
+  end
+end

--- a/app/graphql/types/ahoy/visits_type.rb
+++ b/app/graphql/types/ahoy/visits_type.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Types
+  class Ahoy::VisitsType < Types::BaseObject
+    field :id, ID, null: false
+    field :visit_token, String
+    field :visitor_token, String
+    field :user_id, Integer
+    field :ip, String
+    field :user_agent, String
+    field :referrer, String
+    field :referring_domain, String
+    field :landing_page, String
+    field :browser, String
+    field :os, String
+    field :device_type, String
+    field :country, String
+    field :region, String
+    field :city, String
+    field :latitude, Float
+    field :longitude, Float
+    field :utm_source, String
+    field :utm_medium, String
+    field :utm_term, String
+    field :utm_content, String
+    field :utm_campaign, String
+    field :app_version, String
+    field :os_version, String
+    field :platform, String
+    field :started_at, GraphQL::Types::ISO8601DateTime
+
+    def self.authorized?(object, context)
+      if Subdomain.current.allow_external_analytics_query
+        return true
+      end
+      return false
+    end
+
+    field :events, [Types::Ahoy::EventsType], null: true do
+      description "Returns a list of Ahoy Events with ordering dimension, order direction, offset and limit"
+      argument :limit, Integer, required: false
+      argument :order_direction, String, required: false
+      argument :order_dimension, String, required: false
+      argument :offset, Integer, required: false
+    end
+  end
+end

--- a/app/graphql/types/api_namespace_type.rb
+++ b/app/graphql/types/api_namespace_type.rb
@@ -24,14 +24,15 @@ module Types
       argument :order_direction, String, required: false
       argument :order_dimension, String, required: false
       argument :offset, Integer, required: false
-    end
 
-    def api_resources(args = {})
-      args[:order_dimension] ||= 'created_at'
-      args[:order_direction] ||= 'desc'
-      args[:limit] ||= 50
-      args[:offset] ||= 0
-      ApiResource.all.order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
+      def resolve(parent, frozen_parameters, context)
+        parameters = { **frozen_parameters }
+        parameters[:order_dimension] ||= 'created_at'
+        parameters[:order_direction] ||= 'desc'
+        parameters[:limit] ||= 50
+        parameters[:offset] ||= 0
+        parent.object.api_resources.order("#{parameters[:order_dimension].underscore} #{parameters[:order_direction]}").limit(parameters[:limit]).offset(parameters[:offset])
+      end
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -19,7 +19,6 @@ module Types
     #     }
     #   }
     # }
-    
     field :api_namespaces, [Types::ApiNamespaceType], null: false do
       description "Returns a list of public ApiNamespaces with ordering dimension, order direction, offset and limit"
       argument :limit, Integer, required: false
@@ -27,6 +26,59 @@ module Types
       argument :order_dimension, String, required: false
       argument :offset, Integer, required: false
       argument :slug, String, required: false
+    end
+
+    # {
+    #   ahoyVisits(limit: 100,orderDirection:"desc", orderDimension: "started_at") {
+    #     id
+    #     ip
+    #     userAgent
+    #     referringDomain
+    #     landingPage
+    #     country
+    #     city
+    #     platform
+    #     events {
+    #       id
+    #       visitId
+    #       userId
+    #       name
+    #       properties
+    #     }
+    #   }
+    # }
+    field :ahoy_visits, [Types::Ahoy::VisitsType], null: false do
+      description "Returns a list of ahoy visits"
+      argument :limit, Integer, required: false
+      argument :order_direction, String, required: false
+      argument :order_dimension, String, required: false
+      argument :offset, Integer, required: false
+    end
+    # {
+    #   ahoyEvents(limit: 100, orderDirection:"desc", orderDimension: "time", name: "comfy-cms-page-visit") {
+    #     id
+    #     visitId
+    #     name
+    #     properties
+    #     time
+    #   }
+    # }
+    field :ahoy_events, [Types::Ahoy::EventsType], null: false do
+      description "Returns a list of ahoy events"
+      argument :limit, Integer, required: false
+      argument :order_direction, String, required: false
+      argument :order_dimension, String, required: false
+      argument :offset, Integer, required: false
+
+      argument :name, String, required: false
+    end
+    # {
+    #   ahoyEventNames {
+    #     name
+    #   }
+    # }
+    field :ahoy_event_names, [Types::Ahoy::EventNamesType], null: false do
+      description "Returns all the ahoy event names that are being used in the system"
     end
     
     def api_namespaces(args = {})
@@ -40,6 +92,31 @@ module Types
       else
         return ApiNamespace.where(requires_authentication: false).order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
       end
+    end
+
+    def ahoy_visits(args = {})
+      args[:order_dimension] ||= 'started_at'
+      args[:order_direction] ||= 'desc'
+      args[:limit] ||= 50
+      args[:offset] ||= 0
+      # the trailing :: is required to look for this namespace at the top level instead of in Types:: 
+      return ::Ahoy::Visit.all.includes(:events).order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
+    end
+
+    def ahoy_events(args = {})
+      args[:order_dimension] ||= 'time'
+      args[:order_direction] ||= 'desc'
+      args[:limit] ||= 50
+      args[:offset] ||= 0
+      if args[:name]
+        return ::Ahoy::Event.where(name: args[:name]).order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
+      else
+        return ::Ahoy::Event.all.order("#{args[:order_dimension].underscore} #{args[:order_direction]}").limit(args[:limit]).offset(args[:offset])
+      end
+    end
+
+    def ahoy_event_names
+      return ::Ahoy::Event.distinct.pluck(:name).map{|name| {name: name} }
     end
   end
 end

--- a/app/models/api_form.rb
+++ b/app/models/api_form.rb
@@ -12,4 +12,8 @@ class ApiForm < ApplicationRecord
     datetime: 'datetime-local',
     tel: 'tel'
   }
+
+  def is_field_renderable?(field)
+    properties.dig(field.to_s, 'renderable').nil? || properties.dig(field.to_s, 'renderable') == '1'
+  end
 end

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -1,9 +1,11 @@
 class ApiResource < ApplicationRecord
   include JsonbFieldsParsable
 
+  after_initialize :inherit_properties_from_parent
+
   belongs_to :api_namespace
 
-  before_create :initialize_api_actions
+  before_create :initialize_api_actions, :inject_inherited_properties
 
   validate :presence_of_required_properties
 
@@ -44,6 +46,26 @@ class ApiResource < ApplicationRecord
     properties.each do |key, value|
       if api_namespace.api_form.properties.dig(key,"required") == '1' && !value.present?
         errors.add(:properties, "#{key} is required")
+      end
+    end
+  end
+
+  private
+
+  def inherit_properties_from_parent
+    return unless self.properties.nil?
+
+    self.properties = api_namespace&.properties
+  end
+
+  def inject_inherited_properties
+    # you can make certain primitive properties (inherited from the parent API namespace) non renderable, in these cases we have to populate the values
+    # to - do write test
+    return if !api_namespace&.api_form&.properties
+    api_form_properties = api_namespace.api_form.properties
+    api_namespace.properties.each do |key, value|
+      if api_form_properties[key]['renderable'] == '0'
+        self.properties[key] =  api_namespace.properties[key]
       end
     end
   end

--- a/app/views/comfy/admin/api_forms/_form.html.haml
+++ b/app/views/comfy/admin/api_forms/_form.html.haml
@@ -83,6 +83,10 @@
                 .form-group.col-12
                   = a.label :required, 'Required:', class: 'mr-4'
                   = a.check_box :required, checked: properties[key]["required"] == "1"
+
+                .form-group.col-12
+                  = a.label :renderable, 'Renderable', class: 'mr-4'
+                  = a.check_box :renderable, checked: @api_form.is_field_renderable?(key)
       
       - @api_namespace.non_primitive_properties.each do |prop|
         .col-12.col-md-4.mb-4

--- a/app/views/comfy/admin/api_forms/_render.haml
+++ b/app/views/comfy/admin/api_forms/_render.haml
@@ -6,9 +6,10 @@
   .form-group
     - properties.each do |key, value|
       = f.fields_for :properties do |fff|
-        .form-group{class: "vr-#{key}"}
-          = fff.label key, form_properties[key]["label"]
-          = map_form_field(fff, key, value, form_properties)
+        - if @api_form.is_field_renderable?(key)
+          .form-group{class: "vr-#{key}"}
+            = fff.label key, form_properties[key]["label"]
+            = map_form_field(fff, key, value, form_properties)
     - @api_namespace.non_primitive_properties.each_with_index do |property, index|
       = fields_for "data[non_primitive_properties_attributes][#{index}]", property do |ff|
         .form-group{class: "vr-#{ff.object.label}"}

--- a/app/views/comfy/admin/web_settings/_form.haml
+++ b/app/views/comfy/admin/web_settings/_form.haml
@@ -53,6 +53,12 @@
   %label
     Graphql (experimental):
   = f.check_box :graphql_enabled
+
+.form-group
+  %label
+    Allow external analytics querying (experimental):
+  = f.check_box :allow_external_analytics_query
+
 .form-group
   %label
     Web console (experimental):

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # ahoy analytics
+  mount Ahoy::Engine => "/ahoy", as: :my_ahoy
+
   # to query CMS pages
   post '/query', to: 'search#query'
   # to query the rest of the system

--- a/db/migrate/20220514215146_add_allow_external_analytics_query_to_subdomain.rb
+++ b/db/migrate/20220514215146_add_allow_external_analytics_query_to_subdomain.rb
@@ -1,0 +1,7 @@
+class AddAllowExternalAnalyticsQueryToSubdomain < ActiveRecord::Migration[6.1]
+  def change
+    change_table :subdomains do |t|
+      t.boolean :allow_external_analytics_query, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_03_151800) do
+ActiveRecord::Schema.define(version: 2022_05_14_215146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -470,6 +470,9 @@ ActiveRecord::Schema.define(version: 2022_05_03_151800) do
     t.boolean "api_plugin_events_enabled", default: false
     t.string "after_sign_up_path"
     t.string "after_sign_in_path"
+    t.boolean "allow_external_analytics_query", default: false
+    t.boolean "api_plugin_events_enabled", default: false
+    t.boolean "tracking_enabled", default: false
     t.index ["deleted_at"], name: "index_subdomains_on_deleted_at"
     t.index ["name"], name: "index_subdomains_on_name"
   end

--- a/test/fixtures/api_forms.yml
+++ b/test/fixtures/api_forms.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input' }}
+  properties: { 'name': {'label': 'name', 'placeholder': 'Name', 'field_type': 'input' }}
   api_namespace: one
   success_message: MyString
   failure_message: MyString
@@ -23,4 +23,5 @@ three:
   failure_message: MyString
   submit_button_label: MyString
   title: MyString
+
 

--- a/test/models/api_form_test.rb
+++ b/test/models/api_form_test.rb
@@ -1,7 +1,20 @@
 require "test_helper"
 
 class ApiFormTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "return true if renderable property is nil" do
+    api_form = api_forms(:one)
+    assert api_form.is_field_renderable?('Test')
+  end
+
+  test "return true if renderable property is 1" do
+    api_form = api_forms(:one)
+    api_form.update(properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input', 'renderable': '1' }})
+    assert api_form.is_field_renderable?('Test')
+  end
+
+  test "return false if renderable property is 0" do
+    api_form = api_forms(:one)
+    api_form.update(properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input', 'renderable': '0' }})
+    assert api_form.is_field_renderable?('Test')
+  end
 end

--- a/test/models/api_resource_test.rb
+++ b/test/models/api_resource_test.rb
@@ -1,7 +1,21 @@
 require "test_helper"
 
 class ApiResourceTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "when initialized - inherits parent properties" do
+    api_namespace = api_namespaces(:one)
+    api_resource = ApiResource.new(api_namespace_id: api_namespace.id)
+
+    assert_equal api_resource.properties, api_namespace.properties
+  end
+
+  test "when updated - adheres to presence validations enforced by API form" do
+    api_namespace = api_namespaces(:one)
+    api_form = api_forms(:one)
+    api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Name', 'field_type': 'input', 'required': '1' }})
+
+    api_resource = ApiResource.create(api_namespace_id: api_namespace.id, properties: {'name': ''})
+    refute api_resource.id
+
+    assert_includes api_resource.errors.messages[:properties], 'name is required'
+  end
 end


### PR DESCRIPTION
# API Data/Automations Pipeline 0.2
This PR represents a best effort at,
1. packaging everything needed for: https://github.com/restarone/violet_rails/issues?q=is%3Aissue+is%3Aopen+label%3A%22API+-+data+pipeline+v2%22
2. Making sure we didn't break anything :)

## so far it includes the following features (in merge order):

1. [Feature] Non-renderable (private) attributes in API Namespace: https://github.com/restarone/violet_rails/issues/526
2. [Bug Fix] Correct scoping in External API Clients (before it was showing all External API Clients in the API Namespace/External API Clients view): https://github.com/restarone/violet_rails/pull/572
3. [Feature] Ahoy.js (allows creating tracking events via CMS), add ahoy visit to exception notification): https://github.com/restarone/violet_rails/pull/575
4. [Feature] Allow Ahoy Visits/Events to be queried in GraphQL (gated via Subdomain experiment): https://github.com/restarone/violet_rails/pull/579
5. [Bug Fix] correct scoping in ApiNamespace => children in GQL: https://github.com/restarone/violet_rails/pull/580


## Non-renderable (private) attributes in API Namespace acceptance criteria: 
when deployed to `staging`, it should
* form submission / api actions work as expected
* non renderable attribute is NOT sent to the client 
* when non-rendarable, the field is not shown / present in the DOM

## Ahoy.js (allows creating tracking events via CMS), add ahoy visit to exception notification)
you can now create tracking events from the CMS!

Given the following code in a script tag: 
``` javascript
ahoy.track("my-event-name-here", {title: " foobar"})
```
you can record your ahoy events and see them created in the Admin UI: 
![Screenshot from 2022-05-15 10-32-23](https://user-images.githubusercontent.com/35935196/168478249-689f8a02-a260-4bac-9291-356d3d34c100.png)

The exception notification looks something like this with ahoy visit included (along with the current user): 
``` txt
An Errno::ENOSPC occurred in forum_threads#create:

  No space left on device - bs_fetch:atomic_write_cache_file:write
  app/controllers/simple_discussion/forum_threads_controller.rb:52:in `create'


-------------------------------
Request:
-------------------------------

... request info

-------------------------------
Session:
-------------------------------
... session info

-------------------------------
Environment:
-------------------------------
.... env info 

-------------------------------
Backtrace:
-------------------------------

 .... backtrace info 

-------------------------------
Data:
-------------------------------

  * data: {:current_user=>
     ...  current user info
   :current_visit=>
    * #<Ahoy::Visit:0x00007f45ec3465a0
     id: 80,
     visit_token: "b936e7bb-4a6c-4beb-aa37-2633c1327de9",
     visitor_token: "fd61ac9b-a17d-4689-ba30-d15630cd5413",
     user_id: 1,
     ip: "142.188.123.22",
     user_agent:
      "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0",
     referrer: nil,
     referring_domain: nil,
     landing_page: "https://pr.restarone.solutions/forum/",
     browser: "Firefox",
     os: "Ubuntu",
     device_type: "Desktop",
     country: "CA",
     region: "Ontario",
     city: "Toronto",
     latitude: 43.7001,
     longitude: -79.4163,
     utm_source: nil,
     utm_medium: nil,
     utm_term: nil,
     utm_content: nil,
     utm_campaign: nil,
     app_version: nil,
     os_version: nil,
     platform: nil,
     started_at: Sun, 15 May 2022 15:08:05.849211000 UTC +00:00>} *
```

## Allow Ahoy Visits/Events to be queried in GraphQL 

When enabled at the subdomain level, you can now query ahoy visits and events: 
![Screenshot from 2022-05-15 11-48-26](https://user-images.githubusercontent.com/35935196/168481652-811a315c-8f91-4f8c-87ab-5e0481fa45ab.png)