### PR TITLE
[feature] rails based maintenance mode with turnout, [bug fix] API #show view covers edit / back buttons on certain screen sizes, update MIT license

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,3 +102,5 @@ gem "ember-cli-rails", "0.10.0"
 # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
 gem 'web-console', '>= 4.1.0'
 gem "exception_notification", "~> 4.5"
+
+gem "turnout", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-mini-profiler (2.3.1)
@@ -433,6 +435,11 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    turnout (2.5.0)
+      i18n (>= 0.7, < 2)
+      rack (>= 1.3, < 3)
+      rack-accept (~> 0.4)
+      tilt (>= 1.4, < 3)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -527,6 +534,7 @@ DEPENDENCIES
   sitemap_generator
   spring
   turbolinks (~> 5)
+  turnout (~> 2.5)
   tzinfo-data
   web-console (>= 4.1.0)
   webdrivers

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2021 Restarone Solutions Inc.
+Copyright (c) 2020-2022 Restarone Solutions Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/app/views/comfy/admin/cms/partials/_navigation_before.haml
+++ b/app/views/comfy/admin/cms/partials/_navigation_before.haml
@@ -2,4 +2,4 @@
   = link_to root_path(subdomain: Apartment::Tenant.current), target: '_blank', class: 'd-flex justify-content-center align-items-center' do
     = image_tag(Subdomain.current.logo, class: 'd-none d-lg-block img-fluid p-4', size: '150x150')
 - else 
-  = link_to "Add your logo here", edit_web_settings_path
+  = link_to "Add your logo here", edit_web_settings_path, class: 'd-none d-lg-block p-4' 


### PR DESCRIPTION
# release

## [Feature] rails based maintenance mode with turnout

worked pretty good when we migrated our database from EC2 to RDS: 
<img width="1172" alt="Screen Shot 2022-05-20 at 9 41 58 PM" src="https://user-images.githubusercontent.com/35935196/169629605-befae55c-31f7-45c4-8375-4f90a9626d7a.png">

## [Bug fix] API #show view covers edit / back buttons on certain screen sizes
https://github.com/restarone/violet_rails/issues/563 thanks @yashkir
