### PR TITLE
[Feature] add permission can_manage_analytics to users for controlling analytics access

### DIFF
--- a/app/controllers/comfy/admin/dashboard_controller.rb
+++ b/app/controllers/comfy/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Comfy::Admin::DashboardController < Comfy::Admin::Cms::BaseController
   include AhoyEventsHelper
 
-  before_action :ensure_authority_to_manage_web
+  before_action :ensure_authority_to_manage_analytics
   before_action :set_visit, only: [:visit]
 
   def dashboard

--- a/app/controllers/comfy/admin/users_controller.rb
+++ b/app/controllers/comfy/admin/users_controller.rb
@@ -73,6 +73,7 @@ class Comfy::Admin::UsersController < Comfy::Admin::Cms::BaseController
       :can_manage_email,
       :can_manage_users,
       :can_manage_api,
+      :can_manage_analytics,
       :moderator,
       :name,
       :can_view_restricted_pages,

--- a/app/controllers/subdomains/base_controller.rb
+++ b/app/controllers/subdomains/base_controller.rb
@@ -18,6 +18,13 @@ class Subdomains::BaseController < ApplicationController
     end
   end
 
+  def ensure_authority_to_manage_analytics
+    unless current_user.can_manage_analytics
+      flash.alert = "You do not have the permission to do that. Only users who can_manage_analytics are allowed to perform that action."
+      redirect_back(fallback_location: root_url)
+    end
+  end
+
   def ensure_authority_to_manage_web_settings
     unless current_user.can_manage_subdomain_settings
       flash.alert = "You do not have the permission to do that. Only users who can_manage_subdomain_settings are allowed to perform that action."

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,7 @@ class User < ApplicationRecord
   FULL_PERMISSIONS = {
     can_access_admin: true,
     can_manage_web: true,
+    can_manage_analytics: true,
     can_manage_email: true,
     can_manage_users: true,
     can_manage_blog: true,

--- a/app/views/comfy/admin/users/_form.haml
+++ b/app/views/comfy/admin/users/_form.haml
@@ -24,6 +24,10 @@
                 %label 
                   Can manage website (Layouts, Pages, Files, Snippets)
               .form-group
+                = f.check_box :can_manage_analytics
+                %label
+                  Can manage analytics
+              .form-group
                 = f.check_box :can_manage_email
                 %label 
                   Can manage emailbox

--- a/app/views/comfy/admin/users/edit.haml
+++ b/app/views/comfy/admin/users/edit.haml
@@ -40,43 +40,44 @@
           locked at:
           = @user.locked_at
 
-  %main{class: 'my-5'}
-    %h3
-      Sessions
-    .card
-      = render partial: 'pagination', locals: { objects: @visits }
-      .table-responsive
-        %table.table.table-bordered
-          %thead
-            %tr
-              %th
-                = sort_link @visits_q, :timestamp
-              %th
-                = sort_link @visits_q, :ip
-              %th
-                = sort_link @visits_q, :os
-              %th
-                = sort_link @visits_q, :browser
-              %th
-                = sort_link @visits_q, :device_type
-              %th
-                = sort_link @visits_q, :country
-              %th
-                = sort_link @visits_q, :region
-              %th
-                = sort_link @visits_q, :city
-              %th
-                = sort_link @visits_q, :user_agent
-            - @visits.each do |v|
+  - if current_user.can_manage_analytics?
+    %main{class: 'my-5'}
+      %h3
+        Sessions
+      .card
+        = render partial: 'pagination', locals: { objects: @visits }
+        .table-responsive
+          %table.table.table-bordered
+            %thead
               %tr
-                %th= link_to v.started_at.strftime('%I:%M %P - %b %d, %Y'), user_sessions_visit_admin_user_url(id: @user.id, ahoy_visit_id: v.id), title: 'View session details'
-                %th= v.ip
-                %th= v.os
-                %th= v.browser
-                %th= v.device_type
-                %th= v.country
-                %th= v.region
-                %th= v.city
-                %th.text-wrap.text-break= v.user_agent
-      = render partial: 'pagination', locals: { objects: @visits }
+                %th
+                  = sort_link @visits_q, :timestamp
+                %th
+                  = sort_link @visits_q, :ip
+                %th
+                  = sort_link @visits_q, :os
+                %th
+                  = sort_link @visits_q, :browser
+                %th
+                  = sort_link @visits_q, :device_type
+                %th
+                  = sort_link @visits_q, :country
+                %th
+                  = sort_link @visits_q, :region
+                %th
+                  = sort_link @visits_q, :city
+                %th
+                  = sort_link @visits_q, :user_agent
+              - @visits.each do |v|
+                %tr
+                  %th= link_to v.started_at.strftime('%I:%M %P - %b %d, %Y'), user_sessions_visit_admin_user_url(id: @user.id, ahoy_visit_id: v.id), title: 'View session details'
+                  %th= v.ip
+                  %th= v.os
+                  %th= v.browser
+                  %th= v.device_type
+                  %th= v.country
+                  %th= v.region
+                  %th= v.city
+                  %th.text-wrap.text-break= v.user_agent
+        = render partial: 'pagination', locals: { objects: @visits }
 

--- a/db/migrate/20220524080242_add_can_manage_analytics_to_users.rb
+++ b/db/migrate/20220524080242_add_can_manage_analytics_to_users.rb
@@ -1,0 +1,5 @@
+class AddCanManageAnalyticsToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :can_manage_analytics, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_14_215146) do
+ActiveRecord::Schema.define(version: 2022_05_24_080242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -519,6 +519,7 @@ ActiveRecord::Schema.define(version: 2022_05_14_215146) do
     t.string "session_timeoutable_in", default: "1-hour"
     t.boolean "can_access_admin", default: false
     t.boolean "deliver_error_notifications", default: false
+    t.boolean "can_manage_analytics", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true

--- a/test/controllers/admin/comfy/dashboard_controller_test.rb
+++ b/test/controllers/admin/comfy/dashboard_controller_test.rb
@@ -4,7 +4,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:public)
     @subdomain = subdomains(:public)
-    @user.update(can_manage_web: true)
+    @user.update(can_manage_analytics: true)
   end
 
   test "should deny #dashboard if not signed in" do
@@ -14,7 +14,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
 
   test "should deny #dashboard if not permissioned" do
     sign_in(@user)
-    @user.update(can_manage_web: false)
+    @user.update(can_manage_analytics: false)
     get dashboard_url
     assert_response :redirect
   end
@@ -29,7 +29,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     @subdomain.update!(tracking_enabled: true)
     get root_url
     sign_in(@user)
-    @user.update(can_manage_web: false)
+    @user.update(can_manage_analytics: false)
     get dashboard_visits_url(ahoy_visit_id: Ahoy::Visit.first.id)
     assert_response :redirect
   end
@@ -46,7 +46,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     @subdomain.update!(tracking_enabled: true)
     get root_url
     sign_in(@user)
-    @user.update(can_manage_web: false)
+    @user.update(can_manage_analytics: false)
     Ahoy::Visit.first.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
     get dashboard_events_url(ahoy_event_type: 'test')
     assert_response :redirect
@@ -65,7 +65,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     @subdomain.update!(tracking_enabled: true)
     get root_url
     sign_in(@user)
-    @user.update(can_manage_web: false)
+    @user.update(can_manage_analytics: false)
     get dashboard_events_list_url
     assert_response :redirect
   end

--- a/test/controllers/admin/comfy/users_controller_test.rb
+++ b/test/controllers/admin/comfy/users_controller_test.rb
@@ -59,6 +59,22 @@ class Comfy::Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert flash.alert
   end
 
+  test "#edit: shows session details if the logged-in user can_manage_analytics" do
+    @user.update(can_manage_analytics: true)
+    sign_in(@user)
+    get edit_admin_user_url(subdomain: @domain, id: @user.id)
+    assert_response :success
+    assert_select 'h3', {count: 1, text: 'Sessions'}, 'This page must contain Sessions details.'
+  end
+
+  test "#edit: does not show session details if the logged-in user can_manage_analytics permission is false" do
+    @user.update(can_manage_analytics: false)
+    sign_in(@user)
+    get edit_admin_user_url(subdomain: @domain, id: @user.id)
+    assert_response :success
+    assert_select 'h3', {count: 0, text: 'Sessions'}, 'This page must not contain Sessions details.'
+  end
+
   test "#update" do
     sign_in(@user)
     @user.update(can_manage_users: true)


### PR DESCRIPTION
https://github.com/restarone/violet_rails/issues/552


# acceptance criteria

1. after migration, users should not be able to access analytics
2. only users with permission can_manage_analytics can access views under: `/dashboard`, `dashboard/events_list`, `dashboard/events/:event_name`, `dashboard/sessions/:session_id`, `users/:user_id/edit/sessions/:session_id`