### PR TITLE
[Bug fix] When a forum post is updated with with image/file, user is presented with error and thumbnail is broken for images.

### DIFF
--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,6 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag Rails.application.routes.url_helpers.rails_representation_url(blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]).processed, subdomain: Apartment::Tenant.current, host: ENV['APP_HOST']) %>
+    <%= image_tag Rails.application.routes.url_helpers.rails_representation_url(blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]), subdomain: Apartment::Tenant.current, host: ENV['APP_HOST']) %>
   <% end %>
 
   <figcaption class="attachment__caption">


### PR DESCRIPTION
addresses: https://github.com/restarone/violet_rails/issues/600

# acceptance criteria

1. existing forum posts/threads that contain assets (images, files etc) are not broken
2. user is able to update posts/threads with/without assets 
3. functionality works as expected in subdomains and the apex domain