### PR TITLE
fix(): duplicate attributes removed from schema.rb (#637)

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -463,11 +463,9 @@ ActiveRecord::Schema.define(version: 2022_05_24_080242) do
     t.string "purge_visits_every", default: "never"
     t.string "analytics_report_frequency", default: "never"
     t.datetime "analytics_report_last_sent"
-    t.boolean "tracking_enabled", default: false
     t.boolean "ember_enabled", default: false
     t.boolean "graphql_enabled", default: false
     t.boolean "web_console_enabled", default: false
-    t.boolean "api_plugin_events_enabled", default: false
     t.string "after_sign_up_path"
     t.string "after_sign_in_path"
     t.boolean "allow_external_analytics_query", default: false


### PR DESCRIPTION
addresses P0: 

```txt
An ArgumentError occurred in subdomains#create:

  you can't define an already defined column 'api_plugin_events_enabled'.
  app/models/subdomain.rb:218:in `create_tenant'

```

fix(): duplicate attributes removed from schema.rb (#637)