### PR TITLE
[feature] export data from API resource in CSV format (#629)

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -1,6 +1,6 @@
 class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
   before_action :ensure_authority_to_manage_api
-  before_action :set_api_namespace, only: %i[ show edit update destroy discard_failed_api_actions rerun_failed_api_actions]
+  before_action :set_api_namespace, only: %i[ show edit update destroy discard_failed_api_actions rerun_failed_api_actions export]
 
   # GET /api_namespaces or /api_namespaces.json
   def index
@@ -75,6 +75,18 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
     respond_to do |format|
       format.html { redirect_back(fallback_location: root_path, notice: "Failed api actions reran") }
       format.json { render json: { message: 'Failed api actions reran', status: :ok } }
+    end
+  end
+
+  def export
+    # Naming convention: api_namespace_<API NAMESPACE ID>_<CURRENT TIMESTAMP>.csv
+    filename = "api_namespace_#{@api_namespace.id}_#{DateTime.now.to_i}.csv"
+    respond_to do |format|
+      format.csv do
+        response.headers['Content-Type'] = 'text/csv'
+        response.headers['Content-Disposition'] = "attachment; filename=#{filename}"
+        render template: "comfy/admin/api_namespaces/export"
+      end
     end
   end
 

--- a/app/views/comfy/admin/api_namespaces/export.csv.haml
+++ b/app/views/comfy/admin/api_namespaces/export.csv.haml
@@ -1,0 +1,9 @@
+- headers = ApiNamespace.column_names
+- headers.each do |header|
+  - data = @api_namespace.send(header)
+  - if header == 'properties'
+    - props = data
+    - props.keys.each do |key|
+      = CSV.generate_line([key, props[key]], row_sep: "").html_safe
+  - else
+    = CSV.generate_line([header, data], row_sep: "").html_safe

--- a/app/views/comfy/admin/api_namespaces/show.html.haml
+++ b/app/views/comfy/admin/api_namespaces/show.html.haml
@@ -123,6 +123,7 @@
         = render_form @api_namespace.api_form.id
   #settings.tab-pane.fade{"aria-labelledby" => "settings-tab", :role => "tabpanel"} 
     = link_to 'Delete', @api_namespace, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'  
+    = link_to 'Download CSV', export_api_namespace_path(@api_namespace, format: :csv), class: 'btn btn-warning'  
 
 .container-fluid.mt-5
   .d-flex.justify-content-between.py-2.page-header

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
     member do
       post 'discard_failed_api_actions'
       post 'rerun_failed_api_actions'
+      get 'export'
     end
   end
   resources :non_primitive_properties, controller: 'comfy/admin/non_primitive_properties', only: [:new]

--- a/test/controllers/admin/comfy/api_namespaces_controller_test.rb
+++ b/test/controllers/admin/comfy/api_namespaces_controller_test.rb
@@ -137,4 +137,16 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
       end
     end
   end
+
+  test "should export api_namespace" do
+    sign_in(@user)
+    api_namespace = api_namespaces(:namespace_with_all_types)
+    stubbed_date = DateTime.new(2022, 1, 1)
+    DateTime.stubs(:now).returns(stubbed_date)
+    get export_api_namespace_url(api_namespace, format: :csv)
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\n"
+    assert_response :success
+    assert_equal response.body, expected_csv
+    assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
+  end
 end

--- a/test/fixtures/api_namespaces.yml
+++ b/test/fixtures/api_namespaces.yml
@@ -64,3 +64,21 @@ plugin_subdomain_events:
                   }
                 }
               }
+
+namespace_with_all_types:
+  name: namespace_with_all_types
+  slug: namespace_with_all_types
+  version: 1
+  properties: {
+                "array": ["yes","no"],
+                "object": {
+                  "a": "b",
+                  "c": "d"
+                },
+                "string": "string",
+                "number": 123,
+                "boolean": true,
+                "null": null
+              }
+  requires_authentication: false
+  namespace_type: create-read-update-delete


### PR DESCRIPTION
[* spike

* test api_namespace export (#642)

* Remove row separator (#644)

* test api_namespace export

* row separater single line

Co-authored-by: Pralish Kayastha <50227291+Pralish@users.noreply.github.com>](https://github.com/restarone/violet_rails/issues/321

# acceptance criteria:

1. export button is present on all API Namespaces
2. complex API Namespaces can be converted to CSV format
3. API Actions + automations are working as expected )