### PR TITLE
[Feature] Ability to clone api namespace along with its children

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -1,6 +1,6 @@
 class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
   before_action :ensure_authority_to_manage_api
-  before_action :set_api_namespace, only: %i[ show edit update destroy discard_failed_api_actions rerun_failed_api_actions export]
+  before_action :set_api_namespace, only: %i[ show edit update destroy discard_failed_api_actions rerun_failed_api_actions export duplicate_with_associations duplicate_without_associations ]
 
   # GET /api_namespaces or /api_namespaces.json
   def index
@@ -75,6 +75,38 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
     respond_to do |format|
       format.html { redirect_back(fallback_location: root_path, notice: "Failed api actions reran") }
       format.json { render json: { message: 'Failed api actions reran', status: :ok } }
+    end
+  end
+
+  def duplicate_with_associations
+    response = @api_namespace.duplicate_api_namespace(duplicate_associations: true)
+
+    respond_to do |format|
+      if response[:success]
+        cloned_api_namespace = response[:data]
+
+        format.html { redirect_to api_namespace_path(id: cloned_api_namespace.id), notice: "Api namespace was successfully created." }
+        format.json { render :show, status: :created, location: cloned_api_namespace }
+      else
+        format.html { redirect_to @api_namespace, alert: "Duplicating Api namespace failed due to: #{response[:message]}." }
+        format.json { render json: response, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def duplicate_without_associations
+    response = @api_namespace.duplicate_api_namespace
+
+    respond_to do |format|
+      if response[:success]
+        cloned_api_namespace = response[:data]
+
+        format.html { redirect_to api_namespace_path(id: cloned_api_namespace.id), notice: "Api namespace was successfully created." }
+        format.json { render :show, status: :created, location: cloned_api_namespace }
+      else
+        format.html { redirect_to @api_namespace, alert: "Duplicating Api namespace failed due to: #{response[:message]}." }
+        format.json { render json: response, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -85,4 +85,71 @@ class ApiNamespace < ApplicationRecord
   def discard_failed_actions
     executed_api_actions.where(lifecycle_stage: 'failed').update_all(lifecycle_stage: 'discarded')
   end
+
+  def duplicate_api_namespace(duplicate_associations: false)
+    begin
+      ActiveRecord::Base.transaction do
+        raise 'You cannot duplicate the api_namespace without associations if it has api_form' if duplicate_associations == false && self.api_form.present?
+
+        new_api_namespace = self.dup
+        new_api_namespace.name = self.name + '-copy-' + SecureRandom.hex(4)
+        new_api_namespace.save!
+    
+        if duplicate_associations
+          # Duplicate ApiForm
+          if self.api_form.present?
+            new_api_form = self.api_form.dup
+            new_api_form.api_namespace = new_api_namespace
+            new_api_form.save!
+          end
+    
+          # Duplicate ApiClients
+          self.api_clients.each do |api_client|
+            new_api_client = api_client.dup
+            new_api_client.api_namespace = new_api_namespace
+            new_api_client.save!
+          end
+    
+          # Duplicate ExternalApiClients
+          self.external_api_clients.each do |external_api_client|
+            new_external_api_client = external_api_client.dup
+            new_external_api_client.api_namespace = new_api_namespace
+            new_external_api_client.save!
+          end
+    
+          # Duplicate NonPrimitiveProperties
+          self.non_primitive_properties.each do |non_primitive_property|
+            new_non_primitive_property = non_primitive_property.dup
+            new_non_primitive_property.api_namespace = new_api_namespace
+            new_non_primitive_property.save!
+          end
+    
+          # Duplicate ApiActions
+          self.api_actions.each do |api_action|
+            new_api_action = api_action.dup
+            new_api_action.api_namespace = new_api_namespace
+            new_api_action.save!
+          end
+    
+          # Duplicate ApiResources & ExecutedApiActions
+          self.api_resources.each do |api_resource|
+            # For skipping before_create callback for ApiResource
+            current_date_time = Time.zone.now
+            ApiResource.insert(api_resource.attributes.except("id", "created_at", "updated_at", 'api_namespace_id').merge({api_namespace_id: new_api_namespace.id, created_at: Time.zone.now, updated_at: Time.zone.now}))
+            new_api_resource = new_api_namespace.reload.api_resources.last
+    
+            api_resource.api_actions.each do |executed_api_action|
+              new_executed_api_action = executed_api_action.dup
+              new_executed_api_action.api_resource = new_api_resource
+              new_executed_api_action.save!
+            end
+          end
+        end
+
+        { success: true, data: new_api_namespace }
+      end
+    rescue => e
+      { success: false, message: e.message }
+    end
+  end
 end

--- a/app/views/comfy/admin/api_namespaces/show.html.haml
+++ b/app/views/comfy/admin/api_namespaces/show.html.haml
@@ -122,8 +122,14 @@
       .card.p-3
         = render_form @api_namespace.api_form.id
   #settings.tab-pane.fade{"aria-labelledby" => "settings-tab", :role => "tabpanel"} 
-    = link_to 'Delete', @api_namespace, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'  
-    = link_to 'Download CSV', export_api_namespace_path(@api_namespace, format: :csv), class: 'btn btn-warning'  
+    .my-3
+      = link_to 'Delete', @api_namespace, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'
+    .my-3
+      = link_to 'Download CSV', export_api_namespace_path(@api_namespace, format: :csv), class: 'btn btn-warning'
+    .my-3
+      = link_to 'Duplicate with associations', duplicate_with_associations_api_namespace_path(id: @api_namespace.id), method: :post, target: '_blank', class: 'btn btn-primary'
+    .my-3
+      = link_to 'Duplicate without associations', duplicate_without_associations_api_namespace_path(id: @api_namespace.id), method: :post, target: '_blank', class: 'btn btn-primary'
 
 .container-fluid.mt-5
   .d-flex.justify-content-between.py-2.page-header

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,13 @@ Rails.application.routes.draw do
   end
 
   # api admin
+  post 'users/sign_in', to: 'users/sessions#create'
   resources :api_namespaces, controller: 'comfy/admin/api_namespaces' do
+    member do
+      post 'duplicate_with_associations'
+      post 'duplicate_without_associations'
+    end
+
     resources :resources, controller: 'comfy/admin/api_resources'
     resources :api_clients, controller: 'comfy/admin/api_clients'
     resources :external_api_clients, controller: 'comfy/admin/external_api_clients' do


### PR DESCRIPTION
https://github.com/restarone/violet_rails/issues/622

# acceptance criteria: 

1. API namespaces are accessible 
2. API namespace is duplicable 
3. 2. API namespace is duplicable with associations