### PR TITLE
Fix for heroku and capistrano node version (#657)

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy to Heroku
+
+on:
+  push:
+    branches: [ master, rc, dev ]
+  pull_request:
+    branches: [ master, rc, dev ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "violetrails " #Must be unique in Heroku
+          heroku_email: "contact@restarone.com"
+        env:
+          APP_HOST: "violetrails.herokuapp.com"
+          REDIS_URL: ${{secrets.HEROKU_REDIS_URL}}
+          AWS_REGION: ${{secrets.HEROKU_AWS_REGION}}
+          AWS_ACCESS_KEY_ID: ${{secrets.HEROKU_AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.HEROKU_AWS_SECRET_ACCESS_KEY}}
+          AWS_BUCKET: ${{secrets.HEROKU_AWS_BUCKET}}
+          RECAPTCHA_SITE_KEY: ${{secrets.HEROKU_RECAPTCHA_SITE_KEY}}
+          RECAPTCHA_SECRET_KEY: ${{secrets.HEROKU_RECAPTCHA_SECRET_KEY}}

--- a/Gemfile
+++ b/Gemfile
@@ -102,5 +102,6 @@ gem "ember-cli-rails", "0.10.0"
 # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
 gem 'web-console', '>= 4.1.0'
 gem "exception_notification", "~> 4.5"
+gem 'rails_12factor', group: [:staging, :production]
 
 gem "turnout", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,11 @@ GEM
     rails-i18n (7.0.3)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (6.1.5)
       actionpack (= 6.1.5)
       activesupport (= 6.1.5)
@@ -522,6 +527,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.5)
   rails-controller-testing
+  rails_12factor
   ransack
   recaptcha
   ros-apartment

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: bundle exec rails db:migrate

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,6 @@ class User < ApplicationRecord
     can_manage_email: true,
     can_manage_users: true,
     can_manage_blog: true,
-    can_manage_api: true,
     can_manage_subdomain_settings: true,
     can_manage_api: true,
     can_view_restricted_pages: true,

--- a/package.json
+++ b/package.json
@@ -22,5 +22,10 @@
   "version": "0.1.0",
   "devDependencies": {
     "webpack-dev-server": "^3.11.2"
+  },
+  "cacheDirectories": ["client/node_modules","node_modules"],
+  "engines": {
+    "node": "14.19.x || 10.19.x",
+    "yarn": "1.22.x"
   }
 }


### PR DESCRIPTION
addresses: https://github.com/restarone/violet_rails/issues/385

# acceptance criteria

1. EC2 deployments using an older version of Node is still possible 
2. New Node is only used on Heroku