### PR TITLE
[bug fix] password reset link is broken in apex domain

### DIFF
--- a/app/views/users/mailer/reset_password_instructions.html.haml
+++ b/app/views/users/mailer/reset_password_instructions.html.haml
@@ -2,6 +2,6 @@
 %p
   = "Hello #{@resource.email}!"
 %p Someone has requested a link to change your password. You can do this through the link below.
-%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token, subdomain: Subdomain.current.name)
+%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token, subdomain: Apartment::Tenant.current)
 %p If you didn't request this, please ignore this email.
 %p Your password won't change until you access the link above and create a new one.

--- a/test/controllers/users/passwords_controller_test.rb
+++ b/test/controllers/users/passwords_controller_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class Users::PasswordsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @root_user = users(:public)
+    @root_subdomain = subdomains(:public)
+
+    @restarone_subdomain = Subdomain.find_by(name: 'restarone')
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user = User.find_by(email: 'contact@restarone.com')
+    end
+  end
+
+  test "should send email for resetting password of the user in apex domain" do
+    payload = {
+      user: { email: @root_user.email }
+    }
+
+    Apartment::Tenant.switch(@root_subdomain.name) do
+      assert_difference "Devise::Mailer.deliveries.size", +1 do
+        post user_password_url(subdomain: Apartment::Tenant.current), params: payload
+        assert_response :redirect
+      end
+
+      assert_match "<p><a href=\"http://#{@root_subdomain.name}.", Devise::Mailer.deliveries.last.body.to_s
+    end
+  end
+
+  test "should send email for resetting password of the user in subdomain" do
+    Apartment::Tenant.switch(@restarone_subdomain.name) do
+      payload = {
+        user: { email: @restarone_user.email }
+      }
+
+      assert_difference "Devise::Mailer.deliveries.size", +1 do
+        post user_password_url(subdomain: Apartment::Tenant.current), params: payload
+        assert_response :redirect
+      end
+
+      assert_match "<p><a href=\"http://#{@restarone_subdomain.name}.", Devise::Mailer.deliveries.last.body.to_s
+    end
+  end
+
+  test "should send email for resetting password of the user in apex domain using the current Apartment::Tenant instead of current Subdomain name" do
+    previous_name = @root_subdomain.name
+    @root_subdomain.update!(name: 'root')
+
+    Apartment::Tenant.switch(previous_name) do
+      payload = {
+        user: { email: @root_user.email }
+      }
+
+      assert_difference "Devise::Mailer.deliveries.size", +1 do
+        post user_password_url(subdomain: Apartment::Tenant.current), params: payload
+        assert_response :redirect
+      end
+
+      current_apartment_tenant_name = Apartment::Tenant.current
+      current_subdomain_name = @root_subdomain.name
+
+      # Subdomain in url should be 'public'
+      assert_match "<p><a href=\"http://#{current_apartment_tenant_name}.", Devise::Mailer.deliveries.last.body.to_s
+      # Subdomain in url should not be 'root'
+      assert_no_match "<p><a href=\"http://#{current_subdomain_name}.", Devise::Mailer.deliveries.last.body.to_s
+    end
+  end
+end


### PR DESCRIPTION
addresses: https://github.com/restarone/violet_rails/issues/643

# acceptance criteria

1. password reset workflow works as expected in subdomain (`foo.example.com`)
2. password reset works as expected in apex domain (`example.com`)