### PR TITLE
[feature] Ability to delete custom event and visits, [feature] add code editor to ExternalApiConnection

### DIFF
--- a/app/controllers/comfy/admin/dashboard_controller.rb
+++ b/app/controllers/comfy/admin/dashboard_controller.rb
@@ -28,6 +28,26 @@ class Comfy::Admin::DashboardController < Comfy::Admin::Cms::BaseController
     @events_list = @events_list_q.result.paginate(page: params[:page], per_page: 10)
   end
 
+  def destroy_event
+    response = Ahoy::Event.delete_specific_events_and_associated_visits(delete_events: true, event_type: params[:ahoy_event_type])
+
+    if response[:success]
+      redirect_to dashboard_events_list_path, notice: response[:message]
+    else
+      redirect_to dashboard_events_list_path, alert: "Deleting specific events failed due to: #{response[:message]}"
+    end
+  end
+
+  def destroy_visits
+    response = Ahoy::Event.delete_specific_events_and_associated_visits(delete_events: false, event_type: params[:ahoy_event_type])
+
+    if response[:success]
+      redirect_to dashboard_events_list_path, notice: response[:message]
+    else
+      redirect_to dashboard_events_list_path, alert: "Deleting associated visits of specific events failed due to: #{response[:message]}"
+    end
+  end
+
   private
 
   def set_visit

--- a/app/views/comfy/admin/dashboard/events_detail.haml
+++ b/app/views/comfy/admin/dashboard/events_detail.haml
@@ -1,8 +1,11 @@
 = javascript_include_tag "//www.google.com/jsapi"
 .page-header
-  .h3
-    Event Type:
-    %strong #{params[:ahoy_event_type]}
+  .d-flex.my-2.justify-content-between.align-items-center
+    .h3
+      Event Type:
+      %strong #{params[:ahoy_event_type]}
+    - unless Ahoy::Event::SYSTEM_EVENTS.keys.include?(params[:ahoy_event_type])
+      = link_to 'Delete', dashboard_destroy_event_path(ahoy_event_type: params[:ahoy_event_type]), method: :delete, data: { confirm: 'This will delete all such events and its associated visits data. Are you sure you?' }, class: 'btn btn-sm btn-danger'
 
 %main{class: 'm-5'}
   = render partial: 'events_search_filters'
@@ -48,6 +51,8 @@
           %p By referring domain
           = pie_chart @events.where.not('ahoy_visits.referring_domain': nil).group('ahoy_visits.referring_domain').count, width: "300px", height: "300px", label: "events"
 
+  - unless Ahoy::Event::SYSTEM_EVENTS.keys.include?(params[:ahoy_event_type])
+    = link_to 'Delete all associated visits', dashboard_destroy_visits_path(ahoy_event_type: params[:ahoy_event_type]), method: :delete, data: { confirm: 'This will delete all associated visits. Are you sure?' }, class: 'btn btn-sm btn-danger my-2'
   = render partial: 'comfy/admin/dashboard/pagination', locals: { data: @event_visits }
   .table-responsive
     %table.table.table-bordered

--- a/app/views/comfy/admin/external_api_clients/_form.html.haml
+++ b/app/views/comfy/admin/external_api_clients/_form.html.haml
@@ -32,9 +32,9 @@
     = f.label :max_retries
     = f.number_field :max_retries
 
-  .field
+  .field.mb-3
     = f.label :model_definition
-    = f.text_area :model_definition
+    = f.text_area :model_definition, data: {'cms-cm-mode' => 'javascript'}
 
   #jsoneditor
   = hidden_field_tag "external_api_client[metadata]", @external_api_client.metadata&.to_json 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -133,7 +133,13 @@ end
 
 # exception notifier
 Rails.application.config.middleware.use ExceptionNotification::Rack,
-  ignore_exceptions: ['ActionController::ParameterMissing', 'ActionController::RoutingError'],
+  ignore_exceptions: [
+    'ActionController::ParameterMissing', 
+    'ActionController::RoutingError',
+    'ActionController::InvalidAuthenticityToken',
+    'ActionDispatch::Http::MimeNegotiation::InvalidType',
+    'ActiveRecord::RecordNotFound',
+  ],
   violet_rails_error: {
     app: {
       host: ENV["APP_HOST"]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -137,7 +137,13 @@ end
 
 # exception notifier
 Rails.application.config.middleware.use ExceptionNotification::Rack,
-  ignore_exceptions: ['ActionController::ParameterMissing', 'ActionController::RoutingError'],
+  ignore_exceptions: [
+    'ActionController::ParameterMissing', 
+    'ActionController::RoutingError',
+    'ActionController::InvalidAuthenticityToken',
+    'ActionDispatch::Http::MimeNegotiation::InvalidType',
+    'ActiveRecord::RecordNotFound',
+  ],
   violet_rails_error: {
     app: {
       host: ENV["APP_HOST"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get 'dashboard/sessions/:ahoy_visit_id', to: 'comfy/admin/dashboard#visit', as: :dashboard_visits
   get 'dashboard/events/:ahoy_event_type', to: 'comfy/admin/dashboard#events_detail', as: :dashboard_events
   get 'dashboard/events_list', to: 'comfy/admin/dashboard#events_list', as: :dashboard_events_list
+  delete 'dashboard/events/:ahoy_event_type/destroy_event', to: 'comfy/admin/dashboard#destroy_event', as: :dashboard_destroy_event
+  delete 'dashboard/events/:ahoy_event_type/destroy_visits', to: 'comfy/admin/dashboard#destroy_visits', as: :dashboard_destroy_visits
 
   resources :signup_wizard
   resources :signin_wizard

--- a/test/controllers/admin/comfy/dashboard_controller_test.rb
+++ b/test/controllers/admin/comfy/dashboard_controller_test.rb
@@ -77,4 +77,167 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     get dashboard_events_list_url
     assert_response :success
   end
+
+  test "should deny #destroy_event if not permissioned" do
+    @subdomain.update!(tracking_enabled: true)
+    event = Ahoy::Visit.first.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    @user.update(can_manage_analytics: false)
+    sign_in(@user)
+
+    delete dashboard_destroy_event_url(ahoy_event_type: event.name)
+
+    assert_response :redirect
+
+    expected_message = "You do not have the permission to do that. Only users who can_manage_analytics are allowed to perform that action."
+    assert_equal expected_message, request.flash[:alert]
+  end
+
+  test "should sucessfully #destroy_event if signed in and permissioned" do
+    @subdomain.update!(tracking_enabled: true)
+    event = Ahoy::Visit.first.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    @user.update(can_manage_analytics: true)
+    sign_in(@user)
+
+    delete dashboard_destroy_event_url(ahoy_event_type: event.name)
+
+    assert_response :redirect
+
+    expected_message = "All test events and its associated visits has been deleted successfully."
+    assert_equal expected_message, request.flash[:notice]
+  end
+
+  test "#destroy_event should give error if system-event is provided" do
+    @subdomain.update!(tracking_enabled: true)
+    event = Ahoy::Visit.first.events.create(name: Ahoy::Event::SYSTEM_EVENTS.keys.first, user_id: @user.id, time: Time.zone.now)
+
+    @user.update(can_manage_analytics: true)
+    sign_in(@user)
+
+    delete dashboard_destroy_event_url(ahoy_event_type: event.name)
+
+    assert_response :redirect
+
+    expected_message = "System defined events and their visits cannot be deleted."
+    assert_match expected_message, request.flash[:alert]
+  end
+
+  test "#destroy_event should delete only the specified event-type and its associated visits" do
+    @subdomain.update!(tracking_enabled: true)
+    visit = Ahoy::Visit.first
+    event = visit.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    visit_1 = visit.dup
+    visit_1.save!
+    event_1 = visit_1.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    visit_2 = visit.dup
+    visit_2.save!
+    event_2 = visit_2.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    visit_3 = visit.dup
+    visit_3.save!
+    event_3 = visit_3.events.create(name: 'test-2', user_id: @user.id, time: Time.zone.now)
+
+    @user.update(can_manage_analytics: true)
+    sign_in(@user)
+
+    delete dashboard_destroy_event_url(ahoy_event_type: event.name)
+
+    assert_response :redirect
+
+    expected_message = "All test events and its associated visits has been deleted successfully."
+    assert_equal expected_message, request.flash[:notice]
+
+    # Specified Events and Associated Visits are only deleted
+    assert_equal 0, Ahoy::Event.where(name: 'test').size
+    assert_equal 0, Ahoy::Visit.where(id: [visit.id, visit_1.id, visit_2.id]).size
+
+    # Other are untouched
+    assert_equal 1, Ahoy::Event.where(name: event_3.name).size
+    assert_equal 1, Ahoy::Visit.where(id: [visit_3.id]).size
+  end
+
+  test "should deny #dashboard_destroy_visits if not permissioned" do
+    @subdomain.update!(tracking_enabled: true)
+    event = Ahoy::Visit.first.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    @user.update(can_manage_analytics: false)
+    sign_in(@user)
+
+    delete dashboard_destroy_visits_url(ahoy_event_type: event.name)
+
+    assert_response :redirect
+
+    expected_message = "You do not have the permission to do that. Only users who can_manage_analytics are allowed to perform that action."
+    assert_equal expected_message, request.flash[:alert]
+  end
+
+  test "should sucessfully #dashboard_destroy_visits if signed in and permissioned" do
+    @subdomain.update!(tracking_enabled: true)
+    event = Ahoy::Visit.first.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    @user.update(can_manage_analytics: true)
+    sign_in(@user)
+
+    delete dashboard_destroy_visits_url(ahoy_event_type: event.name)
+
+    assert_response :redirect
+
+    expected_message = "All associated visits of test events has been deleted successfully."
+    assert_equal expected_message, request.flash[:notice]
+  end
+
+
+  test "#dashboard_destroy_visits should give error if system-event is provided" do
+    @subdomain.update!(tracking_enabled: true)
+    event = Ahoy::Visit.first.events.create(name: Ahoy::Event::SYSTEM_EVENTS.keys.first, user_id: @user.id, time: Time.zone.now)
+
+    @user.update(can_manage_analytics: true)
+    sign_in(@user)
+
+    delete dashboard_destroy_visits_url(ahoy_event_type: event.name)
+
+    assert_response :redirect
+
+    expected_message = "System defined events and their visits cannot be deleted."
+    assert_match expected_message, request.flash[:alert]
+  end
+
+  test "#dashboard_destroy_visits should delete only the specified event-type and its associated visits" do
+    @subdomain.update!(tracking_enabled: true)
+    visit = Ahoy::Visit.first
+    event = visit.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    visit_1 = visit.dup
+    visit_1.save!
+    event_1 = visit_1.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    visit_2 = visit.dup
+    visit_2.save!
+    event_2 = visit_2.events.create(name: 'test', user_id: @user.id, time: Time.zone.now)
+
+    visit_3 = visit.dup
+    visit_3.save!
+    event_3 = visit_3.events.create(name: 'test-2', user_id: @user.id, time: Time.zone.now)
+
+    @user.update(can_manage_analytics: true)
+    sign_in(@user)
+
+    delete dashboard_destroy_visits_url(ahoy_event_type: event.name)
+
+    assert_response :redirect
+
+    expected_message = "All associated visits of test events has been deleted successfully."
+    assert_equal expected_message, request.flash[:notice]
+
+    # Associated Visits are only deleted
+    assert_equal 3, Ahoy::Event.where(name: 'test').size
+    assert_equal 0, Ahoy::Visit.where(id: [visit.id, visit_1.id, visit_2.id]).size
+    
+    # Other are untouched
+    assert_equal 1, Ahoy::Event.where(name: event_3.name).size
+    assert_equal 1, Ahoy::Visit.where(id: [visit_3.id]).size
+  end
 end


### PR DESCRIPTION
# [feature] Ability to delete custom event and visits
<img width="860" alt="Screen Shot 2022-06-07 at 5 47 38 PM" src="https://user-images.githubusercontent.com/35935196/172488648-56214aed-ade6-4c58-9a9d-e60dc1d93670.png">
addresses: https://github.com/restarone/violet_rails/issues/651

<img width="866" alt="Screen Shot 2022-06-07 at 5 47 48 PM" src="https://user-images.githubusercontent.com/35935196/172488657-db1f6485-aec8-4909-a658-e7d5e623aa73.png">



## acceptance criteria

1. able delete visits for a given event
2. able to delete event and visits
3. does not delete visits of a event 

#  [feature] add code editor to ExternalApiConnection
<img width="864" alt="Screen Shot 2022-06-07 at 5 47 23 PM" src="https://user-images.githubusercontent.com/35935196/172488714-7ba0dfbd-7a41-4c84-bc79-5755d5ccd7f1.png">

## acceptance criteria

1. does not mutate/corrupt existing data when the form is rendered and submitted with no changes
2. renders existing data correctly

# [tune up] limit error reporting

ideally we should allow each system admin to choose their preferred verbosity in the error reporting service. But for now, most of the systems we are responsible for are too loud in raising the following errors:  
``` ruby
    'ActionController::ParameterMissing', 
     'ActionController::RoutingError',
     'ActionController::InvalidAuthenticityToken',
     'ActionDispatch::Http::MimeNegotiation::InvalidType',
     'ActiveRecord::RecordNotFound',
```
due to crawlers and bots. To ensure that we don't miss actual issues (eg: https://github.com/restarone/violet_rails/issues/578) we should limit the amount of false-positives that are reported to our bug triaging teams