### PR TITLE
tune error reporting again to prevent getting spammed by bots

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -133,7 +133,13 @@ end
 
 # exception notifier
 Rails.application.config.middleware.use ExceptionNotification::Rack,
-  ignore_exceptions: ['ActionController::ParameterMissing', 'ActionController::RoutingError'],
+  ignore_exceptions: [
+    'ActionController::ParameterMissing', 
+    'ActionController::RoutingError',
+    'ActionController::InvalidAuthenticityToken',
+    'ActionDispatch::Http::MimeNegotiation::InvalidType',
+    'ActiveRecord::RecordNotFound',
+  ],
   violet_rails_error: {
     app: {
       host: ENV["APP_HOST"]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -137,7 +137,13 @@ end
 
 # exception notifier
 Rails.application.config.middleware.use ExceptionNotification::Rack,
-  ignore_exceptions: ['ActionController::ParameterMissing', 'ActionController::RoutingError'],
+  ignore_exceptions: [
+    'ActionController::ParameterMissing', 
+    'ActionController::RoutingError',
+    'ActionController::InvalidAuthenticityToken',
+    'ActionDispatch::Http::MimeNegotiation::InvalidType',
+    'ActiveRecord::RecordNotFound',
+  ],
   violet_rails_error: {
     app: {
       host: ENV["APP_HOST"]


### PR DESCRIPTION
ideally we should allow each system admin to choose their preferred verbosity in the error reporting service. But for now, most of the systems we are responsible for are too loud in raising the following errors:  
``` ruby
    'ActionController::ParameterMissing', 
     'ActionController::RoutingError',
     'ActionController::InvalidAuthenticityToken',
     'ActionDispatch::Http::MimeNegotiation::InvalidType',
     'ActiveRecord::RecordNotFound',
```
due to crawlers and bots. To ensure that we don't miss actual issues (eg: https://github.com/restarone/violet_rails/issues/578) we should limit the amount of false-positives that are reported to our bug triaging teams