### PR TITLE
remove 12 factor gem to allow logging to disk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,6 @@ gem "ember-cli-rails", "0.10.0"
 # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
 gem 'web-console', '>= 4.1.0'
 gem "exception_notification", "~> 4.5"
-gem 'rails_12factor', group: [:staging, :production]
+
 
 gem "turnout", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,11 +343,6 @@ GEM
     rails-i18n (7.0.3)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.1.5)
       actionpack (= 6.1.5)
       activesupport (= 6.1.5)
@@ -527,7 +522,6 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.5)
   rails-controller-testing
-  rails_12factor
   ransack
   recaptcha
   ros-apartment


### PR DESCRIPTION
addresses: https://github.com/restarone/violet_rails/issues/669

remove 12 factor gem, we have to make sure that we can still deploy to heroku without it-- the reason for removal is that it treats logs as event streams (we dont have an out-of-the-box solution for logging to stdout) and some clients need to write logs to disk