### PR TITLE
fix data discovery issue in rake tasks (public schema is not being read)

### DIFF
--- a/lib/tasks/external_api_client.rake
+++ b/lib/tasks/external_api_client.rake
@@ -2,7 +2,7 @@ namespace :external_api_client do
   desc "tasks for connecting to external systems (anything backed by ExternalApiClient"
   
   task :drive_cron_jobs => [:environment] do |t, args|
-    Subdomain.all.each do |subdomain|
+    Subdomain.all.to_a.push(Subdomain.new(name: 'public')).each do |subdomain|
       Apartment::Tenant.switch subdomain.name do
         external_api_clients = ExternalApiClient.cron_jobs
         p "**running #{external_api_clients.size} ExternalApiClient cron jobs for #{subdomain.name}** @ #{Time.now}"


### PR DESCRIPTION
we push in a newly initialized subdomain named public so we can switch to it in the context block