### PR TITLE
[feature] sanitize method/model definitions coming into Violet Rails of things like: Subdomain, Apartment, Tenant, switch, SomeModel.destroy_all, SomeModel.update_all, global_admin, can_manage_users

### DIFF
--- a/app/models/api_action.rb
+++ b/app/models/api_action.rb
@@ -19,6 +19,8 @@ class ApiAction < ApplicationRecord
   has_rich_text :custom_message
 
   validates :http_method, inclusion: { in: ApiAction::HTTP_METHODS}, allow_blank: true
+  
+  validates :payload_mapping, safe_executable: true
 
   def self.children
     ['new_api_actions', 'create_api_actions', 'show_api_actions', 'update_api_actions', 'destroy_api_actions', 'error_api_actions']

--- a/app/models/concerns/safe_executable_validator.rb
+++ b/app/models/concerns/safe_executable_validator.rb
@@ -1,0 +1,34 @@
+class SafeExecutableValidator < ActiveModel::EachValidator
+    # https://docs.guardrails.io/docs/vulnerabilities/ruby/insecure_use_of_dangerous_function
+    BLACKLISTED_KEYWORDS = [
+        'exit',
+        'exec',
+        'syscall',
+        'system',
+        'eval',
+        'render',
+        'call',
+        'send',
+        'constantize',
+        'update_all',
+        'destroy_all',
+        'switch',
+        'can_manage_users',
+        'global_admin',
+        'Subdomain',
+        'Tenant',
+        'Apartment',
+    ] + User::PRIVATE_ATTRIBUTES.map(&:to_s)
+
+    # BLACKLISTED_KEYWORDS are usually attached to one of these delimiters
+    # eg: exit(), .constantize, Subdomain.destroy_all, can_manage_users:
+    SPLIT_DELIMITERS = ['(', ')', /\s/, '.', /\n/, ':']
+
+    def validate_each(record,attribute,value)
+        keywords = value.to_s.split(Regexp.union(SPLIT_DELIMITERS)).reject(&:blank?)
+        blacklisted_keywords_in_attribute = keywords & BLACKLISTED_KEYWORDS
+        unless blacklisted_keywords_in_attribute.empty?
+            record.errors.add(attribute, "contains blacklisted keyword: #{blacklisted_keywords_in_attribute.to_s}. Please refactor #{attribute} accordingly")
+        end
+    end
+end

--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -41,6 +41,7 @@ class ExternalApiClient < ApplicationRecord
   validates :drive_every, presence: true, if: -> { drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:cron] }
 
   validates :drive_every, inclusion: { in: ExternalApiClient::DRIVE_INTERVALS.keys.map(&:to_s) }, allow_blank: true, allow_nil: true
+  validates :model_definition, safe_executable: true
 
   def self.cron_jobs
     intervals = ExternalApiClient.pluck(:drive_every).compact

--- a/test/fixtures/external_api_clients.yml
+++ b/test/fixtures/external_api_clients.yml
@@ -125,7 +125,7 @@ modmed:
       end
 
       def get_patient_documents(patient_id)
-        # search documents in postman looks the same as this call but with an additional query parameter (_count)
+        # search documents in postman looks the same as this #call but with an additional query parameter (_count)
         endpoint = "#{@base_url}/#{@clinic_id}/ema/fhir/v2/DocumentReference?patient=#{patient_id}"
         response = HTTParty.get(endpoint, headers: @headers).body
         return JSON.parse(response).deep_symbolize_keys


### PR DESCRIPTION
addresses: https://github.com/restarone/violet_rails/issues/570

# acceptance criteria:

1. after deployment existing model definitions for ExternalAPIClient are not broken
2. user cannot perform dynamic programming in model definitions
3. user cannot escalate privileges in model definition
4. user cannot access other subdomains in model definition