### PR TITLE
Dynamic attributes with access to api_resource (#708)

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -130,7 +130,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
-      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email,:custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
+      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email, :email_subject, :custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,
@@ -155,6 +155,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
     end
 
     def handle_error_redirect
+      flash[:error] = @api_namespace.errors.full_messages
       redirect_to action_workflow_api_namespace_api_actions_path(api_namespace_id: @api_namespace.id) and return  if params[:source] == 'action_workflow'
 
       render :edit, status: :unprocessable_entity

--- a/app/mailers/api_action_mailer.rb
+++ b/app/mailers/api_action_mailer.rb
@@ -8,7 +8,7 @@ class ApiActionMailer < ApplicationMailer
       @api_resource = api_action.api_resource
       mail(
         to: mail_to,
-        subject: "#{api_action.type} #{@api_resource.api_namespace.name.pluralize} v#{@api_resource.api_namespace.version}"
+        subject: api_action.email_subject_evaluated
       )
     end
 end

--- a/app/models/api_action.rb
+++ b/app/models/api_action.rb
@@ -1,7 +1,10 @@
 class ApiAction < ApplicationRecord
   include Encryptable
   include JsonbFieldsParsable
+  include DynamicAttribute
+
   attr_encrypted :bearer_token
+  attr_dynamic :email_subject, :custom_message, :payload_mapping, :request_url
 
   belongs_to :api_namespace, optional: true
   belongs_to :api_resource, optional: true
@@ -43,8 +46,8 @@ class ApiAction < ApplicationRecord
 
   def send_web_request
     begin
-      response = HTTParty.send(http_method.to_s, request_url, 
-                    { body: evaluate_payload, headers: request_headers })
+      response = HTTParty.send(http_method.to_s, request_url_evaluated, 
+                    { body: payload_mapping_evaluated, headers: request_headers })
       if response.success?
         self.update(lifecycle_stage: 'complete', lifecycle_message: response.to_s)
       else
@@ -60,11 +63,6 @@ class ApiAction < ApplicationRecord
   def redirect;end
 
   def serve_file;end
-
-  def evaluate_payload
-    payload = payload_mapping.to_json.gsub('self.', 'self.api_resource.properties_object.')
-    eval(payload).to_json
-  end
 
   def request_headers
     headers = custom_headers.to_json.gsub('SECRET_BEARER_TOKEN', bearer_token)

--- a/app/models/concerns/dynamic_attribute.rb
+++ b/app/models/concerns/dynamic_attribute.rb
@@ -1,0 +1,43 @@
+# evaluate dynamic columns
+# adding attribute defined by attr_dynamic parameters
+# method attributed will be created as <coulmn_name>_evaluated
+# example attr_dynamic :custom_message will add a method custom_message_evaluated
+# column content example: Hi my name is #{api_resource.properties["first_name"]}
+
+module DynamicAttribute
+    extend ActiveSupport::Concern
+
+    included do
+      def parse_dynamic_attribute(value)
+        return unless value.present?
+
+        raise ActiveRecord::RecordInvalid.new(self) unless self.valid?
+
+        parsed_text = value
+        # couldn't gsub directly because of escape characters added by ruby
+        # eval failed on "\#{api_resource.properties[\"String\"]}"
+        value.scan(/\#\{(.*?)\}/).each do |code|
+          parsed_text = parsed_text.sub!("\#{#{code[0]}}", eval(code[0]).to_s)
+        end
+        parsed_text.html_safe
+      end
+
+      def attribute_value_string(attribute)
+        value = public_send(attribute.to_sym)
+        value.is_a?(Enumerable) ? value.to_json : value.to_s
+      end
+    end
+  
+    class_methods do
+      def attr_dynamic(*attributes) # rubocop:disable Metrics/AbcSize
+        attributes.each do |attribute|
+          # all dynamic attributes should be safe
+          validates attribute.to_sym, safe_executable: true
+
+          define_method("#{attribute}_evaluated") do
+            parse_dynamic_attribute(attribute_value_string(attribute))
+          end
+        end
+      end
+    end
+  end

--- a/app/models/concerns/safe_executable_validator.rb
+++ b/app/models/concerns/safe_executable_validator.rb
@@ -1,0 +1,33 @@
+class SafeExecutableValidator < ActiveModel::EachValidator
+    # https://docs.guardrails.io/docs/vulnerabilities/ruby/insecure_use_of_dangerous_function
+    BLACKLISTED_KEYWORDS = [
+        'exit',
+        'exec',
+        'syscall',
+        'system',
+        'eval',
+        'render',
+        'call',
+        'send',
+        'constantize',
+        'update_all',
+        'destroy_all',
+        'switch',
+        'global_admin',
+        'Subdomain',
+        'Tenant',
+        'Apartment',
+    ] + User::PRIVATE_ATTRIBUTES.map(&:to_s) + User::FULL_PERMISSIONS.keys.map(&:to_s)
+     
+    # BLACKLISTED_KEYWORDS are usually attached to one of these delimiters
+    # eg: exit(), .constantize, Subdomain.destroy_all, can_manage_users:
+    SPLIT_DELIMITERS = ['(', ')', /\s/, '.', /\n/, ':', '#{', '}', '=>', '"', '\'']
+
+    def validate_each(record,attribute,value)
+        keywords = value.to_s.split(Regexp.union(SPLIT_DELIMITERS)).reject(&:blank?)
+        blacklisted_keywords_in_attribute = keywords & BLACKLISTED_KEYWORDS
+        unless blacklisted_keywords_in_attribute.empty?
+            record.errors.add(attribute, "contains blacklisted keyword: #{blacklisted_keywords_in_attribute.to_s}. Please refactor #{attribute} accordingly")
+        end
+    end
+end

--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -41,6 +41,7 @@ class ExternalApiClient < ApplicationRecord
   validates :drive_every, presence: true, if: -> { drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:cron] }
 
   validates :drive_every, inclusion: { in: ExternalApiClient::DRIVE_INTERVALS.keys.map(&:to_s) }, allow_blank: true, allow_nil: true
+  validates :model_definition, safe_executable: true
 
   def self.cron_jobs
     intervals = ExternalApiClient.pluck(:drive_every).compact

--- a/app/views/api_action_mailer/send_email.html.erb
+++ b/app/views/api_action_mailer/send_email.html.erb
@@ -4,7 +4,7 @@
   </head>
   <body>
     <main>
-      <p><%= render html: @api_action.custom_message.to_s.html_safe %></p>
+      <p><%= render html: @api_action.custom_message_evaluated.to_s.html_safe %></p>
       <% if @api_action.include_api_resource_data && @api_resource %>
         <p>
             <b>Api namespace:</b>

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -14,6 +14,9 @@
         = label_tag 'Email Address'
         = text_field_tag "api_namespace[#{type}_attributes][#{index}][email]", resource.email, { class: "form-control form-control-sm" }
       .form-group
+        = label_tag 'Subject'
+        =  text_field_tag "api_namespace[#{type}_attributes][#{index}][email_subject]", resource.email_subject, { class: "form-control form-control-sm" }
+      .form-group
         = label_tag 'Custom Message'
         = rich_text_area_tag "api_namespace[#{type}_attributes][#{index}][custom_message]", resource.custom_message, { class: "form-control form-control-sm" }
 

--- a/db/migrate/20220609092515_add_email_subject_to_api_actions.rb
+++ b/db/migrate/20220609092515_add_email_subject_to_api_actions.rb
@@ -1,0 +1,5 @@
+class AddEmailSubjectToApiActions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_actions, :email_subject, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_06_015014) do
+ActiveRecord::Schema.define(version: 2022_06_09_092515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2022_06_06_015014) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "custom_headers"
     t.string "http_method"
+    t.text "email_subject"
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end

--- a/test/fixtures/external_api_clients.yml
+++ b/test/fixtures/external_api_clients.yml
@@ -125,7 +125,7 @@ modmed:
       end
 
       def get_patient_documents(patient_id)
-        # search documents in postman looks the same as this call but with an additional query parameter (_count)
+        # search documents in postman looks the same as this #call but with an additional query parameter (_count)
         endpoint = "#{@base_url}/#{@clinic_id}/ema/fhir/v2/DocumentReference?patient=#{patient_id}"
         response = HTTParty.get(endpoint, headers: @headers).body
         return JSON.parse(response).deep_symbolize_keys

--- a/test/models/api_action_test.rb
+++ b/test/models/api_action_test.rb
@@ -18,4 +18,53 @@ class ApiActionTest < ActiveSupport::TestCase
     assert_equal api_action.reload.lifecycle_stage, 'failed'
     assert_equal api_action.reload.lifecycle_message, 'error response'
   end
+
+  test 'should respond to dynamically generated method' do
+    api_resource = api_resources(:one)
+
+    expected_response = {
+      email_subject: "API Resource Accessed #{api_resource.id}",
+      custom_message: "<div class=\"trix-content\">\n  API Namespace Accessed #{api_resource.api_namespace.id}\n</div>\n",
+      request_url: "API Resource Property Accessed  #{api_resource.properties['can_edit']}",
+      payload_mapping: {
+        test_key: "#{api_resource.id}"
+  }.to_json
+    }
+
+    api_action = ApiAction.new(
+      api_resource_id: api_resource.id,
+      email_subject: "API Resource Accessed \#{api_resource.id}",
+      custom_message: "API Namespace Accessed \#{api_resource.api_namespace.id}",
+      request_url: "API Resource Property Accessed  \#{api_resource.properties['can_edit']}",
+      payload_mapping: {
+        test_key: "\#{api_resource.id}"
+      }
+    )
+    assert api_action.valid?
+    [:email_subject, :custom_message, :request_url, :payload_mapping].each do |dynamic_attr|
+      assert_respond_to api_action, "#{dynamic_attr}_evaluated".to_sym
+      assert_equal api_action.send("#{dynamic_attr}_evaluated".to_sym), expected_response[dynamic_attr]
+    end
+  end
+
+  test 'should raise error if unsafe string is evaluted' do
+    api_resource = api_resources(:one)
+
+    api_action = ApiAction.new(
+      api_resource_id: api_resource.id,
+      email_subject: "API Resource Accessed \#{api_resource.id}",
+      custom_message: "API Namespace Accessed \#{api_resource.api_namespace.id}",
+      request_url: "API Resource Property Accessed  \#{api_resource.properties['can_edit']}",
+      payload_mapping: {
+        test_key: "\#{User.destroy_all}"
+      }
+    )
+    refute api_action.valid?
+
+    [:email_subject, :custom_message, :request_url, :payload_mapping].each do |dynamic_attr|
+      assert_raises ActiveRecord::RecordInvalid do
+        api_action.send("#{dynamic_attr}_evaluated".to_sym)
+      end
+    end
+  end
 end

--- a/test/models/concerns/dynamic_attribute_test.rb
+++ b/test/models/concerns/dynamic_attribute_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class DynamicAttributeTest < ActiveSupport::TestCase
+  setup do
+    # test concern in isolation
+    @dummy_class = Class.new do
+      include ActiveModel::Model
+
+      def self.name
+        'Test'
+      end
+
+      def initialize(test_column: nil)
+          @test_column = test_column
+      end
+
+      include ActiveModel::Validations
+      include DynamicAttribute
+      attr_accessor :test_column
+      attr_accessor :api_resource
+
+      attr_dynamic :test_column
+    end
+  end  
+
+  test 'should respond to dynamic methods if dynamic field is safe' do
+    safe_instance = @dummy_class.new(test_column: "Test \#{1 + 1}")
+    assert safe_instance.valid?
+    assert_respond_to safe_instance, :test_column_evaluated
+    assert_equal safe_instance.test_column_evaluated, 'Test 2'
+  end
+
+
+  test 'should raise invalid record error dynamic field contains unsafe string' do
+    unsafe_instance = @dummy_class.new(test_column: "Test \#{User.destroy_all}")
+    refute unsafe_instance.valid?
+    assert_no_difference "User.all.size" do
+      assert_raises ActiveRecord::RecordInvalid do
+        unsafe_instance.test_column_evaluated
+      end
+    end
+  end
+end

--- a/test/models/external_api_client_test.rb
+++ b/test/models/external_api_client_test.rb
@@ -87,4 +87,43 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     discovered_jobs = ExternalApiClient.cron_jobs
     assert discovered_jobs.size == 0
   end
+
+  test 'should be invalid if blacklisted keywords are present' do
+    api_namespace = api_namespaces(:one)
+    invalid_model_definations = [
+      'Subdomain.destroy_all',
+      'exit()',
+      'subdomain.constantize.last.update(id: 1)',
+      'eval("1 + 1")',
+      'User.last.update(can_manage_users: true)',
+      'User.send(:new)',
+      '#{User.destroy_all}'
+    ]
+
+    invalid_model_definations.each do |invalid_executable|
+      external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: invalid_executable)
+      refute external_api_client.valid?
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+    end
+  end
+
+  test 'should be invalid if users private attributes are accessed' do
+    api_namespace = api_namespaces(:one)
+
+    User::PRIVATE_ATTRIBUTES.each do |private_attr|
+      external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: "User.last.#{private_attr}")
+      refute external_api_client.valid?
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+    end
+  end
+
+  test 'should be invalid if users permissions are referenced' do
+    api_namespace = api_namespaces(:one)
+
+    User::FULL_PERMISSIONS.keys.each do |permission_attr|
+      external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: "User.last.update(#{permission_attr} => false)")
+      refute external_api_client.valid?
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+    end
+  end
 end


### PR DESCRIPTION
* add subject to api action

* [feature] sanitize method/model definitions coming into Violet Rails of things like: Subdomain, Apartment, Tenant, switch, SomeModel.destroy_all, SomeModel.update_all, global_admin, can_manage_users

addresses: https://github.com/restarone/violet_rails/issues/570

# acceptance criteria:

1. after deployment existing model definitions for ExternalAPIClient are not broken
2. user cannot perform dynamic programming in model definitions
3. user cannot escalate privileges in model definition
4. user cannot access other subdomains in model definition

* fix(): make categories for remote

* sanitize executable strings before save

* add specs

* revert changes

* fix test

* fix test case

Co-authored-by: Shashike Jayatunge <35935196+donrestarone@users.noreply.github.com>

* concern to evaluate dynamic strings

* Sanitize executable (#706)

* fix(): make categories for remote

* sanitize executable strings before save

* add specs

* revert changes

* fix test

* fix test case

* handle unsafe cases

Co-authored-by: Shashike Jayatunge <35935196+donrestarone@users.noreply.github.com>

* dynamic attributes should be safe

* Sanitize executable (#707)

* fix(): make categories for remote

* sanitize executable strings before save

* add specs

* revert changes

* fix test

* fix test case

* handle unsafe cases

* do not allow users permissions to be referenced

Co-authored-by: Shashike Jayatunge <35935196+donrestarone@users.noreply.github.com>

* test dynmaic attr

* render evaluated string

Co-authored-by: Shashike Jayatunge <35935196+donrestarone@users.noreply.github.com>