### PR TITLE
[feature] add subject to send_email API action, make subject / body dynamic, expose API entities in context, [feature] add dynamic string to HTTP action request URL

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -130,7 +130,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
-      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email,:custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
+      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email, :email_subject, :custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,

--- a/app/mailers/api_action_mailer.rb
+++ b/app/mailers/api_action_mailer.rb
@@ -8,7 +8,7 @@ class ApiActionMailer < ApplicationMailer
       @api_resource = api_action.api_resource
       mail(
         to: mail_to,
-        subject: "#{api_action.type} #{@api_resource.api_namespace.name.pluralize} v#{@api_resource.api_namespace.version}"
+        subject: api_action.email_subject_evaluated
       )
     end
 end

--- a/app/models/concerns/dynamic_attribute.rb
+++ b/app/models/concerns/dynamic_attribute.rb
@@ -1,0 +1,43 @@
+# evaluate dynamic columns
+# adding attribute defined by attr_dynamic parameters
+# method attributed will be created as <coulmn_name>_evaluated
+# example attr_dynamic :custom_message will add a method custom_message_evaluated
+# column content example: Hi my name is #{api_resource.properties["first_name"]}
+
+module DynamicAttribute
+    extend ActiveSupport::Concern
+
+    included do
+      def parse_dynamic_attribute(value)
+        return unless value.present?
+
+        raise ActiveRecord::RecordInvalid.new(self) unless self.valid?
+
+        parsed_text = value
+        # couldn't gsub directly because of escape characters added by ruby
+        # eval failed on "\#{api_resource.properties[\"String\"]}"
+        value.scan(/\#\{(.*?)\}/).each do |code|
+          parsed_text = parsed_text.sub!("\#{#{code[0]}}", eval(code[0]).to_s)
+        end
+        parsed_text.html_safe
+      end
+
+      def attribute_value_string(attribute)
+        value = public_send(attribute.to_sym)
+        value.is_a?(Enumerable) ? value.to_json : value.to_s
+      end
+    end
+  
+    class_methods do
+      def attr_dynamic(*attributes) # rubocop:disable Metrics/AbcSize
+        attributes.each do |attribute|
+          # all dynamic attributes should be safe
+          validates attribute.to_sym, safe_executable: true
+
+          define_method("#{attribute}_evaluated") do
+            parse_dynamic_attribute(attribute_value_string(attribute))
+          end
+        end
+      end
+    end
+  end

--- a/app/models/concerns/safe_executable_validator.rb
+++ b/app/models/concerns/safe_executable_validator.rb
@@ -13,14 +13,12 @@ class SafeExecutableValidator < ActiveModel::EachValidator
         'update_all',
         'destroy_all',
         'switch',
-        'can_manage_users',
         'global_admin',
         'Subdomain',
         'Tenant',
         'Apartment',
     ] + User::PRIVATE_ATTRIBUTES.map(&:to_s) + User::FULL_PERMISSIONS.keys.map(&:to_s)
      
-
     # BLACKLISTED_KEYWORDS are usually attached to one of these delimiters
     # eg: exit(), .constantize, Subdomain.destroy_all, can_manage_users:
     SPLIT_DELIMITERS = ['(', ')', /\s/, '.', /\n/, ':', '#{', '}', '=>', '"', '\'']
@@ -29,7 +27,7 @@ class SafeExecutableValidator < ActiveModel::EachValidator
         keywords = value.to_s.split(Regexp.union(SPLIT_DELIMITERS)).reject(&:blank?)
         blacklisted_keywords_in_attribute = keywords & BLACKLISTED_KEYWORDS
         unless blacklisted_keywords_in_attribute.empty?
-            record.errors.add(attribute, "contains blacklisted keyword: #{blacklisted_keywords_in_attribute.to_s}. Please refactor #{attribute} accordingly")
+            record.errors.add(attribute, "contains disallowed keyword: #{blacklisted_keywords_in_attribute.to_s}. Please refactor #{attribute} accordingly")
         end
     end
 end

--- a/app/views/api_action_mailer/send_email.html.erb
+++ b/app/views/api_action_mailer/send_email.html.erb
@@ -4,7 +4,7 @@
   </head>
   <body>
     <main>
-      <p><%= render html: @api_action.custom_message.to_s.html_safe %></p>
+      <p><%= render html: @api_action.custom_message_evaluated.to_s.html_safe %></p>
       <% if @api_action.include_api_resource_data && @api_resource %>
         <p>
             <b>Api namespace:</b>

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -14,6 +14,9 @@
         = label_tag 'Email Address'
         = text_field_tag "api_namespace[#{type}_attributes][#{index}][email]", resource.email, { class: "form-control form-control-sm" }
       .form-group
+        = label_tag 'Subject'
+        =  text_field_tag "api_namespace[#{type}_attributes][#{index}][email_subject]", resource.email_subject, { class: "form-control form-control-sm" }
+      .form-group
         = label_tag 'Custom Message'
         = rich_text_area_tag "api_namespace[#{type}_attributes][#{index}][custom_message]", resource.custom_message, { class: "form-control form-control-sm" }
 

--- a/db/migrate/20220609092515_add_email_subject_to_api_actions.rb
+++ b/db/migrate/20220609092515_add_email_subject_to_api_actions.rb
@@ -1,0 +1,5 @@
+class AddEmailSubjectToApiActions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_actions, :email_subject, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_06_015014) do
+ActiveRecord::Schema.define(version: 2022_06_09_092515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2022_06_06_015014) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "custom_headers"
     t.string "http_method"
+    t.text "email_subject"
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end

--- a/test/models/api_action_test.rb
+++ b/test/models/api_action_test.rb
@@ -18,4 +18,53 @@ class ApiActionTest < ActiveSupport::TestCase
     assert_equal api_action.reload.lifecycle_stage, 'failed'
     assert_equal api_action.reload.lifecycle_message, 'error response'
   end
+
+  test 'should respond to dynamically generated method' do
+    api_resource = api_resources(:one)
+
+    expected_response = {
+      email_subject: "API Resource Accessed #{api_resource.id}",
+      custom_message: "<div class=\"trix-content\">\n  API Namespace Accessed #{api_resource.api_namespace.id}\n</div>\n",
+      request_url: "API Resource Property Accessed  #{api_resource.properties['can_edit']}",
+      payload_mapping: {
+        test_key: "#{api_resource.id}"
+  }.to_json
+    }
+
+    api_action = ApiAction.new(
+      api_resource_id: api_resource.id,
+      email_subject: "API Resource Accessed \#{api_resource.id}",
+      custom_message: "API Namespace Accessed \#{api_resource.api_namespace.id}",
+      request_url: "API Resource Property Accessed  \#{api_resource.properties['can_edit']}",
+      payload_mapping: {
+        test_key: "\#{api_resource.id}"
+      }
+    )
+    assert api_action.valid?
+    [:email_subject, :custom_message, :request_url, :payload_mapping].each do |dynamic_attr|
+      assert_respond_to api_action, "#{dynamic_attr}_evaluated".to_sym
+      assert_equal api_action.send("#{dynamic_attr}_evaluated".to_sym), expected_response[dynamic_attr]
+    end
+  end
+
+  test 'should raise error if unsafe string is evaluted' do
+    api_resource = api_resources(:one)
+
+    api_action = ApiAction.new(
+      api_resource_id: api_resource.id,
+      email_subject: "API Resource Accessed \#{api_resource.id}",
+      custom_message: "API Namespace Accessed \#{api_resource.api_namespace.id}",
+      request_url: "API Resource Property Accessed  \#{api_resource.properties['can_edit']}",
+      payload_mapping: {
+        test_key: "\#{User.destroy_all}"
+      }
+    )
+    refute api_action.valid?
+
+    [:email_subject, :custom_message, :request_url, :payload_mapping].each do |dynamic_attr|
+      assert_raises ActiveRecord::RecordInvalid do
+        api_action.send("#{dynamic_attr}_evaluated".to_sym)
+      end
+    end
+  end
 end

--- a/test/models/concerns/dynamic_attribute_test.rb
+++ b/test/models/concerns/dynamic_attribute_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class DynamicAttributeTest < ActiveSupport::TestCase
+  setup do
+    # test concern in isolation
+    @dummy_class = Class.new do
+      include ActiveModel::Model
+
+      def self.name
+        'Test'
+      end
+
+      def initialize(test_column: nil)
+          @test_column = test_column
+      end
+
+      include ActiveModel::Validations
+      include DynamicAttribute
+      attr_accessor :test_column
+      attr_accessor :api_resource
+
+      attr_dynamic :test_column
+    end
+  end  
+
+  test 'should respond to dynamic methods if dynamic field is safe' do
+    safe_instance = @dummy_class.new(test_column: "Test \#{1 + 1}")
+    assert safe_instance.valid?
+    assert_respond_to safe_instance, :test_column_evaluated
+    assert_equal safe_instance.test_column_evaluated, 'Test 2'
+  end
+
+
+  test 'should raise invalid record error dynamic field contains unsafe string' do
+    unsafe_instance = @dummy_class.new(test_column: "Test \#{User.destroy_all}")
+    refute unsafe_instance.valid?
+    assert_no_difference "User.all.size" do
+      assert_raises ActiveRecord::RecordInvalid do
+        unsafe_instance.test_column_evaluated
+      end
+    end
+  end
+end

--- a/test/models/external_api_client_test.rb
+++ b/test/models/external_api_client_test.rb
@@ -103,7 +103,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     invalid_model_definations.each do |invalid_executable|
       external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: invalid_executable)
       refute external_api_client.valid?
-      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains disallowed keyword'
     end
   end
 
@@ -113,7 +113,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     User::PRIVATE_ATTRIBUTES.each do |private_attr|
       external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: "User.last.#{private_attr}")
       refute external_api_client.valid?
-      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains disallowed keyword'
     end
   end
 
@@ -123,7 +123,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     User::FULL_PERMISSIONS.keys.each do |permission_attr|
       external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: "User.last.update(#{permission_attr} => false)")
       refute external_api_client.valid?
-      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains disallowed keyword'
     end
   end
 end


### PR DESCRIPTION
[add subject to send_email API action, make subject / body dynamic, expose API entities in context](https://github.com/restarone/violet_rails/issues/653)

[add dynamic string to HTTP action request URL](https://github.com/restarone/violet_rails/issues/652)


# acceptance criteria: 

1. Existing HTTP actions are functional :heavy_check_mark: 
2. HTTP action allows string interpolation in URL :heavy_check_mark: 
3. Existing send email actions are functional
4. ability to use string interpolation in email, subject and body