### PR TITLE
[Bug fix] last admin should not be able to delete themselves

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,15 +111,17 @@ class User < ApplicationRecord
     timeout = User::SESSION_TIMEOUT.detect{|n| n[:slug] == self.session_timeoutable_in }[:exec]
     eval(timeout)
    end
+
+  def is_last_admin?
+    User.all.size == 1 || (self.can_manage_users && User.where(can_manage_users: true).size == 1)
+  end
   
   private
 
 
   def ensure_final_user
-    if Rails.env != 'test'
-      if User.all.size - 1 == 0
-        throw :abort
-      end 
-    end
+    if self.is_last_admin?
+      throw :abort
+    end 
   end
 end

--- a/app/views/comfy/admin/users/_form.haml
+++ b/app/views/comfy/admin/users/_form.haml
@@ -83,4 +83,5 @@
                 %label 
                   Can manage forum
   = f.submit "Update", class: 'btn btn-success'
-  = link_to "Remove", admin_user_path(id: @user.id), method: :delete, class: 'btn btn-sm btn-danger', data: { confirm: 'Are you sure you want to remove this user? This cannot be undone' }
+  - unless @user.is_last_admin?
+    = link_to "Remove", admin_user_path(id: @user.id), method: :delete, class: 'btn btn-sm btn-danger', data: { confirm: 'Are you sure you want to remove this user? This cannot be undone' }   

--- a/test/controllers/admin/comfy/users_controller_test.rb
+++ b/test/controllers/admin/comfy/users_controller_test.rb
@@ -177,7 +177,7 @@ class Comfy::Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   test "#destroy" do
     assert_difference "User.all.size", -1 do
       sign_in(@user)
-      delete admin_user_url(subdomain: @domain, id: @user.id)
+      delete admin_user_url(subdomain: @domain, id: users(:one).id)
       assert flash.notice
       refute flash.alert
       assert_redirected_to admin_users_url(subdomain: @domain)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -18,14 +18,43 @@ class UserTest < ActiveSupport::TestCase
     ).valid?
   end
 
-  test "can be destroyed" do
+  test "can be destroyed if not last user or admin" do
     user = User.new(
       email: 'foo@bar.com',
       password: '123456',
       password_confirmation: '123456',
     )
-    assert user.save
-    user.destroy
+    user.save
+    assert user.destroy
+  end
+
+  test "cannot be destroyed if last user" do
+    User.delete_all
+    user = User.new(
+      email: 'foo@bar.com',
+      password: '123456',
+      password_confirmation: '123456',
+    )
+    user.save
+    assert_not user.destroy
+  end
+
+  test "cannot be destroyed if last admin" do
+    User.delete_all
+    user = User.new(
+      email: 'foo@bar.com',
+      password: '123456',
+      password_confirmation: '123456',
+    )
+    admin = User.new(
+      email: 'admin@email.com',
+      password: '123456',
+      password_confirmation: '123456',
+      can_manage_users: true
+    )
+    user.save
+    admin.save
+    assert_not admin.destroy
   end
 
   test "can infer session timeout time (default)" do


### PR DESCRIPTION
Addresses #313 

# acceptance criteria

1. delete button not shown if the user is the last admin who can manage users
2. admin cannot be deleted from the web console if they are the only one who can manage users