### PR TITLE
allow multiple recipients for emails with select2

### DIFF
--- a/app/controllers/mailbox/message_threads_controller.rb
+++ b/app/controllers/mailbox/message_threads_controller.rb
@@ -14,6 +14,8 @@ class Mailbox::MessageThreadsController < Mailbox::BaseController
   end
 
   def create
+    # remove empty string (a side-effect of rails select fields)
+    params[:message_thread][:recipients].delete("")
     @message_thread = MessageThread.new(message_thread_params)
     @message = Message.new(message_params[:message].merge!(message_thread: @message_thread))
     if @message_thread.save && @message.save

--- a/app/mailers/e_mailer.rb
+++ b/app/mailers/e_mailer.rb
@@ -5,13 +5,13 @@ class EMailer < ApplicationMailer
     @from = "#{Subdomain.current.name}@#{ENV["APP_HOST"]}"
     message_id = "#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@#{Apartment::Tenant.current}@#{ENV['APP_HOST']}"
     @message_thread.update(current_email_message_id: message_id)
-    @message_thread.recipients.each do |recipient|
-      mail(
-        to: recipient, 
-        subject: @message_thread.subject,
-        from: @from,
-        message_id: message_id
-      )
-    end
+
+    # This will make the mail addresses visible to all
+    mail(
+      to: @message_thread.recipients, 
+      subject: @message_thread.subject,
+      from: @from,
+      message_id: message_id
+    )
   end
 end

--- a/app/views/mailbox/message_threads/_form.haml
+++ b/app/views/mailbox/message_threads/_form.haml
@@ -2,9 +2,19 @@
   .form-group
     %label
       recipients: 
-    = f.text_field :recipients, multiple: true, required: true, class: 'form-control'
+    = f.select :recipients, options_for_select([]), { include_blank: false }, { multiple: true }
   .form-group
     %label
       Subject: 
     = f.text_field :subject, class: 'form-control'
   = render partial: 'messages/form', locals: { f: f }
+
+:javascript
+  $(document).ready( function() {
+    $("#message_thread_recipients").select2({
+      multiple: true,
+      required: true,
+      tags: true,
+      tokenSeparators: [',', ' '],
+    })
+  });

--- a/test/mailers/e_mailer_test.rb
+++ b/test/mailers/e_mailer_test.rb
@@ -1,7 +1,17 @@
 require "test_helper"
 
 class EMailerTest < ActionMailer::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'sends email to multiple recipients' do
+    recipients = ['a@a.com', 'b@b.com', 'c@c.com']
+
+    message_thread = MessageThread.new(recipients: recipients)
+    message = Message.new(content: 'content')
+    email = EMailer.with(message: message, message_thread: message_thread).ship
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal recipients, email.to
+  end
 end


### PR DESCRIPTION
resolves #149 

- connected select2 to recipients field
- previous `EMailer.ship` attempted to send separate email for each recipient, only the last recipient was being sent to
- EMailer now correctly fills the recipients array