### PR TITLE
[feature] add pagination + search to email threads/index

### DIFF
--- a/app/controllers/mailbox/mailbox_controller.rb
+++ b/app/controllers/mailbox/mailbox_controller.rb
@@ -1,5 +1,8 @@
 class Mailbox::MailboxController < Mailbox::BaseController
   def show
-    @message_threads = MessageThread.all.order(created_at: :desc)
+    params[:q] ||= {}
+    @message_threads_q = MessageThread.all.includes(:messages).ransack(params[:q])
+    @message_threads_q.sorts = ['created_at desc'] if @message_threads_q.sorts.empty?
+    @message_threads = @message_threads_q.result(distinct: true).paginate(page: params[:page], per_page: params[:per_page] || 10)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,6 +5,7 @@ class Message < ApplicationRecord
   accepts_nested_attributes_for :message_thread
 
   has_rich_text :content
+  has_one :content, class_name: 'ActionText::RichText', as: :record
   has_many_attached :attachments
 
   default_scope { order(created_at: 'DESC') }

--- a/app/models/message_thread.rb
+++ b/app/models/message_thread.rb
@@ -2,4 +2,18 @@ class MessageThread < ApplicationRecord
   validates :recipients, presence: true, length: { minimum: 1 }
   has_many :messages, dependent: :destroy
   accepts_nested_attributes_for :messages
+
+  scope :search_messages_content_body_or_subject_or_messages_from_or_recipients_contains,->(value) {
+    value = "%#{value}%"
+  
+    left_outer_joins(messages: :content)
+    .where('action_text_rich_texts.body ILIKE ? OR message_threads.subject ILIKE ? OR messages.from ILIKE ? OR message_threads.recipients::text ILIKE ?', value, value, value, value)
+    .distinct
+  }
+
+  private
+
+  def self.ransackable_scopes(auth_object = nil)
+    [:search_messages_content_body_or_subject_or_messages_from_or_recipients_contains]
+  end
 end

--- a/app/views/mailbox/mailbox/_pagination.haml
+++ b/app/views/mailbox/mailbox/_pagination.haml
@@ -1,0 +1,4 @@
+.digg_pagination
+  .page-info
+    = page_entries_info data
+  = will_paginate data, container: false

--- a/app/views/mailbox/mailbox/_search_filters.haml
+++ b/app/views/mailbox/mailbox/_search_filters.haml
@@ -1,0 +1,7 @@
+= search_form_for @message_threads_q, url: mailbox_path do |f|
+  .form-group
+    = f.label "email body, subject or email address (both: sender & recipients)", class: 'col-form-label'
+    = f.search_field :search_messages_content_body_or_subject_or_messages_from_or_recipients_contains, value: params[:q][:search_messages_content_body_or_subject_or_messages_from_or_recipients_contains], class: 'form-control'
+    .text-center
+      = f.submit class: 'btn btn-primary my-2'
+      = link_to "Clear Search", request.path, class:"cancel-button"

--- a/app/views/mailbox/mailbox/show.haml
+++ b/app/views/mailbox/mailbox/show.haml
@@ -3,6 +3,8 @@
   .h2
     = I18n.t('views.mailbox.index.header.title')
     = Subdomain.current.mailing_address
+= render partial: 'mailbox/mailbox/search_filters'
+= render partial: 'mailbox/mailbox/pagination', locals: { data: @message_threads }
 - @message_threads.each do |message_thread|
   = link_to mailbox_message_thread_path(id: message_thread.id), class: 'text-reset text-decoration-none' do
     .card.my-3
@@ -17,3 +19,4 @@
         - if message_thread.messages.any?
           .card-text.bg-light.p-2
             = message_thread.messages.first.content
+= render partial: 'mailbox/mailbox/pagination', locals: { data: @message_threads }

--- a/test/controllers/mailbox/mailbox_controller_test.rb
+++ b/test/controllers/mailbox/mailbox_controller_test.rb
@@ -43,4 +43,144 @@ class Mailbox::MailboxControllerTest < ActionDispatch::IntegrationTest
     get mailbox_url
     assert_response :success
   end
+
+  test "#show: searches email-threads by email-body content" do
+    other_user = users(:one)
+
+    message_thread_1 = MessageThread.first
+    message_1 = message_thread_1.messages.create!(content: '<div>body 1</div>')
+
+    message_thread_2 = MessageThread.create!(unread: true, subject: 'test', recipients: [other_user.email])
+    message_2 = message_thread_2.messages.create!(content: '<div>body 2</div>')
+
+    message_thread_3 = MessageThread.create!(unread: true, subject: 'new email', recipients: [other_user.email])
+    message_3 = message_thread_3.messages.create!(content: '<div>description</div>')
+
+    message_thread_4 = MessageThread.create!(unread: true, subject: 'restarone', recipients: [other_user.email])
+    message_4 = message_thread_4.messages.create!(content: '<div>violet</div>')
+
+    payload = {
+      q: {
+        search_messages_content_body_or_subject_or_messages_from_or_recipients_contains: 'body'
+      }
+    }
+    
+    sign_in(@user)
+    get mailbox_url, params: payload
+
+    assert_response :success
+    
+    message_threads = @controller.view_assigns['message_threads']
+
+    assert_equal [message_thread_1.id, message_thread_2.id].sort, message_threads.pluck(:id).sort
+    
+    message_threads.each do |message_thread|
+      assert_match 'body', message_thread.messages.first.content.body.to_s
+    end
+  end
+
+  test "#show: searches email-threads by email-subject" do
+    other_user = users(:one)
+
+    message_thread_1 = MessageThread.first
+    message_1 = message_thread_1.messages.create!(content: '<div>body 1</div>')
+
+    message_thread_2 = MessageThread.create!(unread: true, subject: 'test', recipients: [other_user.email])
+    message_2 = message_thread_2.messages.create!(content: '<div>body 2</div>')
+
+    message_thread_3 = MessageThread.create!(unread: true, subject: 'new email', recipients: [other_user.email])
+    message_3 = message_thread_3.messages.create!(content: '<div>description</div>')
+
+    message_thread_4 = MessageThread.create!(unread: true, subject: 'restarone inc', recipients: [other_user.email])
+    message_4 = message_thread_4.messages.create!(content: '<div>violet</div>')
+
+    payload = {
+      q: {
+        search_messages_content_body_or_subject_or_messages_from_or_recipients_contains: 'restarone inc'
+      }
+    }
+    
+    sign_in(@user)
+    get mailbox_url, params: payload
+
+    assert_response :success
+    
+    message_threads = @controller.view_assigns['message_threads']
+
+    assert_equal [message_thread_4.id].sort, message_threads.pluck(:id).sort
+    
+    message_threads.each do |message_thread|
+      assert_match 'restarone', message_thread.subject
+    end
+  end
+
+  test "#show: searches email-threads by sender-email-address" do
+    other_user = users(:one)
+
+    message_thread_1 = MessageThread.first
+    message_1 = message_thread_1.messages.create!(content: '<div>body 1</div>')
+
+    message_thread_2 = MessageThread.create!(unread: true, subject: 'test', recipients: [other_user.email])
+    message_2 = message_thread_2.messages.create!(content: '<div>body 2</div>')
+
+    message_thread_3 = MessageThread.create!(unread: true, subject: 'new email', recipients: [other_user.email])
+    message_3 = message_thread_3.messages.create!(content: '<div>description</div>', from: 'violet@rails.com')
+
+    message_thread_4 = MessageThread.create!(unread: true, subject: 'restarone', recipients: [other_user.email])
+    message_4 = message_thread_4.messages.create!(content: '<div>violet</div>', from: 'violet@rails.com')
+
+    payload = {
+      q: {
+        search_messages_content_body_or_subject_or_messages_from_or_recipients_contains: 'violet@rails.com'
+      }
+    }
+    
+    sign_in(@user)
+    get mailbox_url, params: payload
+
+    assert_response :success
+    
+    message_threads = @controller.view_assigns['message_threads']
+
+    assert_equal [message_thread_3.id, message_thread_4.id].sort, message_threads.pluck(:id).sort
+    
+    message_threads.each do |message_thread|
+      assert_match 'violet@rails.com', message_thread.messages.first.from
+    end
+  end
+
+  test "#show: searches email-threads by recipients-email-address" do
+    other_user = users(:one)
+
+    message_thread_1 = MessageThread.first
+    message_1 = message_thread_1.messages.create!(content: '<div>body 1</div>')
+
+    message_thread_2 = MessageThread.create!(unread: true, subject: 'test', recipients: [other_user.email])
+    message_2 = message_thread_2.messages.create!(content: '<div>body 2</div>')
+
+    message_thread_3 = MessageThread.create!(unread: true, subject: 'new email', recipients: [other_user.email])
+    message_3 = message_thread_3.messages.create!(content: '<div>description</div>', from: 'violet@rails.com')
+
+    message_thread_4 = MessageThread.create!(unread: true, subject: 'restarone', recipients: [other_user.email])
+    message_4 = message_thread_4.messages.create!(content: '<div>violet</div>', from: 'violet@rails.com')
+
+    payload = {
+      q: {
+        search_messages_content_body_or_subject_or_messages_from_or_recipients_contains: other_user.email
+      }
+    }
+    
+    sign_in(@user)
+    get mailbox_url, params: payload
+
+    assert_response :success
+    
+    message_threads = @controller.view_assigns['message_threads']
+
+    assert_equal [message_thread_2.id, message_thread_3.id, message_thread_4.id].sort, message_threads.pluck(:id).sort
+    
+    message_threads.each do |message_thread|
+      assert_match other_user.email, message_thread.recipients.to_s
+    end
+  end
 end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/777


## video demo
https://user-images.githubusercontent.com/35935196/174919097-eaca5e9d-61cc-4ade-9647-bab7355a3ecd.mp4





* [Violet Rails Core] add pagination + search to email threads/index (#788)

* feat(): implementation for pagination and searching by email-body, subject or sender-email adrress in mailbox

* feat(): added test cases

* feat(): add functionality to search my recipients email (#794)

Co-authored-by: Prashant <alish.khadka@gmail.com>