### PR TITLE
revert ruby 3 docker dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:3.0.0-alpine
+FROM ruby:2.6.6-alpine
 
 # Build ENV vars
 ENV APP_PATH /var/app


### PR DESCRIPTION
## change log

1. downgrade to ruby 2.6.6 for dev, since we run it in production its important we catch issues early on. 