### PR TITLE
revert ruby 3 docker dev, remove model filter from test coverage, when feature is un-enabled remove buttons related to it

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:3.0.0-alpine
+FROM ruby:2.6.6-alpine
 
 # Build ENV vars
 ENV APP_PATH /var/app

--- a/app/views/comfy/admin/cms/partials/_navigation_before.haml
+++ b/app/views/comfy/admin/cms/partials/_navigation_before.haml
@@ -3,3 +3,4 @@
     = image_tag(Subdomain.current.logo, class: 'd-none d-lg-block img-fluid p-4', size: '150x150')
 - else 
   = link_to "Add your logo here", edit_web_settings_path, class: 'd-none d-lg-block p-4' 
+  

--- a/app/views/comfy/admin/cms/partials/_navigation_inner.haml
+++ b/app/views/comfy/admin/cms/partials/_navigation_inner.haml
@@ -11,6 +11,8 @@
       = "#{Subdomain.current.name.capitalize} Shortcuts"
     .dropdown-menu{"aria-labelledby" => "navbarDropdown"}
       = link_to "Website", '/', class: 'dropdown-item', target: '_blank'
-      = link_to "Blog", '/blog', class: 'dropdown-item', target: '_blank'
-      = link_to "Forum", '/forum', class: 'dropdown-item', target: '_blank'
+      - if Subdomain.current.blog_enabled
+        = link_to "Blog", '/blog', class: 'dropdown-item', target: '_blank'
+      - if Subdomain.current.forum_enabled
+        = link_to "Forum", '/forum', class: 'dropdown-item', target: '_blank'
   = link_to "Logout", destroy_user_session_path, class: 'nav-link text-danger', method: :delete

--- a/test/controllers/admin/comfy/users_controller_test.rb
+++ b/test/controllers/admin/comfy/users_controller_test.rb
@@ -4,8 +4,9 @@ class Comfy::Admin::UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
     @restarone_subdomain = Subdomain.find_by(name: 'restarone')
     @user = users(:public)
+    @public_subdomain = subdomains(:public)
     @domain = @user.subdomain
-    @user.update(can_manage_users: true)
+    @user.update(can_manage_users: true, can_manage_email: true)
 
     @restarone_subdomain = Subdomain.find_by(name: 'restarone')
 
@@ -74,6 +75,34 @@ class Comfy::Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     sign_in(@user)
     get edit_admin_user_url(subdomain: @domain, id: @user.id)
     assert_response :success
+  end
+
+  test "#edit: show forum button if selected " do
+    sign_in(@user)
+    @public_subdomain.update(forum_enabled: true)
+    get mailbox_path
+    assert_select 'a', {count: 1, text: 'Forum'}
+  end
+
+  test "#edit: show blog button if selected " do
+    sign_in(@user)
+    @public_subdomain.update(blog_enabled: true)
+    get mailbox_path
+    assert_select 'a', {count: 1, text: 'Blog'}
+  end
+  
+  test "#edit: hide forum button if unselected " do
+    sign_in(@user)
+    @public_subdomain.update(forum_enabled: false)
+    get mailbox_path
+    assert_select 'a', {count: 0, text:'Forum'}
+  end
+  
+  test "#edit: hide blog button if unselected " do
+    sign_in(@user)
+    @public_subdomain.update(blog_enabled: false)
+    get mailbox_path
+    assert_select 'a', {count: 0, text:'Blog'}
   end
 
   test "denies #edit if not permissioned" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,6 @@
 ENV['RAILS_ENV'] ||= 'test'
 require 'simplecov'
 SimpleCov.start 'rails' do
-  # filtering out models because it doesnt track coverage on models for some reason (i suspect the apartment gem is to blame)
-  add_filter "app/models/"
   # these arent customized. so these dont need to be integration tested
   add_filter "app/controllers/users/confirmations_controller.rb"
   add_filter "app/controllers/users/omniauth_callbacks_controller.rb"


### PR DESCRIPTION
Deploy not necessary (but will do once RC is packaged)

## change log

1. downgrade to ruby 2.6.6 for dev, since we run it in production its important we catch issues early on.  @donrestarone 
2. remove model filter from test coverage @Pralish 
3. https://github.com/restarone/violet_rails/issues/384 by @Gloria-kuang 