### PR TITLE
[feature] make server turbo native ready

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,22 @@ module ApplicationHelper
   def sanitize_recaptcha_action_name(action_name)
     action_name.strip.gsub(/[- ]/, '_').scan(/[\/\_a-zA-Z0-9]/).join
   end
+
+  def mobile?
+    request&.user_agent&.include?('VioletRailsiOS')
+  end
+
+  def render_smart_navbar
+    # conditionally renders a navbar for web / none for native in CMS
+    unless mobile?
+      return cms_snippet_render('navbar').html_safe
+    end
+  end
+
+  def render_smart_footer
+    # conditionally renders a navbar for footer / none for native in CMS
+    unless mobile?
+      return cms_snippet_render('footer').html_safe
+    end
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 import Rails from "@rails/ujs"
-import "@hotwired/turbo-rails";
+import { Turbo } from "@hotwired/turbo-rails";
 
 import "channels"
 import "bootstrap"
@@ -13,6 +13,7 @@ import "chartkick/chart.js"
 import ahoy from "ahoy.js";
 import ctaSuccessHandler, {ctaSuccessHandlerRecaptchaV3} from "./website/call_to_actions"
 window.ahoy = ahoy;
+window.Turbo = Turbo
 window.ctaSuccessHandler = ctaSuccessHandler
 window.ctaSuccessHandlerRecaptchaV3 = ctaSuccessHandlerRecaptchaV3
 

--- a/app/views/layouts/comfy/blog/application.html.erb
+++ b/app/views/layouts/comfy/blog/application.html.erb
@@ -20,8 +20,8 @@
   <%= render partial: 'shared/navbars/web_admin' %>
 
   <body>
-    <%= cms_snippet_render('navbar').html_safe %>
+    <%= cms_snippet_render('navbar').html_safe unless mobile?  %>
     <%= yield %>
-    <%= cms_snippet_render('footer').html_safe %>
+    <%= cms_snippet_render('footer').html_safe unless mobile? %>
   </body>
 </html>

--- a/app/views/layouts/devise.html.haml
+++ b/app/views/layouts/devise.html.haml
@@ -11,7 +11,7 @@
 
   %body
     = render partial: 'shared/flash'
-    = cms_snippet_render('navbar').html_safe
+    = cms_snippet_render('navbar').html_safe unless mobile?
     .d-flex.flex-column.justify-content-center.align-items-center
       .my-5
         - custom_logo_path = logo_url(Subdomain.current)
@@ -21,4 +21,4 @@
           %a{href: 'https://github.com/restarone/violet_rails', target: "_blank"}
             = image_tag('violet-rails-vertical-logo.png', class: "img-fluid", size: '100x100')  
       = yield
-    = cms_snippet_render('footer').html_safe
+    = cms_snippet_render('footer').html_safe unless mobile?

--- a/app/views/layouts/simple_discussion.html.erb
+++ b/app/views/layouts/simple_discussion.html.erb
@@ -1,4 +1,4 @@
-<%= cms_snippet_render('navbar').html_safe %>
+<%= cms_snippet_render('navbar').html_safe unless mobile? %>
 
 <div class="row col-md-12">
   <h1>
@@ -105,4 +105,4 @@
 </div>
 
 <% parent_layout("forum") %>
-<%= cms_snippet_render('footer').html_safe %>
+<%= cms_snippet_render('footer').html_safe unless mobile? %>


### PR DESCRIPTION
resolves: https://github.com/restarone/violet_rails/issues/817

## client repository

iOS project: https://github.com/restarone/violet_rails_ios_client

## upgrade path
replace `{{ cms:snippet navbar }}` and `{{ cms:snippet footer }}` with `{{cms:helper render_smart_navbar}}` and `{{cms:helper render_smart_footer}}`. These new functions will intelligently render navbar/footer as `{{ cms:snippet navbar }}` and `{{ cms:snippet footer }}` for web clients. We don't want to show web navigation on native clients
<img width="1728" alt="Screen Shot 2022-06-26 at 11 33 06 AM" src="https://user-images.githubusercontent.com/35935196/175827078-bce6c6e1-b40f-4718-a104-aff5589aa63c.png">


## iOS support

Your Violet Rails app will now look like this on iOS

<img width="1728" alt="Screen Shot 2022-06-26 at 1 46 32 PM" src="https://user-images.githubusercontent.com/35935196/175827355-b7d7e41b-c116-4d22-b9c2-226bd9ca0dad.png">


## how the app looks

### native navigation 
web navbar is not shown, instead a system tray is shown at the bottom with relevant navigation buttons
![Simulator Screen Shot - iPhone 12 - 2022-06-26 at 13 44 25](https://user-images.githubusercontent.com/35935196/175827646-7926f459-79e7-4425-a803-40eacab7faac.png)
### Blog

![Simulator Screen Shot - iPhone 12 - 2022-06-26 at 13 44 29](https://user-images.githubusercontent.com/35935196/175827649-a064500e-ee84-41b6-aa89-c485c9a5348c.png)
### Forum
![Simulator Screen Shot - iPhone 12 - 2022-06-26 at 13 45 02](https://user-images.githubusercontent.com/35935196/175827650-df1ac6f6-1c04-4780-9d8e-57cb8dc80446.png)
![Simulator Screen Shot - iPhone 12 - 2022-06-26 at 13 45 05](https://user-images.githubusercontent.com/35935196/175827652-eea5b061-0819-43f4-bb16-101b59c91a40.png)
![Simulator Screen Shot - iPhone 12 - 2022-06-26 at 13 45 10](https://user-images.githubusercontent.com/35935196/175827653-4929c3ff-81d8-4e4a-83d6-356a04e5a0d2.png)
