### PR TITLE
[CI] Save code coverage as artifact

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -83,6 +83,10 @@ jobs:
       run: |
         cd client
         npm install -g ember-cli
-
     - name: Run Tests
       run: bin/rails test -f
+    - name: Save code coverage report
+      uses: actions/upload-artifact@v3
+      with:
+        name: code-coverage-report(Ruby - ${{ matrix.ruby_version }}, Node.js - ${{ matrix.node_version }})
+        path: coverage/


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/815

If we click on one of the link of artifact, a zip folder _(coverage folder)_ is downloaded. Within the folder, we can view the _index.html_ file.

https://user-images.githubusercontent.com/25191509/175912039-18e8d52e-7bbd-4850-b50a-67869d399fa6.mp4

## Expiry
artifacts will clear after 90 days by default. 
[reference](https://github.com/actions/upload-artifact#retention-period)

credits @alis-khadka 
Co-authored-by: Prashant <alish.khadka@gmail.com>