### PR TITLE
[Bug Fix]: forum post/thread creation errors are not showing

### DIFF
--- a/app/controllers/simple_discussion/forum_posts_controller.rb
+++ b/app/controllers/simple_discussion/forum_posts_controller.rb
@@ -14,7 +14,7 @@ class SimpleDiscussion::ForumPostsController < SimpleDiscussion::ApplicationCont
       ApiNamespace::Plugin::V1::SubdomainEventsService.new(@forum_post).track_event
       redirect_to simple_discussion.forum_thread_path(@forum_thread, anchor: "forum_post_#{@forum_post.id}")
     else
-      render template: "simple_discussion/forum_threads/show"
+      render template: "simple_discussion/forum_threads/show", status: :unprocessable_entity
     end
   end
 
@@ -30,7 +30,7 @@ class SimpleDiscussion::ForumPostsController < SimpleDiscussion::ApplicationCont
 
       redirect_to simple_discussion.forum_thread_path(@forum_thread)
     else
-      render action: :edit
+      render action: :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/simple_discussion/forum_threads_controller.rb
+++ b/app/controllers/simple_discussion/forum_threads_controller.rb
@@ -53,7 +53,7 @@ class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationCo
       ApiNamespace::Plugin::V1::SubdomainEventsService.new(@forum_thread).track_event
       redirect_to simple_discussion.forum_thread_path(@forum_thread)
     else
-      render action: :new
+      render action: :new, status: :unprocessable_entity
     end
   end
 
@@ -64,7 +64,7 @@ class SimpleDiscussion::ForumThreadsController < SimpleDiscussion::ApplicationCo
     if @forum_thread.update(forum_thread_params)
       redirect_to simple_discussion.forum_thread_path(@forum_thread), notice: I18n.t("your_changes_were_saved")
     else
-      render action: :edit
+      render action: :edit, status: :unprocessable_entity
     end
   end
 

--- a/test/controllers/simple_discussion/forum_threads_controller_test.rb
+++ b/test/controllers/simple_discussion/forum_threads_controller_test.rb
@@ -185,6 +185,35 @@ class SimpleDiscussion::ForumThreadsControllerTest < ActionDispatch::Integration
       post simple_discussion.forum_threads_url, params: payload
       Sidekiq::Worker.drain_all
     end
+
+    # Validation errors are not present in the response-body
+    assert_select 'div#error_explanation', { count: 0 }
+    refute @controller.view_assigns['forum_thread'].errors.present?
+  end
+
+  test 'denies new thread creation with validation errors in response if invalid payload is provided' do
+    subdomains(:public).update(api_plugin_events_enabled: true)
+    sign_in(@user)
+    payload = {
+      forum_thread: {
+        forum_category_id: '',
+        title: '',
+        forum_posts_attributes: {
+          "0": {
+            body: ''
+          }
+        }
+      }
+    }
+    assert_no_difference "ApiResource.count" do
+      post simple_discussion.forum_threads_url, params: payload
+      Sidekiq::Worker.drain_all
+    end
+
+    assert_response :unprocessable_entity
+    # Validation errors are present in the response-body
+    assert_select 'div#error_explanation'
+    assert @controller.view_assigns['forum_thread'].errors.present?
   end
 
   test 'tracks new thread/reply creation if plugin: subdomain/subdomain_events is enabled' do
@@ -210,6 +239,33 @@ class SimpleDiscussion::ForumThreadsControllerTest < ActionDispatch::Integration
       }
       Sidekiq::Worker.drain_all
     end
+  end
+
+  test 'denies new thread/reply creation with validation-errors in response' do
+    sign_in(@user)
+    payload = {
+      forum_thread: {
+        forum_category_id: @forum_category.id,
+        title: 'foo',
+        forum_posts_attributes: {
+          "0": {
+            body: 'bar'
+          }
+        }
+      }
+    }
+    post simple_discussion.forum_threads_url, params: payload
+    post simple_discussion.forum_thread_forum_posts_path(ForumThread.last), params: {
+      forum_post: {
+        body: ""
+      }
+    }
+    Sidekiq::Worker.drain_all
+
+    assert_response :unprocessable_entity
+    # Validation errors are present in the response-body
+    assert_select 'div#error_explanation'
+    assert @controller.view_assigns['forum_post'].errors.present?
   end
 
   test 'tracks forum-thread view (if tracking is enabled)' do
@@ -250,5 +306,55 @@ class SimpleDiscussion::ForumThreadsControllerTest < ActionDispatch::Integration
 
     end
     assert_response :success
+  end
+
+  test 'denies forum-thread update with validation errors in response if invalid payload is provided' do
+    forum_thread = @user.forum_threads.create!(title: 'Test Thread 1', forum_category_id: @forum_category.id)
+    ForumPost.create!(forum_thread_id: forum_thread.id, user_id: @user.id, body: 'test body 1')
+    ForumPost.create!(forum_thread_id: forum_thread.id, user_id: @user.id, body: 'test body 2')
+    ForumPost.create!(forum_thread_id: forum_thread.id, user_id: @user.id, body: 'test body 3')
+  
+    sign_in(@user)
+    payload = {
+      forum_thread: {
+        forum_category_id: '',
+        title: '',
+        forum_posts_attributes: {
+          "0": {
+            body: ''
+          }
+        }
+      }
+    }
+
+    patch simple_discussion.forum_thread_url(id: forum_thread.id), params: payload
+    Sidekiq::Worker.drain_all
+
+    assert_response :unprocessable_entity
+    # Validation errors are present in the response-body
+    assert_select 'div#error_explanation'
+    assert @controller.view_assigns['forum_thread'].errors.present?
+  end
+
+  test 'allows forum-thread update without validation errors in response' do
+    forum_thread = @user.forum_threads.create!(title: 'Test Thread 1', forum_category_id: @forum_category.id)
+    ForumPost.create!(forum_thread_id: forum_thread.id, user_id: @user.id, body: 'test body 1')
+  
+    sign_in(@user)
+    payload = {
+      forum_thread: {
+        title: 'Title Changed'
+      }
+    }
+
+    patch simple_discussion.forum_thread_url(id: forum_thread.id), params: payload
+    Sidekiq::Worker.drain_all
+
+    assert_response :redirect
+    # Validation errors are not present in the response-body
+    assert_select 'div#error_explanation', { count: 0 }
+    refute @controller.view_assigns['forum_thread'].errors.present?
+
+    assert_equal payload[:forum_thread][:title], forum_thread.reload.title
   end
 end


### PR DESCRIPTION
RCA:
This issue seems to have started after we introduced hotwire-turbo in violet-rails.
Turbo expects 303(redirection) for form submission and 4xx/5xx to show validation errors in form.
Previously, when creating/updating of post/thread fails, we were not specifying status_code for the response.

https://turbo.hotwired.dev/handbook/drive#redirecting-after-a-form-submission

https://user-images.githubusercontent.com/35935196/176429422-cd40c98f-9ff3-49fa-a5cd-a64d21fcb283.mp4



