### PR TITLE
[Bug] Devise login forms do not show correct error messages

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,6 +14,25 @@ class RSolutionsFailureApp < Devise::FailureApp
   end
 end
 
+class RSolutionsDeviseController < ApplicationController
+  class Responder < ActionController::Responder
+    def to_turbo_stream
+      controller.render(options.merge(formats: :html))
+    rescue ActionView::MissingTemplate => error
+      if get?
+        raise error
+      elsif has_errors? && default_action
+        render rendering_options.merge(formats: :html, status: :unprocessable_entity)
+      else
+        redirect_to navigation_location
+      end
+    end
+  end
+
+  self.responder = Responder
+  respond_to :html, :turbo_stream
+end
+
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
 # are not: uncommented lines are intended to protect your configuration from
@@ -32,7 +51,7 @@ Devise.setup do |config|
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
-  # config.parent_controller = 'DeviseController'
+  config.parent_controller = 'RSolutionsDeviseController'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,6 +9,9 @@ class RSolutionsFailureApp < Devise::FailureApp
     end
   end
 
+  def skip_format?
+    %w(html turbo_stream */*).include? request_format.to_s
+  end
 end
 
 # Assuming you have not yet modified this file, each configuration option below

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+class RSolutionsFailureApp < Devise::FailureApp
+  def respond
+    if request_format == :turbo_stream
+      redirect
+    else
+      super
+    end
+  end
+
+end
+
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
 # are not: uncommented lines are intended to protect your configuration from
@@ -326,10 +337,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
+  config.warden do |manager|
+    manager.failure_app = RSolutionsFailureApp
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -111,4 +111,17 @@ class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_template :index
   end
+
+  test '#create denies login with' do
+    payload = {
+      user: {
+        email: @user.email,
+        password: ''
+      }
+    }
+    post users_sign_in_url, params: payload
+    
+    assert_template :new
+    assert_match "Invalid Email or password.", flash[:alert]
+  end
 end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/842


The bug existed in _sign-in_, _sign-up_, and _users/edit_ page. You can view it in the attached video below.
 ﻿

https://user-images.githubusercontent.com/25191509/176618871-e3e9c2b5-b6bd-4dfb-a59b-80e9ccfecf0b.mp4


The following reference is used to patch this bug.
[https://github.com/hotwired/turbo/issues/45](https://github.com/hotwired/turbo/issues/45)

And, below is the demo video after the fix.

https://user-images.githubusercontent.com/25191509/176619214-bf10ce2c-60be-44ce-bfe8-ed97c9930dff.mp4


﻿