### PR TITLE
[Bug fix] Devise login forms do not show correct error messages (#850)

### DIFF
--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -111,4 +111,17 @@ class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_template :index
   end
+
+  test '#create denies login with' do
+    payload = {
+      user: {
+        email: @user.email,
+        password: ''
+      }
+    }
+    post users_sign_in_url, params: payload
+    
+    assert_template :new
+    assert_match "Invalid Email or password.", flash[:alert]
+  end
 end


### PR DESCRIPTION
* fix(): show error messages while invalid login attempt

* fix(): remove '.turbo_stream' text form url for login requests

* fix(): validation errors not showing in sign-up & my-settings page

* chore(): test cases added