### PR TITLE
[Bug fix] Devise login forms do not show correct error messages

### DIFF
--- a/config/initializers/active_support.rb
+++ b/config/initializers/active_support.rb
@@ -1,0 +1,4 @@
+ActiveSupport.on_load(:action_view) do
+  include ActionText::ContentHelper
+  include ActionText::TagHelper
+end

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -111,4 +111,17 @@ class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_template :index
   end
+
+  test '#create denies login with' do
+    payload = {
+      user: {
+        email: @user.email,
+        password: ''
+      }
+    }
+    post users_sign_in_url, params: payload
+    
+    assert_template :new
+    assert_match "Invalid Email or password.", flash[:alert]
+  end
 end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/842


The bug existed in _sign-in_, _sign-up_, and _users/edit_ page. You can view it in the attached video below.
 ﻿

https://user-images.githubusercontent.com/25191509/176618871-e3e9c2b5-b6bd-4dfb-a59b-80e9ccfecf0b.mp4


The following reference is used to patch this bug.
[https://github.com/hotwired/turbo/issues/45](https://github.com/hotwired/turbo/issues/45)

And, below is the demo video after the fix.

https://user-images.githubusercontent.com/25191509/176619214-bf10ce2c-60be-44ce-bfe8-ed97c9930dff.mp4



## fix for action text not loading in production / staging

Reference: https://github.com/rails/rails/issues/37672

Addresses: https://github.com/restarone/violet_rails/pull/852