### PR TITLE
[feature] ability to toggle trix editor attachments

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -163,7 +163,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
                                             :requires_authentication,
                                             :namespace_type,
                                             :has_form,
-                                            non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :_destroy],
+                                            non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :allow_attachments, :_destroy],
                                             new_api_actions_attributes: api_actions_attributes,
                                             create_api_actions_attributes: api_actions_attributes,
                                             show_api_actions_attributes: api_actions_attributes,

--- a/app/models/non_primitive_property.rb
+++ b/app/models/non_primitive_property.rb
@@ -8,4 +8,12 @@ class NonPrimitiveProperty < ApplicationRecord
   has_one_attached :attachment
 
   validates_presence_of :label
+
+  before_save :reset_allow_attachments
+
+  private
+
+  def reset_allow_attachments
+    self.allow_attachments = true if self.field_type != 'richtext' && !self.allow_attachments
+  end
 end

--- a/app/views/comfy/admin/api_forms/_render.haml
+++ b/app/views/comfy/admin/api_forms/_render.haml
@@ -18,7 +18,7 @@
               = map_form_field(fff, key, value, form_properties)
       - @api_namespace.non_primitive_properties.each_with_index do |property, index|
         = fields_for "data[non_primitive_properties_attributes][#{index}]", property do |ff|
-          .form-group{class: "vr-#{ff.object.label}"}
+          .form-group{class: "vr-#{ff.object.label} #{'disable-trix-file-attachment' unless ff.object.allow_attachments}"}
             = label_tag property.label
             = map_non_primitive_data_type(ff, property.field_type, form_properties)
             - if property.field_type == 'file'
@@ -64,7 +64,19 @@
         tags: $(this).attr('data-tags')
       })
       $(this).val(JSON.parse($(this).attr('default_value'))).change();
-    })
+    });
+  });
+
+  // Disabling file attachment functionality
+  addEventListener('trix-initialize', function(e) {
+    $('.disable-trix-file-attachment').each(function(e) {
+      // Remove file-attach icon
+      $(this).find('trix-toolbar .trix-button-group--file-tools').remove();
+      // Disables functionality to drag-and-drop files onto the trix-editor
+      $(this).find('trix-editor').on('trix-file-accept', function(e) {
+        e.preventDefault();
+      });
+    });
   });
 
 - execute_actions(@api_namespace, 'new_api_actions')

--- a/app/views/comfy/admin/api_namespaces/_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_form.html.haml
@@ -43,9 +43,11 @@
    if (fieldType === 'file') {
      $("#file_field_" + index).show();
      $("#rich_text_field_" + index).hide();
+     $("#rich_text_field_allow_attachments_" + index).hide();
    } else if (fieldType === 'richtext') {
      $("#file_field_" + index).hide();
      $("#rich_text_field_" + index).show();
+     $("#rich_text_field_allow_attachments_" + index).show();
    }
   }
 

--- a/app/views/comfy/admin/non_primitive_properties/_nested_form.haml
+++ b/app/views/comfy/admin/non_primitive_properties/_nested_form.haml
@@ -12,8 +12,13 @@
   .form-group{style: "#{'display:none' unless resource.field_type == 'richtext'}", id: "rich_text_field_#{index}"}
     = label_tag 'Default Content'
     = rich_text_area_tag "api_namespace[non_primitive_properties_attributes][#{index}][content]", resource.content
+  .form-group.toggle-file-attachment.align-items-center{style: "#{resource.field_type == 'richtext' ? 'display:flex' : 'display:none'}", id: "rich_text_field_allow_attachments_#{index}"}
+    = label_tag 'Allow Attachments', nil, class: 'm-0 mr-1'
+    -# workaround reference: https://github.com/rails/rails/issues/5937, https://stackoverflow.com/a/20380051
+    = hidden_field_tag "api_namespace[non_primitive_properties_attributes][#{index}][allow_attachments]", false
+    = check_box_tag "api_namespace[non_primitive_properties_attributes][#{index}][allow_attachments]", true, resource.allow_attachments, onclick: 'toggleFileAttachment(this)'
   .form-group.mb-0{style: "#{'display:none' unless resource.field_type == 'file'}", id: "file_field_#{index}"}
-    = label_tag 'Deafult attachment'
+    = label_tag 'Default attachment'
     = file_field_tag "api_namespace[non_primitive_properties_attributes][#{index}][attachment]", class: "form-control form-control-sm", onchange: "previewFile(event, 'file_field_#{index}_preview')"
     .mt-3
       %video{id: "file_field_#{index}_preview_video", controls: true, style: "max-height: 150px; display: none"}
@@ -21,3 +26,27 @@
     
 
   = hidden_field_tag "api_namespace[non_primitive_properties_attributes][#{index}][_destroy]", false ,{id: "form_destroy_field_#{index}"}
+
+:javascript
+  addEventListener('trix-initialize', function() {
+    $('.toggle-file-attachment input[type="checkbox"]').each(function() {
+      toggleFileAttachment(this);
+    })
+  });
+
+  function toggleFileAttachment(element) {
+    const fileAttachIcon = $(element).parents('.card').find('trix-toolbar .trix-button-group--file-tools');
+    const trixEditor = $(element).parents('.card').find('trix-editor');
+
+    if (element.checked) {
+      fileAttachIcon.show();
+    } else {
+      fileAttachIcon.hide();
+    }
+
+    trixEditor.on('trix-file-accept', function(e) {
+      if (!element.checked) {
+        e.preventDefault();
+      }
+    })
+  }

--- a/db/migrate/20220628050113_add_allow_attachments_to_non_primitive_properties.rb
+++ b/db/migrate/20220628050113_add_allow_attachments_to_non_primitive_properties.rb
@@ -1,0 +1,5 @@
+class AddAllowAttachmentsToNonPrimitiveProperties < ActiveRecord::Migration[6.1]
+  def change
+    add_column :non_primitive_properties, :allow_attachments, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_09_041057) do
+ActiveRecord::Schema.define(version: 2022_06_28_050113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -424,6 +424,7 @@ ActiveRecord::Schema.define(version: 2022_06_09_041057) do
     t.bigint "api_namespace_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "allow_attachments", default: true
     t.index ["api_namespace_id"], name: "index_non_primitive_properties_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_non_primitive_properties_on_api_resource_id"
   end

--- a/test/models/non_primitive_property_test.rb
+++ b/test/models/non_primitive_property_test.rb
@@ -1,7 +1,20 @@
 require "test_helper"
 
 class NonPrimitivePropertyTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should reset allow_attachments if field_type is not richtext" do
+    non_primitive_property = non_primitive_properties(:one)
+    non_primitive_property.update!(field_type: 'file')
+    
+    non_primitive_property.update!(allow_attachments: false)
+    assert non_primitive_property.reload.allow_attachments
+  end
+
+  test "should not reset allow_attachments if field_type is richtext" do
+    non_primitive_property = non_primitive_properties(:one)
+    non_primitive_property.update!(field_type: 'richtext')
+    
+    expected_value = false
+    non_primitive_property.update!(allow_attachments: expected_value)
+    assert_equal expected_value, non_primitive_property.reload.allow_attachments
+  end
 end


### PR DESCRIPTION
# changes

## [feature] ability to toggle trix editor attachments

Addresses: https://github.com/restarone/violet_rails/issues/661

### **Demo Video**

https://user-images.githubusercontent.com/35935196/176429682-a19cc7b7-f692-4f18-8bc9-7f95947fc9b2.mp4




### challenges
Unchecked checkbox not passing false to params:
It took me some time to figure this out. In the end, I followed these reference for the workaround;

    https://github.com/rails/rails/issues/5937
    https://stackoverflow.com/questions/20379311/how-to-get-blank-checkboxes-to-pass-as-false-to-params/20380051#20380051
