### PR TITLE
[feature] Dynamic attributes in API Actions

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -156,7 +156,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
-      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email,:custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
+      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email, :email_subject, :custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,

--- a/app/mailers/api_action_mailer.rb
+++ b/app/mailers/api_action_mailer.rb
@@ -1,14 +1,14 @@
 class ApiActionMailer < ApplicationMailer
     helper ApiResourcesHelper
     def send_email(api_action)
-      mail_to = api_action.email
+      mail_to = api_action.email_evaluated
       return if mail_to.empty?
     
       @api_action = api_action
       @api_resource = api_action.api_resource
       mail(
         to: mail_to,
-        subject: "#{api_action.type} #{@api_resource.api_namespace.name.pluralize} v#{@api_resource.api_namespace.version}"
+        subject: api_action.email_subject_evaluated || "#{api_action.type} #{@api_resource.api_namespace.name.pluralize} v#{@api_resource.api_namespace.version}"
       )
     end
 end

--- a/app/mailers/api_action_mailer.rb
+++ b/app/mailers/api_action_mailer.rb
@@ -2,11 +2,13 @@ class ApiActionMailer < ApplicationMailer
     helper ApiResourcesHelper
     def send_email(api_action)
       mail_to = api_action.email_evaluated
+      from = "#{Subdomain.current.name}@#{ENV["APP_HOST"]}"
       return if mail_to.empty?
     
       @api_action = api_action
       @api_resource = api_action.api_resource
       mail(
+        from: from,
         to: mail_to,
         subject: api_action.email_subject_evaluated || "#{api_action.type} #{@api_resource.api_namespace.name.pluralize} v#{@api_resource.api_namespace.version}"
       )

--- a/app/models/api_action.rb
+++ b/app/models/api_action.rb
@@ -1,7 +1,12 @@
 class ApiAction < ApplicationRecord
   include Encryptable
   include JsonbFieldsParsable
+  include DynamicAttribute
+
   attr_encrypted :bearer_token
+  attr_dynamic :email, :email_subject, :custom_message, :payload_mapping, :request_url
+
+  after_update :update_executed_actions_payload, if: Proc.new { api_namespace.present? && saved_change_to_payload_mapping? }
 
   belongs_to :api_namespace, optional: true
   belongs_to :api_resource, optional: true
@@ -33,6 +38,10 @@ class ApiAction < ApplicationRecord
 
   private
 
+  def update_executed_actions_payload
+    ApiAction.where(api_resource_id: api_namespace.api_resources.pluck(:id), payload_mapping: payload_mapping_previously_was, type: type, action_type: action_type).update_all(payload_mapping: payload_mapping)
+  end
+
   def send_email
     begin
       ApiActionMailer.send_email(self).deliver_now
@@ -45,8 +54,8 @@ class ApiAction < ApplicationRecord
 
   def send_web_request
     begin
-      response = HTTParty.send(http_method.to_s, request_url, 
-                    { body: evaluate_payload, headers: request_headers })
+      response = HTTParty.send(http_method.to_s, request_url_evaluated, 
+                    { body: payload_mapping_evaluated, headers: request_headers })
       if response.success?
         self.update(lifecycle_stage: 'complete', lifecycle_message: response.to_s)
       else
@@ -62,11 +71,6 @@ class ApiAction < ApplicationRecord
   def redirect;end
 
   def serve_file;end
-
-  def evaluate_payload
-    payload = payload_mapping.to_json.gsub('self.', 'self.api_resource.properties_object.')
-    eval(payload).to_json
-  end
 
   def request_headers
     headers = custom_headers.to_json.gsub('SECRET_BEARER_TOKEN', bearer_token)

--- a/app/models/concerns/dynamic_attribute.rb
+++ b/app/models/concerns/dynamic_attribute.rb
@@ -1,0 +1,43 @@
+# evaluate dynamic columns
+# adding attribute defined by attr_dynamic parameters
+# method attributed will be created as <coulmn_name>_evaluated
+# example attr_dynamic :custom_message will add a method custom_message_evaluated
+# column content example: Hi my name is #{api_resource.properties["first_name"]}
+
+module DynamicAttribute
+    extend ActiveSupport::Concern
+
+    included do
+      def parse_dynamic_attribute(value)
+        return unless value.present?
+
+        raise ActiveRecord::RecordInvalid.new(self) unless self.valid?
+
+        parsed_text = value
+        # couldn't gsub directly because of escape characters added by ruby
+        # eval failed on "\#{api_resource.properties[\"String\"]}"
+        value.scan(/\#\{(.*?)\}/).each do |code|
+          parsed_text = parsed_text.sub!("\#{#{code[0]}}", eval(code[0]).to_s)
+        end
+        parsed_text.html_safe
+      end
+
+      def attribute_value_string(attribute)
+        value = public_send(attribute.to_sym)
+        value.is_a?(Enumerable) ? value.to_json : value.to_s
+      end
+    end
+  
+    class_methods do
+      def attr_dynamic(*attributes) # rubocop:disable Metrics/AbcSize
+        attributes.each do |attribute|
+          # all dynamic attributes should be safe
+          validates attribute.to_sym, safe_executable: true
+
+          define_method("#{attribute}_evaluated") do
+            parse_dynamic_attribute(attribute_value_string(attribute))
+          end
+        end
+      end
+    end
+  end

--- a/app/models/concerns/safe_executable_validator.rb
+++ b/app/models/concerns/safe_executable_validator.rb
@@ -13,14 +13,12 @@ class SafeExecutableValidator < ActiveModel::EachValidator
         'update_all',
         'destroy_all',
         'switch',
-        'can_manage_users',
         'global_admin',
         'Subdomain',
         'Tenant',
         'Apartment',
     ] + User::PRIVATE_ATTRIBUTES.map(&:to_s) + User::FULL_PERMISSIONS.keys.map(&:to_s)
      
-
     # BLACKLISTED_KEYWORDS are usually attached to one of these delimiters
     # eg: exit(), .constantize, Subdomain.destroy_all, can_manage_users:
     SPLIT_DELIMITERS = ['(', ')', /\s/, '.', /\n/, ':', '#{', '}', '=>', '"', '\'']
@@ -29,7 +27,7 @@ class SafeExecutableValidator < ActiveModel::EachValidator
         keywords = value.to_s.split(Regexp.union(SPLIT_DELIMITERS)).reject(&:blank?)
         blacklisted_keywords_in_attribute = keywords & BLACKLISTED_KEYWORDS
         unless blacklisted_keywords_in_attribute.empty?
-            record.errors.add(attribute, "contains blacklisted keyword: #{blacklisted_keywords_in_attribute.to_s}. Please refactor #{attribute} accordingly")
+            record.errors.add(attribute, "contains disallowed keyword: #{blacklisted_keywords_in_attribute.to_s}. Please refactor #{attribute} accordingly")
         end
     end
 end

--- a/app/views/api_action_mailer/send_email.html.erb
+++ b/app/views/api_action_mailer/send_email.html.erb
@@ -4,7 +4,7 @@
   </head>
   <body>
     <main>
-      <p><%= render html: @api_action.custom_message.to_s.html_safe %></p>
+      <p><%= render html: @api_action.custom_message_evaluated.to_s.html_safe %></p>
       <% if @api_action.include_api_resource_data && @api_resource %>
         <p>
             <b>Api namespace:</b>

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -6,16 +6,43 @@
     .form-group.col-12
       = label_tag "Action"
       = select_tag "api_namespace[#{type}_attributes][#{index}][action_type]", options_for_select(ApiAction.action_types.keys, resource.action_type), { class: "form-control form-control-sm", id: "action_type_field_#{type}_#{index}", onchange: "toggleApiActionFields('#{index}', '#{type}');"}
+      - if resource.action_type == 'send_email' || resource.action_type == 'send_web_request'
+        .form-group.my-2
+          .d-block
+            %strong Top-Level Model Attributes: 
+            .d-block
+              = @api_namespace&.properties&.keys
+        - last_instance = @api_namespace&.api_resources&.last
+        - if last_instance
+          .form-group
+            .d-block
+              %strong Last API Resource Instance Attributes: 
+              .d-block
+                = last_instance.properties.keys
+          .d-block
+            %small
+              Dynamic:
+              %code
+                \\#{api_resource.properties['your_custom_attribute_here']} 
+
     .send_email.col-12{style: "#{'display:none' unless resource.action_type == 'send_email'}", id: "send_email_fields_#{type}_#{index}"}
       .form-group
+        -# this is how we allow the user to unselect the selected checkbox. Using jquery and this hidden field to set the value to false if unchecked
+        = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][include_api_resource_data]", false
         = label_tag 'Include Api Resource Data'
-        = check_box_tag "api_namespace[#{type}_attributes][#{index}][include_api_resource_data]", resource.include_api_resource_data , resource.include_api_resource_data
+        = check_box_tag "api_namespace[#{type}_attributes][#{index}][include_api_resource_data]", resource.include_api_resource_data , resource.include_api_resource_data, onClick: "$(this).attr('value', this.checked ? 1 : 0)"
       .form-group
         = label_tag 'Email Address'
         = text_field_tag "api_namespace[#{type}_attributes][#{index}][email]", resource.email, { class: "form-control form-control-sm" }
+
+      .form-group
+        = label_tag 'Subject'
+        =  text_field_tag "api_namespace[#{type}_attributes][#{index}][email_subject]", resource.email_subject, { class: "form-control form-control-sm" }
+
       .form-group
         = label_tag 'Custom Message'
         = rich_text_area_tag "api_namespace[#{type}_attributes][#{index}][custom_message]", resource.custom_message, { class: "form-control form-control-sm" }
+
 
     .redirect.col-12{style: "#{'display:none' unless resource.action_type == 'redirect'}", id: "redirect_fields_#{type}_#{index}"}
       .form-group
@@ -31,17 +58,21 @@
       .form-group
         = label_tag 'Request Url'
         = text_field_tag "api_namespace[#{type}_attributes][#{index}][request_url]", resource.request_url, { class: "form-control form-control-sm" }
+
       .form-group
         = label_tag 'HTTP method'
         = select_tag "api_namespace[#{type}_attributes][#{index}][http_method]", options_for_select(ApiAction::HTTP_METHODS, resource.http_method), { class: "form-control form-control-sm"}
+        
       .form-group
         = label_tag 'Request body'
         .js-jsoneditor{id: "payload_mapping_#{type}_#{index}-editor", 'data-field-id': "api_namespace_#{type}_attributes_#{index}_payload_mapping"}
         = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][payload_mapping]", resource.payload_mapping ? resource.payload_mapping.to_json : nil
+
       .form-group
         = label_tag 'Headers'
         .js-jsoneditor{id: "custom_headers_#{type}_#{index}-editor", 'data-field-id': "api_namespace_#{type}_attributes_#{index}_custom_headers"}
         = hidden_field_tag "api_namespace[#{type}_attributes][#{index}][custom_headers]", resource.custom_headers ? resource.custom_headers.to_json : nil
+
       .form-group
         = label_tag 'Bearer Token'
         = text_field_tag "api_namespace[#{type}_attributes][#{index}][bearer_token]", resource.bearer_token, { class: "form-control form-control-sm" }

--- a/app/views/comfy/admin/api_actions/action_workflow.html.haml
+++ b/app/views/comfy/admin/api_actions/action_workflow.html.haml
@@ -1,6 +1,8 @@
 .page-header.mb-5
   .h2
-    Api Actions > Action Workflow
+    = @api_namespace.name.pluralize
+    > API Actions
+    > Workflow
 
 = form_for @api_namespace, html: {multipart: true} do |f|
   = hidden_field_tag 'source', 'action_workflow'

--- a/app/views/comfy/admin/api_actions/index.html.haml
+++ b/app/views/comfy/admin/api_actions/index.html.haml
@@ -1,8 +1,7 @@
 .d-flex.justify-content-between.page-header.pb-3.mb-4
   %h2
-    Listing
     =  @api_namespace.name.pluralize
-    > Api Actions
+    > API Actions
   %div
     = link_to 'Action Workflow', action_workflow_api_namespace_api_actions_path(api_namespace_id: @api_namespace.id), class: 'btn btn-primary'
 = render partial: 'comfy/admin/api_actions/search_filters', locals: { objects: @api_actions_q, path: api_namespace_api_actions_path(api_namespace_id: @api_namespace.id) }

--- a/app/views/comfy/admin/api_actions/show.html.haml
+++ b/app/views/comfy/admin/api_actions/show.html.haml
@@ -8,11 +8,11 @@
       .col-12.d-flex.mb-3
         .mr-3
           Request Url:
-        = @api_action.request_url
+        = @api_action.request_url_evaluated
       .col-12.d-flex.mb-3
         .mr-3
           Payload: 
-        = @api_action.payload_mapping
+        = @api_action.payload_mapping_evaluated
     
     - if @api_action.action_type == 'redirect'
       .col-12.d-flex.mb-3
@@ -23,11 +23,15 @@
       .col-12.d-flex.mb-3
         .mr-3
           Email:
-        = @api_action.email
+        = @api_action.email_evaluated
+      .col-12.d-flex.mb-3
+        .mr-3
+          Email Subject:
+        = @api_action.email_subject_evaluated
       .col-12.d-flex.mb-3
         .mr-3
           Custom message:
-        = @api_action.custom_message
+        = @api_action.custom_message_evaluated
       .col-12.d-flex.mb-3
         .mr-3
           Include resource:

--- a/app/views/comfy/admin/api_namespaces/show.html.haml
+++ b/app/views/comfy/admin/api_namespaces/show.html.haml
@@ -36,7 +36,7 @@
   #interface.tab-pane.fade.show.active{"aria-labelledby" => "interface-tab", :role => "tabpanel"} 
     .card.p-3
       .card-title
-        = link_to 'Api Actions', api_namespace_api_actions_path(api_namespace_id: @api_namespace.id), class: 'btn btn-primary'
+        = link_to 'API Actions', api_namespace_api_actions_path(api_namespace_id: @api_namespace.id), class: 'btn btn-primary'
       %p
         %b Requires authentication:
         = @api_namespace.requires_authentication

--- a/app/views/comfy/admin/api_resources/show.html.haml
+++ b/app/views/comfy/admin/api_resources/show.html.haml
@@ -10,7 +10,7 @@
 = render 'comfy/admin/api_namespaces/init_editor', {read_only: true}
 
 .my-3
-  = link_to 'Api Actions', api_namespace_api_actions_path(api_namespace_id: @api_resource.api_namespace_id, 'q[api_resource_id_eq]': @api_resource.id)
+  = link_to 'API Actions', api_namespace_api_actions_path(api_namespace_id: @api_resource.api_namespace_id, 'q[api_resource_id_eq]': @api_resource.id)
 
 .my-5
   = link_to 'Destroy', api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id, id: @api_resource.id), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'

--- a/app/views/comfy/admin/external_api_clients/index.html.haml
+++ b/app/views/comfy/admin/external_api_clients/index.html.haml
@@ -1,29 +1,29 @@
-%h1 Listing External API Connections
-
-%table
-  %thead
-    %tr
-      %th Label
-      %th Slug
-      %th Active
-      %th Drive Strategy
-      %th Max Requests / Minute
-      %th
-      %th
-      %th
-
-  %tbody
-    - @external_api_clients.each do |external_api_client|
+.container-fluid.mt-5
+  .d-flex.justify-content-between.py-2.page-header
+    %h2
+      =  @api_namespace.name.pluralize
+      > External API Connections
+  
+  %table{class: 'table my-5 table-responsive'}
+    %thead
       %tr
-        %td= external_api_client.label
-        %td= external_api_client.slug
-        %td= external_api_client.enabled
-        %td= external_api_client.drive_strategy
-        %td= external_api_client.max_requests_per_minute
-        %td= link_to 'Show', api_namespace_external_api_client_path(api_namespace_id: external_api_client.api_namespace.id, id: external_api_client.id)
-        %td= link_to 'Edit', edit_api_namespace_external_api_client_path(api_namespace_id: external_api_client.api_namespace.id, id: external_api_client.id)
-        %td= link_to 'Destroy', api_namespace_external_api_client_path(api_namespace_id: external_api_client.api_namespace.id, id: external_api_client.id), method: :delete, data: { confirm: 'Are you sure?' }
+        %th.px-3 Label
+        %th.px-3 Slug
+        %th.px-3 Active
+        %th.px-3 Drive Strategy
+        %th.px-3
+        %th.px-3
 
-%br
+    %tbody
+      - @external_api_clients.each do |external_api_client|
+        %tr
+          %td.px-3= link_to external_api_client.label, api_namespace_external_api_client_path(api_namespace_id: external_api_client.api_namespace.id, id: external_api_client.id)
+          %td.px-3= external_api_client.slug
+          %td.px-3= external_api_client.enabled
+          %td.px-3= external_api_client.drive_strategy
+          %td.px-3= link_to 'Edit', edit_api_namespace_external_api_client_path(api_namespace_id: external_api_client.api_namespace.id, id: external_api_client.id)
+          %td.px-3= link_to 'Destroy', api_namespace_external_api_client_path(api_namespace_id: external_api_client.api_namespace.id, id: external_api_client.id), method: :delete, data: { confirm: 'Are you sure?' }
 
-= link_to 'New Api client', new_api_namespace_external_api_client_path
+  %br
+
+  = link_to 'New External API Connection', new_api_namespace_external_api_client_path

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,9 +59,8 @@ Rails.application.configure do
   config.assets.debug = true
 
 
-  config.hosts << "*.lvh.me"
-  config.hosts << "lvh.me"
-  config.hosts << "violet.ngrok.io"
+  config.hosts = nil
+  
   
   config.action_mailer.default_url_options = { host: ENV['APP_HOST'] }
   config.action_mailer.perform_deliveries = true 

--- a/db/migrate/20220609092515_add_email_subject_to_api_actions.rb
+++ b/db/migrate/20220609092515_add_email_subject_to_api_actions.rb
@@ -1,0 +1,5 @@
+class AddEmailSubjectToApiActions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_actions, :email_subject, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_09_041057) do
+ActiveRecord::Schema.define(version: 2022_06_09_092515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2022_06_09_041057) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "custom_headers"
     t.string "http_method"
+    t.text "email_subject"
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end

--- a/test/models/api_action_test.rb
+++ b/test/models/api_action_test.rb
@@ -18,4 +18,54 @@ class ApiActionTest < ActiveSupport::TestCase
     assert_equal api_action.reload.lifecycle_stage, 'failed'
     assert_equal api_action.reload.lifecycle_message, 'error response'
   end
+
+  test 'should respond to dynamically generated method' do
+    api_resource = api_resources(:one)
+
+    expected_response = {
+      email_subject: "API Resource Accessed #{api_resource.id}",
+      custom_message: "<div class=\"trix-content\">\n  API Namespace Accessed #{api_resource.api_namespace.id}\n</div>\n",
+      request_url: "API Resource Property Accessed  #{api_resource.properties['can_edit']}",
+      payload_mapping: {
+        test_key: "#{api_resource.id}"
+  }.to_json
+    }
+
+    api_action = ApiAction.new(
+      api_resource_id: api_resource.id,
+      email_subject: "API Resource Accessed \#{api_resource.id}",
+      custom_message: "API Namespace Accessed \#{api_resource.api_namespace.id}",
+      request_url: "API Resource Property Accessed  \#{api_resource.properties['can_edit']}",
+      payload_mapping: {
+        test_key: "\#{api_resource.id}"
+      }
+    )
+    assert api_action.valid?
+    [:email_subject, :custom_message, :request_url, :payload_mapping].each do |dynamic_attr|
+      assert_respond_to api_action, "#{dynamic_attr}_evaluated".to_sym
+      assert_equal api_action.send("#{dynamic_attr}_evaluated".to_sym), expected_response[dynamic_attr]
+    end
+  end
+
+  test 'should raise error if unsafe string is evaluted' do
+    api_resource = api_resources(:one)
+
+    api_action = ApiAction.new(
+      api_resource_id: api_resource.id,
+      email_subject: "API Resource Accessed \#{api_resource.id}",
+      custom_message: "API Namespace Accessed \#{api_resource.api_namespace.id}",
+      request_url: "API Resource Property Accessed  \#{api_resource.properties['can_edit']}",
+      email: "test\#{api_resource.id}@test.com",
+      payload_mapping: {
+        test_key: "\#{User.destroy_all}"
+      }
+    )
+    refute api_action.valid?
+
+    [:email, :email_subject, :custom_message, :request_url, :payload_mapping].each do |dynamic_attr|
+      assert_raises ActiveRecord::RecordInvalid do
+        api_action.send("#{dynamic_attr}_evaluated".to_sym)
+      end
+    end
+  end
 end

--- a/test/models/concerns/dynamic_attribute_test.rb
+++ b/test/models/concerns/dynamic_attribute_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class DynamicAttributeTest < ActiveSupport::TestCase
+  setup do
+    # test concern in isolation
+    @dummy_class = Class.new do
+      include ActiveModel::Model
+
+      def self.name
+        'Test'
+      end
+
+      def initialize(test_column: nil)
+          @test_column = test_column
+      end
+
+      include ActiveModel::Validations
+      include DynamicAttribute
+      attr_accessor :test_column
+      attr_accessor :api_resource
+
+      attr_dynamic :test_column
+    end
+  end  
+
+  test 'should respond to dynamic methods if dynamic field is safe' do
+    safe_instance = @dummy_class.new(test_column: "Test \#{1 + 1}")
+    assert safe_instance.valid?
+    assert_respond_to safe_instance, :test_column_evaluated
+    assert_equal safe_instance.test_column_evaluated, 'Test 2'
+  end
+
+
+  test 'should raise invalid record error dynamic field contains unsafe string' do
+    unsafe_instance = @dummy_class.new(test_column: "Test \#{User.destroy_all}")
+    refute unsafe_instance.valid?
+    assert_no_difference "User.all.size" do
+      assert_raises ActiveRecord::RecordInvalid do
+        unsafe_instance.test_column_evaluated
+      end
+    end
+  end
+end

--- a/test/models/external_api_client_test.rb
+++ b/test/models/external_api_client_test.rb
@@ -103,7 +103,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     invalid_model_definations.each do |invalid_executable|
       external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: invalid_executable)
       refute external_api_client.valid?
-      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains disallowed keyword'
     end
   end
 
@@ -113,7 +113,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     User::PRIVATE_ATTRIBUTES.each do |private_attr|
       external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: "User.last.#{private_attr}")
       refute external_api_client.valid?
-      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains disallowed keyword'
     end
   end
 
@@ -123,7 +123,7 @@ class ExternalApiClientTest < ActiveSupport::TestCase
     User::FULL_PERMISSIONS.keys.each do |permission_attr|
       external_api_client = ExternalApiClient.new(api_namespace_id: api_namespace.id, model_definition: "User.last.update(#{permission_attr} => false)")
       refute external_api_client.valid?
-      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains blacklisted keyword'
+      assert_includes external_api_client.errors.messages[:model_definition].to_s, 'contains disallowed keyword'
     end
   end
 end


### PR DESCRIPTION
# Dynamic segments in API Actions

This change adds dynamic segments in Email and Web Request Actions in the API Namespace / API Actions sub-systems.

addresses: https://github.com/restarone/violet_rails/issues/653


addresses: https://github.com/restarone/violet_rails/issues/652

upgrade path: https://github.com/restarone/violet_rails/issues/836


# Feature Showcase

## Dynamic Emails
Given a simple form like this: 
![Screenshot from 2022-07-03 14-27-25](https://user-images.githubusercontent.com/35935196/177052592-099d22f2-5df7-4f19-b8f7-3178275d3a82.png)



an email like this is triggered: 
![Screenshot from 2022-07-03 14-24-27](https://user-images.githubusercontent.com/35935196/177052558-041538fb-82f3-4caf-b9f0-05b1463c6810.png)

the system will generate the email message: 
![Screenshot from 2022-07-03 14-25-07](https://user-images.githubusercontent.com/35935196/177052571-614f4cd4-1596-4d44-a16c-fd63a68caef1.png)

## Dynamic HTTP requests
Now you have dynamic segments in the request URL
<img width="1728" alt="Screen Shot 2022-07-04 at 9 30 47 AM" src="https://user-images.githubusercontent.com/35935196/177165487-90c086c5-99d1-427f-b993-76d24cf375ad.png">

## View evaluated work
Every API Action is tracked by Violet Rails, and you can see what the system did after it evaluated your code. 

<img width="1728" alt="Screen Shot 2022-07-04 at 9 39 22 AM" src="https://user-images.githubusercontent.com/35935196/177167635-f5a9aaf6-27dd-4006-9d83-c1f3d836fefc.png">

The above action  resulted in the following email: 

<img width="710" alt="Screen Shot 2022-07-04 at 9 41 11 AM" src="https://user-images.githubusercontent.com/35935196/177167633-b82be549-8f10-4a4d-a2ac-c86892e20150.png">

The same evaluation rules apply to HTTP actions, so you can see exactly what was sent to external systems -- for example: 
<img width="1728" alt="Screen Shot 2022-07-04 at 2 20 45 PM" src="https://user-images.githubusercontent.com/35935196/177203674-f9fe391f-67d4-4d6b-bf19-77c00466e0eb.png">


