### PR TITLE
[bug fix] Cannot define a custom success/fail message without setting up a redirect action

### DIFF
--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -29,7 +29,8 @@ module ApiActionable
   end
 
   def handle_redirection
-    flash[:notice] = @api_namespace.api_form.success_message
+    flash[:notice] = @api_namespace.api_form.success_message || 'Api resource was successfully updated.'
+
     if @redirect_action.present?
       if @redirect_action.update!(lifecycle_stage: 'complete', lifecycle_message: @redirect_action.redirect_url.to_s)
         redirect_to @redirect_action.redirect_url and return
@@ -39,7 +40,7 @@ module ApiActionable
       end
     end
 
-    redirect_back(fallback_location: root_path, notice: "Api resource was successfully updated.")
+    redirect_back(fallback_location: root_path)
   end
 
   def execute_api_actions

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -191,4 +191,80 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
     end
   end
+
+  test 'should allow #create and show the custom success message' do
+    api_namespace = api_namespaces(:one)
+    api_namespace.api_form.update(success_message: 'test success message')
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "api_namespace.api_resources.count", +1 do
+      post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+
+    assert_equal 'test success message', flash[:notice]
+    refute flash[:error]
+  end
+
+  test 'should allow #create and show the custom success message even if no redirect action is defined' do
+    api_namespace = api_namespaces(:one)
+    api_namespace.api_form.update(success_message: 'test success message')
+    api_namespace.api_actions.where(type: 'CreateApiAction', action_type: 'redirect').destroy_all
+
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "api_namespace.api_resources.count", +1 do
+      post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+
+    assert_equal 'test success message', flash[:notice]
+    refute flash[:error]
+  end
+
+  test 'should deny #create and show the custom failure message' do
+    api_namespace = api_namespaces(:one)
+    api_namespace.api_form.update(failure_message: 'test failure message', properties: { 'name': {'label': 'name', 'placeholder': 'Name', 'field_type': 'input', 'required': '1' } })
+    payload = {
+      data: {
+          properties: {
+            name: '',
+          }
+      }
+    }
+    assert_no_difference "api_namespace.api_resources.count" do
+      post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+
+    assert_equal 'test failure message', flash[:error]
+    refute flash[:notice]
+  end
+
+  test 'should deny #create and show the custom failure message even if no redirect action is defined' do
+    api_namespace = api_namespaces(:one)
+    api_namespace.api_form.update(failure_message: 'test failure message', properties: { 'name': {'label': 'name', 'placeholder': 'Name', 'field_type': 'input', 'required': '1' } })
+    api_namespace.api_actions.where(type: 'CreateApiAction', action_type: 'redirect').destroy_all
+
+    payload = {
+      data: {
+          properties: {
+            name: '',
+          }
+      }
+    }
+    assert_no_difference "api_namespace.api_resources.count" do
+      post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+
+    assert_equal 'test failure message', flash[:error]
+    refute flash[:notice]
+  end
 end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/789