### PR TITLE
[feature] Allow dynamic segment in api redirect action 

### DIFF
--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -156,7 +156,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
-      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email, :email_subject, :custom_message, :payload_mapping, :request_url, :redirect_url, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
+      api_actions_attributes =  [:id, :trigger, :action_type, :properties, :include_api_resource_data, :email, :email_subject, :custom_message, :payload_mapping, :request_url, :redirect_url, :redirect_type, :bearer_token, :file_snippet, :position, :custom_headers, :http_method, :_destroy]
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,

--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -40,11 +40,11 @@ module ApiActionable
     flash[:notice] = @api_namespace.api_form.success_message || 'Api resource was successfully updated.'
 
     if @redirect_action.present?
-      if @redirect_action.update!(lifecycle_stage: 'complete', lifecycle_message: @redirect_action.redirect_url.to_s)
-        redirect_url = @redirect_action.dynamic_url? ? @redirect_action.redirect_url_evaluated : @redirect_action.redirect_url
+      redirect_url = @redirect_action.dynamic_url? ? @redirect_action.redirect_url_evaluated : @redirect_action.redirect_url
+      if @redirect_action.update!(lifecycle_stage: 'complete', lifecycle_message: redirect_url)
         redirect_to redirect_url and return
       else
-        @redirect_action.update!(lifecycle_stage: 'failed', lifecycle_message: @redirect_action.redirect_url.to_s)
+        @redirect_action.update!(lifecycle_stage: 'failed', lifecycle_message: redirect_url)
         execute_error_actions
       end
     end

--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -11,7 +11,7 @@ module ApiActionable
 
   def check_for_redirect_action
     @redirect_action = if @api_resource.present?
-                        @api_resource.send(api_action_name).where(action_type: 'redirect', lifecycle_stage: 'initialized').last
+                        @api_resource.send(api_action_name).where(action_type: 'redirect').reorder(:created_at).last
                       else
                         @api_namespace.send(api_action_name).where(action_type: 'redirect').last
                       end
@@ -19,7 +19,7 @@ module ApiActionable
 
   def check_for_serve_file_action
     serve_file_action = if @api_resource.present?
-                        @api_resource.send(api_action_name).where(action_type: 'serve_file', lifecycle_stage: 'initialized').last
+                        @api_resource.send(api_action_name).where(action_type: 'serve_file').reorder(:created_at).last
                       else
                         @api_namespace.send(api_action_name).where(action_type: 'serve_file').last
                       end

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -7,6 +7,7 @@ class ResourceController < ApplicationController
     @api_resource = @api_namespace.api_resources.new(resource_params)
     if @api_namespace&.api_form&.show_recaptcha
       if verify_recaptcha(model: @api_resource) && @api_resource.save
+        load_api_actions_from_api_resource
         handle_redirection
       else
         execute_error_actions
@@ -15,6 +16,7 @@ class ResourceController < ApplicationController
       end
     elsif @api_namespace&.api_form&.show_recaptcha_v3
       if verify_recaptcha(model: @api_resource, action: helpers.sanitize_recaptcha_action_name(@api_namespace.name), minimum_score: ApiForm::RECAPTCHA_V3_MINIMUM_SCORE, secret_key: ENV['RECAPTCHA_SECRET_KEY_V3']) && @api_resource.save
+        load_api_actions_from_api_resource
         handle_redirection
       else
         execute_error_actions
@@ -22,6 +24,7 @@ class ResourceController < ApplicationController
         redirect_back(fallback_location: root_path)
       end
     elsif @api_resource.save
+      load_api_actions_from_api_resource
       handle_redirection
     else
       execute_error_actions

--- a/app/models/api_action.rb
+++ b/app/models/api_action.rb
@@ -4,7 +4,7 @@ class ApiAction < ApplicationRecord
   include DynamicAttribute
 
   attr_encrypted :bearer_token
-  attr_dynamic :email, :email_subject, :custom_message, :payload_mapping, :request_url
+  attr_dynamic :email, :email_subject, :custom_message, :payload_mapping, :request_url, :redirect_url
 
   after_update :update_executed_actions_payload, if: Proc.new { api_namespace.present? && saved_change_to_payload_mapping? }
 
@@ -14,6 +14,8 @@ class ApiAction < ApplicationRecord
   enum action_type: { send_email: 0, send_web_request: 1, redirect: 2, serve_file: 3 }
 
   enum lifecycle_stage: {initialized: 0, executing: 1, complete: 2, failed: 3, discarded: 4}
+  
+  enum redirect_type: { cms_page: 0, dynamic_url: 1 }
 
   HTTP_METHODS = ['get', 'post', 'patch', 'put', 'delete']
   
@@ -26,6 +28,7 @@ class ApiAction < ApplicationRecord
   validates :http_method, inclusion: { in: ApiAction::HTTP_METHODS}, allow_blank: true
   
   validates :payload_mapping, safe_executable: true
+  validates :redirect_url, safe_executable: true, if: Proc.new { self.redirect? && self.dynamic_url? }
 
   def self.children
     ['new_api_actions', 'create_api_actions', 'show_api_actions', 'update_api_actions', 'destroy_api_actions', 'error_api_actions']

--- a/app/models/api_action.rb
+++ b/app/models/api_action.rb
@@ -28,7 +28,6 @@ class ApiAction < ApplicationRecord
   validates :http_method, inclusion: { in: ApiAction::HTTP_METHODS}, allow_blank: true
   
   validates :payload_mapping, safe_executable: true
-  validates :redirect_url, safe_executable: true, if: Proc.new { self.redirect? && self.dynamic_url? }
 
   def self.children
     ['new_api_actions', 'create_api_actions', 'show_api_actions', 'update_api_actions', 'destroy_api_actions', 'error_api_actions']

--- a/app/models/concerns/dynamic_attribute.rb
+++ b/app/models/concerns/dynamic_attribute.rb
@@ -6,6 +6,7 @@
 
 module DynamicAttribute
     extend ActiveSupport::Concern
+    include Rails.application.routes.url_helpers
 
     included do
       def parse_dynamic_attribute(value)

--- a/app/models/concerns/dynamic_attribute.rb
+++ b/app/models/concerns/dynamic_attribute.rb
@@ -25,7 +25,8 @@ module DynamicAttribute
 
       def attribute_value_string(attribute)
         value = public_send(attribute.to_sym)
-        value.is_a?(Enumerable) ? value.to_json : value.to_s
+        # Deep copy of non-enumerable column like string-type would get passed and the evaluated value would get reflected as change.
+        value.is_a?(Enumerable) ? value.to_json : value.to_s.dup
       end
     end
   

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -6,7 +6,7 @@
     .form-group.col-12
       = label_tag "Action"
       = select_tag "api_namespace[#{type}_attributes][#{index}][action_type]", options_for_select(ApiAction.action_types.keys, resource.action_type), { class: "form-control form-control-sm", id: "action_type_field_#{type}_#{index}", onchange: "toggleApiActionFields('#{index}', '#{type}');"}
-      - if resource.action_type == 'send_email' || resource.action_type == 'send_web_request'
+      .extra-details{ style: "#{'display: none' unless (resource.send_email? || resource.send_web_request? || (resource.redirect? && resource.dynamic_url?))}"}
         .form-group.my-2
           .d-block
             %strong Top-Level Model Attributes: 
@@ -19,11 +19,20 @@
               %strong Last API Resource Instance Attributes: 
               .d-block
                 = last_instance.properties.keys
-          .d-block
-            %small
-              Dynamic:
-              %code
-                \\#{api_resource.properties['your_custom_attribute_here']} 
+        .mt-2.non-redirect-fields-guide{ style: "#{'display: none' if (resource.redirect? && resource.dynamic_url?)}"}
+          %small
+            Dynamic:
+            %code
+              \\#{api_resource.properties['your_custom_attribute_here']}
+        .mt-2.redirect-field-guide{ style: "#{'display: none' unless (resource.redirect? && resource.dynamic_url?)}"}
+          %small.d-block
+            %strong
+              Available Variables:
+            api_resource, rails-route-helpers (example: root_path)
+          %small.d-block
+            Dynamic:
+            %code
+              \\#{ api_resource.properties['your_custom_attribute_here'] == 'true' ? rooth_path : some_other_path } 
 
     .send_email.col-12{style: "#{'display:none' unless resource.action_type == 'send_email'}", id: "send_email_fields_#{type}_#{index}"}
       .form-group
@@ -109,6 +118,7 @@
 
     $("input[type='radio'][name='api_namespace[#{type}_attributes][#{index}][redirect_type]']").on('click', function () {
       toggleRedirectInputField(this);
+      toggleDynamicRedirectUrlGuide(this);
     })
 
     $("input[type='radio'][name='api_namespace[#{type}_attributes][#{index}][redirect_type]']").each(function () {
@@ -127,6 +137,19 @@
       targetFormGroup.find('span.select-field').hide();
       targetFormGroup.find('input[type="text"]').show();
       targetFormGroup.find('input[type="text"]').attr('disabled', false);
+    }
+  }
+
+  function toggleDynamicRedirectUrlGuide(element) {
+    const extraDetailsContainer = $(element).parents('.card').find('.extra-details');
+    if ($(element).val() == 'cms_page' && $(element).is(':checked')) {
+      extraDetailsContainer.hide();
+      extraDetailsContainer.find('.non-redirect-fields-guide').show();
+      extraDetailsContainer.find('.redirect-field-guide').hide();
+    } else if ($(element).val() == 'dynamic_url' && $(element).is(':checked')) {
+      extraDetailsContainer.show();
+      extraDetailsContainer.find('.non-redirect-fields-guide').hide();
+      extraDetailsContainer.find('.redirect-field-guide').show();
     }
   }
 

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -46,8 +46,18 @@
 
     .redirect.col-12{style: "#{'display:none' unless resource.action_type == 'redirect'}", id: "redirect_fields_#{type}_#{index}"}
       .form-group
+        = label_tag 'Redirect Type', nil, class: 'd-block'
+        = label_tag "api_namespace[#{type}_attributes][#{index}][redirect_type]", 'cms_page'
+        = radio_button_tag "api_namespace[#{type}_attributes][#{index}][redirect_type]", 'cms_page', resource.cms_page?
+        = label_tag "api_namespace[#{type}_attributes][#{index}][redirect_type]", 'dynamic_url'
+        = radio_button_tag "api_namespace[#{type}_attributes][#{index}][redirect_type]", 'dynamic_url', resource.dynamic_url?
+
+      .form-group
         = label_tag 'Redirect Url'
-        = select_tag "api_namespace[#{type}_attributes][#{index}][redirect_url]", options_for_select((system_paths << resource.redirect_url).uniq), {class: "form-control form-control-sm path_select", default_value: resource.redirect_url}
+        -# Parent: <span> is used beacause select2 adds other adjacent elements as well.
+        %span.select-field{style: "#{'display:none' if resource.cms_page?}"}
+          = select_tag "api_namespace[#{type}_attributes][#{index}][redirect_url]", options_for_select((system_paths << resource.redirect_url).uniq), {class: "form-control form-control-sm path_select", default_value: resource.redirect_url}
+        = text_field_tag "api_namespace[#{type}_attributes][#{index}][redirect_url]", resource.redirect_url, { class: "form-control form-control-sm", style: "#{'display:none' if resource.dynamic_url?}" }
 
     .serve_file.col-12{style: "#{'display:none' unless resource.action_type == 'serve_file'}", id: "serve_file_fields_#{type}_#{index}"}
       .form-group
@@ -96,7 +106,29 @@
     $('.path_select').each(function() {
       $(this).val($(this).attr('default_value')).change();
     })
+
+    $("input[type='radio'][name='api_namespace[#{type}_attributes][#{index}][redirect_type]']").on('click', function () {
+      toggleRedirectInputField(this);
+    })
+
+    $("input[type='radio'][name='api_namespace[#{type}_attributes][#{index}][redirect_type]']").each(function () {
+      toggleRedirectInputField(this);
+    })
   });
+
+  function toggleRedirectInputField(element) {
+    const targetFormGroup = $(element).parent().next();
+    if ($(element).val() == 'cms_page' && $(element).is(':checked')) {
+      targetFormGroup.find('span.select-field').show();
+      targetFormGroup.find('input[type="text"]').hide();
+      // Disabling text field otherwise it's value will override the select field's value
+      targetFormGroup.find('input[type="text"]').attr('disabled', true);
+    } else if ($(element).val() == 'dynamic_url' && $(element).is(':checked')) {
+      targetFormGroup.find('span.select-field').hide();
+      targetFormGroup.find('input[type="text"]').show();
+      targetFormGroup.find('input[type="text"]').attr('disabled', false);
+    }
+  }
 
   function #{type}_#{index}_initializeJsonEditor(containerId, fieldId) {
     const container = document.getElementById(containerId)

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -20,16 +20,20 @@
               .d-block
                 = last_instance.properties.keys
         .mt-2.non-redirect-fields-guide{ style: "#{'display: none' if (resource.redirect? && resource.dynamic_url?)}"}
-          %small
+          .d-block
             Dynamic:
             %code
               \\#{api_resource.properties['your_custom_attribute_here']}
         .mt-2.redirect-field-guide{ style: "#{'display: none' unless (resource.redirect? && resource.dynamic_url?)}"}
-          %small.d-block
+          .d-block
+            %strong
+              Dynamic Fields:
+            Request Url, Request Body, Headers
+          .d-block
             %strong
               Available Variables:
-            api_resource, rails-route-helpers (example: comfy_admin_cms_path)
-          %small.d-block
+            api_resource, current_user, current_visit, rails-route-helpers (example: comfy_admin_cms_path)
+          .d-block
             Dynamic:
             %code
               \\#{ api_resource.properties['your_custom_attribute_here'] == 'true' ? comfy_admin_cms_path : some_other_path } 

--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -28,11 +28,11 @@
           %small.d-block
             %strong
               Available Variables:
-            api_resource, rails-route-helpers (example: root_path)
+            api_resource, rails-route-helpers (example: comfy_admin_cms_path)
           %small.d-block
             Dynamic:
             %code
-              \\#{ api_resource.properties['your_custom_attribute_here'] == 'true' ? rooth_path : some_other_path } 
+              \\#{ api_resource.properties['your_custom_attribute_here'] == 'true' ? comfy_admin_cms_path : some_other_path } 
 
     .send_email.col-12{style: "#{'display:none' unless resource.action_type == 'send_email'}", id: "send_email_fields_#{type}_#{index}"}
       .form-group

--- a/app/views/comfy/admin/api_actions/action_workflow.html.haml
+++ b/app/views/comfy/admin/api_actions/action_workflow.html.haml
@@ -28,24 +28,25 @@
     = f.submit 'Save'
 
 :javascript
+  const guideClassNames = ['.non-redirect-fields-guide', '.redirect-field-guide'];
+
   function toggleApiActionFields(index, type) {
     var fieldType = $("#action_type_field_" + type + '_' + index).val();
     hideAllFields(index, type)
     if (fieldType === 'send_email') {
       $("#send_email_fields_" + type + '_' + index).show();
-      $("#send_email_fields_" + type + '_' + index).parents('.card').find('.extra-details').show();
+      showRelatedExtraDetails($("#send_email_fields_" + type + '_' + index), '.non-redirect-fields-guide');
     } else if (fieldType === 'redirect') {
       $("#redirect_fields_" + type + '_' + index).show();
       if ($('#api_namespace_' + type + '_attributes_' + index + '_redirect_type_dynamic_url').is(':checked')) {
-        $("#redirect_fields_" + type + '_' + index).parents('.card').find('.extra-details').show();
-        $("#redirect_fields_" + type + '_' + index).parents('.card').find('.extra-details').find('.non-redirect-fields-guide').hide();
-        $("#redirect_fields_" + type + '_' + index).parents('.card').find('.extra-details').find('.redirect-field-guide').show();
+        showRelatedExtraDetails($("#redirect_fields_" + type + '_' + index), '.redirect-field-guide');
       }
     } else if (fieldType === 'serve_file') {
       $("#serve_file_fields_" + type + '_' + index).show();
     } else if (fieldType === 'send_web_request') {
       $("#serve_web_request_fields_" + type + '_' + index).show();
       $("#serve_web_request_fields_" + type + '_' + index).parents('.card').find('.extra-details').show();
+      showRelatedExtraDetails($("#serve_web_request_fields_" + type + '_' + index), '.non-redirect-fields-guide');
     }
   }
 
@@ -58,8 +59,6 @@
     // Hiding the extra-details section and resetting the inline-documentation part.
     // The parent of all fields (send-email/redirect/send-web-request/serve-file) is same.
     $("#serve_web_request_fields_" + type + '_' + index).parents('.card').find('.extra-details').hide();
-    $("#serve_web_request_fields_" + type + '_' + index).parents('.card').find('.extra-details').find('.non-redirect-fields-guide').show();
-    $("#serve_web_request_fields_" + type + '_' + index).parents('.card').find('.extra-details').find('.redirect-field-guide').hide();
   }
 
   function removeForm(form_id, destroy_field_id) {
@@ -76,6 +75,19 @@
       dataType: 'script',
       contentType: "application/html",
       success: function(response) {}
+    });
+  }
+
+  function showRelatedExtraDetails(element, actionType) {
+    $(element).parents('.card').find('.extra-details').show();
+
+    // Showing the required guide according to actionType
+    guideClassNames.forEach(function(className) {
+      if (actionType == className) {
+        $(element).parents('.card').find('.extra-details').find(className).show();
+      } else {
+        $(element).parents('.card').find('.extra-details').find(className).hide();
+      }
     });
   }
   

--- a/app/views/comfy/admin/api_actions/action_workflow.html.haml
+++ b/app/views/comfy/admin/api_actions/action_workflow.html.haml
@@ -33,12 +33,19 @@
     hideAllFields(index, type)
     if (fieldType === 'send_email') {
       $("#send_email_fields_" + type + '_' + index).show();
+      $("#send_email_fields_" + type + '_' + index).parents('.card').find('.extra-details').show();
     } else if (fieldType === 'redirect') {
       $("#redirect_fields_" + type + '_' + index).show();
+      if ($('#api_namespace_' + type + '_attributes_' + index + '_redirect_type_dynamic_url').is(':checked')) {
+        $("#redirect_fields_" + type + '_' + index).parents('.card').find('.extra-details').show();
+        $("#redirect_fields_" + type + '_' + index).parents('.card').find('.extra-details').find('.non-redirect-fields-guide').hide();
+        $("#redirect_fields_" + type + '_' + index).parents('.card').find('.extra-details').find('.redirect-field-guide').show();
+      }
     } else if (fieldType === 'serve_file') {
       $("#serve_file_fields_" + type + '_' + index).show();
     } else if (fieldType === 'send_web_request') {
       $("#serve_web_request_fields_" + type + '_' + index).show();
+      $("#serve_web_request_fields_" + type + '_' + index).parents('.card').find('.extra-details').show();
     }
   }
 
@@ -47,6 +54,12 @@
     $("#redirect_fields_" + type + '_'  + index).hide();
     $("#serve_file_fields_" + type + '_' + index).hide();
     $("#serve_web_request_fields_" + type + '_' + index).hide();
+
+    // Hiding the extra-details section and resetting the inline-documentation part.
+    // The parent of all fields (send-email/redirect/send-web-request/serve-file) is same.
+    $("#serve_web_request_fields_" + type + '_' + index).parents('.card').find('.extra-details').hide();
+    $("#serve_web_request_fields_" + type + '_' + index).parents('.card').find('.extra-details').find('.non-redirect-fields-guide').show();
+    $("#serve_web_request_fields_" + type + '_' + index).parents('.card').find('.extra-details').find('.redirect-field-guide').hide();
   }
 
   function removeForm(form_id, destroy_field_id) {

--- a/app/views/comfy/admin/api_actions/show.html.haml
+++ b/app/views/comfy/admin/api_actions/show.html.haml
@@ -19,6 +19,10 @@
         .mr-3
           Redirect Url:
         = @api_action.redirect_url
+      .col-12.d-flex.mb-3
+        .mr-3
+          Redirect Type:
+        = @api_action.redirect_type
     - if @api_action.action_type == 'send_email'
       .col-12.d-flex.mb-3
         .mr-3

--- a/db/migrate/20220707090412_add_redirect_type_to_api_actions.rb
+++ b/db/migrate/20220707090412_add_redirect_type_to_api_actions.rb
@@ -1,0 +1,5 @@
+class AddRedirectTypeToApiActions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_actions, :redirect_type, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_28_050113) do
+ActiveRecord::Schema.define(version: 2022_07_07_090412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 2022_06_28_050113) do
     t.jsonb "custom_headers"
     t.string "http_method"
     t.text "email_subject"
+    t.integer "redirect_type", default: 0
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -208,10 +208,13 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       actions_count = @api_namespace.create_api_actions.size
       assert_difference "@api_namespace.executed_api_actions.count", actions_count do
         post api_namespace_resource_index_url(api_namespace_id: @api_namespace.id, params: payload)
-        assert_response :redirect
-        assert_redirected_to api_namespaces_path
       end
     end
+
+    assert_response :redirect
+    assert_redirected_to api_namespaces_path
+    # The evaluated value is saved as lifecycle_message
+    assert_equal api_namespaces_path, @controller.view_assigns['redirect_action'].lifecycle_message
   end
 
   test 'should allow #create and should not redirect by evaluating redirect_url if redirect_type is not dynamic_url' do
@@ -231,10 +234,13 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       actions_count = @api_namespace.create_api_actions.size
       assert_difference "@api_namespace.executed_api_actions.count", actions_count do
         post api_namespace_resource_index_url(api_namespace_id: @api_namespace.id, params: payload)
-        assert_response :redirect
-        assert_redirected_to url
       end
     end
+
+    assert_response :redirect
+    assert_redirected_to url
+    # The evaluated value is not saved as lifecycle_message
+    assert_equal url, @controller.view_assigns['redirect_action'].lifecycle_message
   end
 
   test 'should allow #create and should redirect to the provided cms-page if redirect_type is cms_page' do
@@ -256,10 +262,12 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       actions_count = @api_namespace.create_api_actions.size
       assert_difference "@api_namespace.executed_api_actions.count", actions_count do
         post api_namespace_resource_index_url(api_namespace_id: @api_namespace.id, params: payload)
-        assert_response :redirect
-        assert_redirected_to cms_page.full_path
       end
     end
+
+    assert_response :redirect
+    assert_redirected_to cms_page.full_path
+    assert_equal cms_page.full_path, @controller.view_assigns['redirect_action'].lifecycle_message
   end
 
   test 'should allow #create and show the custom success message' do


### PR DESCRIPTION
# Allow dynamic segment in api redirect action

This feature allows Ruby evaluation in the redirect action so you can do conditional redirects and other fanciness: 

<img width="1728" alt="Screen Shot 2022-07-08 at 11 14 21 AM" src="https://user-images.githubusercontent.com/35935196/178021412-90005e11-a8bb-48d1-b260-3f63320eeaac.png">

---
## How it works

The implicit return value of the evaluated statement should be a valid path in the application. As illustrated above, you can use an absolute path (like: `'/'`, or a Rails route helper like `dashboard_path`)

---

Addresses: https://github.com/restarone/violet_rails/issues/873


## Video demo


https://user-images.githubusercontent.com/35935196/178011977-82aab515-87b5-49a3-8591-f8ba3535d9eb.mp4

## The evaluated output of the dynamic_url segment  is saved in the lifecycle message
![image](https://user-images.githubusercontent.com/25191509/178540033-bba9e309-b9bb-45b6-a438-b8cfd5716663.png)

