### PR TITLE
[bug fix] handle textarea overflow in send_email API action

### DIFF
--- a/app/views/comfy/admin/api_actions/_form.html.haml
+++ b/app/views/comfy/admin/api_actions/_form.html.haml
@@ -41,7 +41,7 @@
 
       .form-group
         = label_tag 'Custom Message'
-        = rich_text_area_tag "api_namespace[#{type}_attributes][#{index}][custom_message]", resource.custom_message, { class: "form-control form-control-sm" }
+        = rich_text_area_tag "api_namespace[#{type}_attributes][#{index}][custom_message]", resource.custom_message, { class: "form-control form-control-sm", style: "height: auto;" }
 
 
     .redirect.col-12{style: "#{'display:none' unless resource.action_type == 'redirect'}", id: "redirect_fields_#{type}_#{index}"}


### PR DESCRIPTION
Addresses #872 

![Capture](https://user-images.githubusercontent.com/73725297/177894791-3ceaedcd-93e0-4e41-beab-f42057ebd3d1.PNG)


Co-authored-by: Mushfiq Rahman <mushfiqurrahman78@yahoo.com>