### PR TITLE
rename Web Settings to App Settings

### DIFF
--- a/app/views/comfy/admin/cms/partials/_navigation_inner.haml
+++ b/app/views/comfy/admin/cms/partials/_navigation_inner.haml
@@ -2,7 +2,7 @@
   = active_link_to "Users", admin_users_path, class: 'nav-link'
   = active_link_to "Email", mailbox_path, class: 'nav-link'
   = active_link_to "API", api_namespaces_path, class: 'nav-link'
-  = active_link_to "Web Settings", edit_web_settings_path, class: 'nav-link'
+  = active_link_to "App Settings", edit_web_settings_path, class: 'nav-link'
   = active_link_to "Visitor Analytics", dashboard_path, class: 'nav-link'
   = active_link_to "My Settings", edit_user_registration_path, class: 'nav-link'
 %li{class: 'nav-item'}

--- a/app/views/comfy/admin/users/index.html.haml
+++ b/app/views/comfy/admin/users/index.html.haml
@@ -26,7 +26,7 @@
         %th{:scope => "col"}
           = sort_link @users_q, :can_manage_api
         %th{:scope => "col"}
-          = sort_link @users_q, :can_manage_subdomain_settings
+          = sort_link @users_q, :can_manage_subdomain_settings, 'Can manage app settings'
         %th{:scope => "col"}
           = sort_link @users_q, :can_view_restricted_pages
         %th{:scope => "col"}

--- a/config/locales/views/comfy/web_settings/en.yml
+++ b/config/locales/views/comfy/web_settings/en.yml
@@ -4,4 +4,4 @@ en:
       web_settings:
         index:
           header:
-            title: Manage your website
+            title: App Settings

--- a/test/controllers/admin/comfy/users_controller_test.rb
+++ b/test/controllers/admin/comfy/users_controller_test.rb
@@ -38,7 +38,7 @@ class Comfy::Admin::UsersControllerTest < ActionDispatch::IntegrationTest
       "Can manage users",
       "Can manage blog",
       "Can manage api",
-      "Can manage subdomain settings",
+      "Can manage app settings",
       "Can view restricted pages",
       "Can manage forum",
       "Current sign in at",


### PR DESCRIPTION
To keep the UI in-line with current features. namely iPhone support since release: https://github.com/restarone/violet_rails/releases/tag/0.9.5

![Screenshot from 2022-07-09 15-12-18](https://user-images.githubusercontent.com/35935196/178119678-8c53bc93-08b3-47b2-a905-0366343b6eaa.png)

![Screenshot from 2022-07-09 15-12-38](https://user-images.githubusercontent.com/35935196/178119699-93bb688b-7d58-4ef5-a8df-ee1ba06d5000.png)


