### PR TITLE
namespace sidekiq + add queues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,3 +109,5 @@ gem "exception_notification", "~> 4.5"
 gem "turnout", "~> 2.5"
 
 gem "turbo-rails", "~> 1.1"
+
+gem "redis-namespace", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,6 +360,8 @@ GEM
     recaptcha (5.8.0)
       json
     redis (4.6.0)
+    redis-namespace (1.8.2)
+      redis (>= 3.0.4)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -525,6 +527,7 @@ DEPENDENCIES
   rails-controller-testing
   ransack
   recaptcha
+  redis-namespace (~> 1.8)
   ros-apartment
   ros-apartment-sidekiq
   sass-rails (>= 6)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,2 +1,9 @@
-Sidekiq.configure_server { |c| c.redis = { url: ENV['REDIS_URL'] } }
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV['REDIS_URL'], namespace: "#{ENV['APP_HOST']}_#{Rails.env}" }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV['REDIS_URL'], namespace: "#{ENV['APP_HOST']}_#{Rails.env}" }
+end   
+
 Sidekiq.strict_args!

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,1 +1,14 @@
+:verbose: false
+:concurrency: 1
+:max_retries: 3
+:timeout: 8
 :logfile: ./log/sidekiq.log
+:queues:
+  - critical
+  - mailers
+  - default
+  - action_mailbox_routing
+  - action_mailbox_incineration
+  - active_storage_analysis
+  - active_storage_purge
+  - low


### PR DESCRIPTION
# Sidekiq namespace + queues

Make sure that each Violet Rails application is reading off a namespace so multiple apps can share Redis infrastructure (eg: AWS Elasticache). 

resolves: https://github.com/restarone/violet_rails/issues/904 & https://github.com/restarone/violet_rails/issues/536

# Test plan
1. Sending / receiving emails :heavy_check_mark: 
2. Ahoy geocode / analytics :heavy_check_mark: 
3. file uploads :heavy_check_mark: 
4. file previews :heavy_check_mark: 
5. forum
6. API forms (file upload, rich text) :heavy_check_mark: 
7. ruby automation :heavy_check_mark: 

# upgrade path: https://github.com/restarone/violet_rails/issues/908

# CAVEATS 🔴 

## This will reset sidekiq job stats !

So be sure to drain all jobs BEFORE deploying this to production

### Before

<img width="1495" alt="Screen Shot 2022-07-10 at 12 18 02 PM" src="https://user-images.githubusercontent.com/35935196/178153043-b0194420-2090-4a46-a1ab-38a7511460a1.png">

### After
<img width="1728" alt="Screen Shot 2022-07-10 at 12 16 17 PM" src="https://user-images.githubusercontent.com/35935196/178152984-befaae86-e379-4c73-bfc6-844c5414d129.png">





### cheatsheet

tail the logs for sidekiq: 
``` bash
journalctl -u sidekiq.service -f
```