### PR TITLE
[feature] Pass current user and current visit to api data pipeline

### DIFF
--- a/app/controllers/comfy/admin/api_actions_controller.rb
+++ b/app/controllers/comfy/admin/api_actions_controller.rb
@@ -1,6 +1,7 @@
 class Comfy::Admin::ApiActionsController < Comfy::Admin::Cms::BaseController
   before_action :ensure_authority_to_manage_api
   before_action :set_api_action, except: :new
+  before_action :set_current_user_and_visit
 
   def new
     @index = params[:index]
@@ -30,5 +31,10 @@ class Comfy::Admin::ApiActionsController < Comfy::Admin::Cms::BaseController
   def set_api_action
     @api_namespace = ApiNamespace.find_by(id: params[:api_namespace_id])
     @api_action = @api_namespace.executed_api_actions.find_by(id: params[:id])
+  end
+
+  def set_current_user_and_visit
+    Current.user = current_user
+    Current.visit = current_visit
   end
 end

--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -1,6 +1,7 @@
 module ApiActionable
   extend ActiveSupport::Concern
   included do
+    before_action :set_current_user_and_visit
     before_action :initialize_api_actions, only: [:update, :show, :destroy]
     before_action :check_for_redirect_action, only: [:create, :update, :show, :destroy]
     after_action :execute_api_actions, only: [:show, :create, :update, :destroy]
@@ -84,5 +85,10 @@ module ApiActionable
     @api_namespace.send(action_name).each do |action|
       @api_resource.send(action_name).create(action.attributes.merge(custom_message: action.custom_message.to_s).except("id", "created_at", "updated_at", "api_namespace_id"))
     end
+  end
+
+  def set_current_user_and_visit
+    Current.user = current_user
+    Current.visit = current_visit
   end
 end

--- a/app/models/api_action.rb
+++ b/app/models/api_action.rb
@@ -4,7 +4,7 @@ class ApiAction < ApplicationRecord
   include DynamicAttribute
 
   attr_encrypted :bearer_token
-  attr_dynamic :email, :email_subject, :custom_message, :payload_mapping, :request_url
+  attr_dynamic :email, :email_subject, :custom_message, :payload_mapping, :request_url, :custom_headers
 
   after_update :update_executed_actions_payload, if: Proc.new { api_namespace.present? && saved_change_to_payload_mapping? }
 
@@ -24,8 +24,6 @@ class ApiAction < ApplicationRecord
   has_rich_text :custom_message
 
   validates :http_method, inclusion: { in: ApiAction::HTTP_METHODS}, allow_blank: true
-  
-  validates :payload_mapping, safe_executable: true
 
   def self.children
     ['new_api_actions', 'create_api_actions', 'show_api_actions', 'update_api_actions', 'destroy_api_actions', 'error_api_actions']
@@ -73,7 +71,7 @@ class ApiAction < ApplicationRecord
   def serve_file;end
 
   def request_headers
-    headers = custom_headers.to_json.gsub('SECRET_BEARER_TOKEN', bearer_token)
+    headers = custom_headers_evaluated.gsub('SECRET_BEARER_TOKEN', bearer_token)
     { 'Content-Type' => 'application/json' }.merge(JSON.parse(headers))
   end
 

--- a/app/models/concerns/dynamic_attribute.rb
+++ b/app/models/concerns/dynamic_attribute.rb
@@ -26,6 +26,15 @@ module DynamicAttribute
         value = public_send(attribute.to_sym)
         value.is_a?(Enumerable) ? value.to_json : value.to_s
       end
+
+      # Fetching session specific data should be defined here.
+      def current_user
+        Current.user
+      end
+
+      def current_visit
+        Current.visit
+      end
     end
   
     class_methods do

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,4 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+  attribute :visit
+end

--- a/app/views/comfy/admin/api_actions/show.html.haml
+++ b/app/views/comfy/admin/api_actions/show.html.haml
@@ -13,6 +13,8 @@
         .mr-3
           Payload: 
         = @api_action.payload_mapping_evaluated
+      -# payload_mapping_evaluated & custom_headers_evaluated will show current_user & current_visit according to the logged-in user.
+      -# TO DO: show the data that was evaluated while making the web-request instead of reevaluating on every request.
     
     - if @api_action.action_type == 'redirect'
       .col-12.d-flex.mb-3

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -192,6 +192,42 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'should allow #create with the current_user & current_visit being available in the send_web_request action' do
+    @api_namespace.api_form.update(properties: { 'name': {'label': 'name', 'placeholder': 'Test', 'type_validation': 'tel'}})
+
+    api_action = api_actions(:one)
+    api_action.update!(
+                      type: 'CreateApiAction',
+                      bearer_token: 'test-token',
+                      position: 0,
+                      action_type: 'send_web_request',
+                      request_url: "http://www.example.com/success",
+                      payload_mapping: {"email": '#{current_user.email}'},
+                      custom_headers: {"User-Id": '#{current_visit.user_id}'},
+                      http_method: 'post'
+                    )
+    @api_namespace.api_actions.where.not(id: api_action.id).destroy_all
+    user = users(:public)
+    sign_in(user)
+
+    stub_post = stub_request(:post, "http://www.example.com/success").with(headers: { 'User-Id' => user.id.to_s }, body: {'email' => user.email}).to_return(:body => "abc")
+
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+
+    assert_difference "@api_namespace.api_resources.count", +1 do
+      post api_namespace_resource_index_url(api_namespace_id: @api_namespace.id), params: payload
+    end
+
+    # Provided current_user & current_visit variable are available through send_web_request api-action
+    assert_requested stub_post
+  end
+
   test 'should allow #create and show the custom success message' do
     api_namespace = api_namespaces(:one)
     api_namespace.api_form.update(success_message: 'test success message')
@@ -222,6 +258,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
           }
       }
     }
+
     assert_difference "api_namespace.api_resources.count", +1 do
       post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
     end


### PR DESCRIPTION
# ability to reference `current_user` and `current_visit` in API Actions
Addresses: https://github.com/restarone/violet_rails/issues/457

## Email action
![Screenshot from 2022-07-11 20-12-18](https://user-images.githubusercontent.com/35935196/178379475-76ed12b5-bf8b-4a35-8102-60e5c927d601.png)
![Screenshot from 2022-07-11 20-11-57](https://user-images.githubusercontent.com/35935196/178379476-534183df-d251-406b-b0e7-f7197bed3bbe.png)


## HTTP Action
![Screenshot from 2022-07-11 17-57-56](https://user-images.githubusercontent.com/35935196/178365888-45273665-9617-4d97-919f-e29772ee2d17.png)
## example usage
![Screenshot from 2022-07-11 17-58-10](https://user-images.githubusercontent.com/35935196/178365941-ad6136eb-24ba-47a2-9928-46b11580e549.png)

Co-authored-by: Prashant Khadka <prashant.khadka052@gmail.com>