### PR TITLE
[feature] show dynamic attributes in API Resources index table (#945)

### DIFF
--- a/app/views/comfy/admin/api_namespaces/show.html.haml
+++ b/app/views/comfy/admin/api_namespaces/show.html.haml
@@ -144,23 +144,29 @@
       = link_to "Create new #{@api_namespace.name.singularize}", new_api_namespace_resource_path(api_namespace_id: @api_namespace.id), class: 'btn btn-primary'
 
   = render partial: 'comfy/admin/api_resources/search_filters', locals: { objects: @api_resources_q, path: api_namespace_path(@api_namespace) }
-  %table
-    %thead
-      %tr
-        %th.px-3= sort_link @api_resources_q, :id
-        %th.px-3= sort_link @api_resources_q, :created_at
-        %th.px-3= sort_link @api_resources_q, :updated_at
-        %th.px-3
-        %th.px-3
-    = render partial: 'pagination', locals: { objects: @api_resources }
-    %tbody
-      - @api_resources.each do |api_resource|
+  = render partial: 'pagination', locals: { objects: @api_resources }
+  .table-responsive
+    %table
+      %thead
         %tr
-          %td.px-3.py-2= link_to api_resource.id, api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id) 
-          %td.px-3= api_resource.created_at.strftime('%F %T')
-          %td.px-3= api_resource.updated_at.strftime('%F %T')
-          %td.px-3= link_to 'Edit', edit_api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id)
-          %td.px-3= link_to 'Destroy', api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), method: :delete, data: { confirm: 'Are you sure?' }
+          %th.px-3= sort_link @api_resources_q, :id
+          %th.px-3= sort_link @api_resources_q, :created_at
+          %th.px-3= sort_link @api_resources_q, :updated_at
+          - dynamic_columns = @api_namespace.properties.keys
+          - dynamic_columns.each do |dynamic_column|
+            %th.px-3= dynamic_column
+          %th.px-3
+          %th.px-3
+      %tbody
+        - @api_resources.each do |api_resource|
+          %tr
+            %td.px-3.py-2= link_to api_resource.id, api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id)
+            %td.px-3= api_resource.created_at.strftime('%F %T')
+            %td.px-3= api_resource.updated_at.strftime('%F %T')
+            - dynamic_columns.each do |dynamic_column|
+              %td.px-3= api_resource.properties[dynamic_column]
+            %td.px-3= link_to 'Edit', edit_api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id)
+            %td.px-3= link_to 'Destroy', api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), method: :delete, data: { confirm: 'Are you sure?' }
 
   %br
 

--- a/test/controllers/admin/comfy/api_namespaces_controller_test.rb
+++ b/test/controllers/admin/comfy/api_namespaces_controller_test.rb
@@ -467,4 +467,20 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_match success_message, request.flash[:notice]
     assert_equal api_namespace_hash['api_namespace']['name'], ApiNamespace.last.name
   end
+
+  test "should allow #show and the dynamic properties should be shown in the api-resources tables" do
+    sign_in(@user)
+    properties = {"attr_1"=>true, "attr_2"=>true, "attr_3"=>true, "attr_4"=>true}
+
+    @api_namespace.has_form = '1'
+    @api_namespace.update(properties: properties)
+
+    get api_namespace_url(@api_namespace)
+    assert_response :success
+
+    assert_select "table", 1, "This page must contain a api-resources table"
+    properties.keys.each do |heading|
+      assert_select "thead th", {count: 1, text: heading}, "Api-resources table must contain '#{heading}' column"
+    end
+  end
 end


### PR DESCRIPTION
## show dynamic attributes in API Resources index table

Addresses: https://github.com/restarone/violet_rails/issues/871

**Demo:**

https://user-images.githubusercontent.com/25191509/179969416-1d807c22-9c82-46d1-91b9-bc27bbdbce2c.mp4

**Mobile**

https://user-images.githubusercontent.com/25191509/180193220-563d3c31-352d-491c-91f1-c32ccfaa54ab.mp4


* feat(): refactoring test case

* feat(): make api-resources index table responsive

* feat(): making table pagination fixed when the table is scrollable

Co-authored-by: Prashant Khadka <prashant.khadka052@gmail.com>