### PR TITLE
[feature] attach current_visit and current_user to created API Resource, [feature] Render rich text or file content on a new line in API

### DIFF
--- a/app/helpers/ahoy_events_helper.rb
+++ b/app/helpers/ahoy_events_helper.rb
@@ -37,6 +37,10 @@ module AhoyEventsHelper
         forum_thread = ForumThread.find(event.properties['forum_thread_id'])
 
         simple_discussion.forum_thread_path(id: forum_thread.slug)
+      elsif Ahoy::Event::SYSTEM_EVENTS[event.name] == Ahoy::Event::SYSTEM_EVENTS['api-resource-create']
+        api_resource = ApiResource.find(event.properties['api_resource_id'])
+
+        api_namespace_resource_path(api_namespace_id: api_resource.api_namespace.id ,id: api_resource.id)
       end
     rescue => e
       e.message

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -1,7 +1,17 @@
 class Ahoy::Event < ApplicationRecord
   include Ahoy::QueryMethods
 
-  SYSTEM_EVENTS = { 'comfy-blog-page-visit'=> 0, 'comfy-cms-page-update'=> 1, 'comfy-cms-page-visit'=> 2, 'comfy-cms-file-update'=> 3, 'subdomain-user-update'=> 4, 'subdomain-email-visit'=> 5, 'subdomain-forum-post-update'=> 6, 'subdomain-forum-thread-visit'=> 7 }
+  SYSTEM_EVENTS = {
+    'comfy-blog-page-visit'=> 0,
+    'comfy-cms-page-update'=> 1,
+    'comfy-cms-page-visit'=> 2,
+    'comfy-cms-file-update'=> 3,
+    'subdomain-user-update'=> 4,
+    'subdomain-email-visit'=> 5,
+    'subdomain-forum-post-update'=> 6,
+    'subdomain-forum-thread-visit'=> 7,
+    'api-resource-create' => 8
+  }
 
   self.table_name = "ahoy_events"
 

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -50,6 +50,14 @@ class ApiResource < ApplicationRecord
     end
   end
 
+  def tracked_event
+    Ahoy::Event.where(name: 'api-resource-create').where("properties @> ?", { api_resource_id: self.id }.to_json).last
+  end
+
+  def tracked_user
+    User.find_by(id: tracked_event.properties.dig('user_id')) if tracked_event
+  end
+
   private
 
   def inherit_properties_from_parent

--- a/app/views/comfy/admin/api_namespaces/_editor.haml
+++ b/app/views/comfy/admin/api_namespaces/_editor.haml
@@ -20,8 +20,8 @@
   .my-3
     %b.mb-2.d-block Non-primitive Properties
     - api_resource.non_primitive_properties.each do |prop|
-      .d-flex.mb-3
-        .mr-4
+      .mb-3
+        %div
           = "#{prop.label}:"
         %div
           - if prop.file?

--- a/app/views/comfy/admin/api_resources/show.html.haml
+++ b/app/views/comfy/admin/api_resources/show.html.haml
@@ -9,6 +9,27 @@
 = render 'comfy/admin/api_namespaces/editor', {api_resource: @api_resource, form_properties: @api_resource.api_namespace&.api_form&.properties&.symbolize_keys, read_only: true}
 = render 'comfy/admin/api_namespaces/init_editor', {read_only: true}
 
+- user = @api_resource.tracked_user
+- if user
+  %p 
+    %b Submitted by User:
+    .ml-5
+      %p 
+        %b User Id:
+        = link_to user.id, edit_admin_user_path(id: user.id)
+      %p
+        %b Email:
+        = user.email
+      %p
+        %b Name:
+        = user.name
+
+
+%p
+  %b Current Visit:
+  - visit = @api_resource.tracked_event&.visit
+  = link_to visit.started_at.strftime('%I:%M %P - %b %d, %Y'), dashboard_visits_path(ahoy_visit_id: visit.id) if visit
+
 .my-3
   = link_to 'API Actions', api_namespace_api_actions_path(api_namespace_id: @api_resource.api_namespace_id, 'q[api_resource_id_eq]': @api_resource.id)
 

--- a/app/views/comfy/admin/api_resources/show.html.haml
+++ b/app/views/comfy/admin/api_resources/show.html.haml
@@ -26,9 +26,10 @@
 
 
 %p
-  %b Current Visit:
   - visit = @api_resource.tracked_event&.visit
-  = link_to visit.started_at.strftime('%I:%M %P - %b %d, %Y'), dashboard_visits_path(ahoy_visit_id: visit.id) if visit
+  - if visit
+    %b Visit:
+    = link_to visit.started_at.strftime('%I:%M %P - %b %d, %Y'), dashboard_visits_path(ahoy_visit_id: visit.id) if visit
 
 .my-3
   = link_to 'API Actions', api_namespace_api_actions_path(api_namespace_id: @api_resource.api_namespace_id, 'q[api_resource_id_eq]': @api_resource.id)

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -661,4 +661,50 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     custom_actions = api_resource.reload.create_api_actions.where(action_type: 'custom_action').reorder(nil)
     assert_equal custom_actions.order(updated_at: :asc).pluck(:id), custom_actions.order(position: :asc).pluck(:id)
   end
+  
+  test 'tracking diabled: should not track current vist and current user after create' do
+    Subdomain.current.update(tracking_enabled: false)
+    api_namespace = api_namespaces(:one)
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_no_difference "Ahoy::Event.count" do
+      post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+  end
+
+  test 'tracking enabled: should track current vist and current user after create' do
+    user = users(:public)
+    Subdomain.current.update(tracking_enabled: true)
+    api_namespace = api_namespaces(:one)
+    payload = {
+      data: {
+          properties: {
+            name: 123,
+          }
+      }
+    }
+    assert_difference "Ahoy::Event.count", +1 do
+      post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+    assert_equal Ahoy::Event.last.properties['api_resource_id'], ApiResource.last.id
+    assert_equal Ahoy::Event.last.properties['api_namespace_id'], api_namespace.id
+    assert_equal Ahoy::Event.last.name, 'api-resource-create'
+    # When user is not signed in
+    refute Ahoy::Event.last.properties['user_id']
+
+    sign_in(user)
+    assert_difference "Ahoy::Event.count", +1 do
+      post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+    end
+    assert_equal Ahoy::Event.last.properties['api_resource_id'], ApiResource.last.id 
+    assert_equal Ahoy::Event.last.properties['api_namespace_id'], api_namespace.id
+    assert_equal Ahoy::Event.last.name, 'api-resource-create'
+    # When user is signed in
+    assert_equal Ahoy::Event.last.properties['user_id'], user.id 
+  end
 end

--- a/test/helpers/ahoy_events_helper_test.rb
+++ b/test/helpers/ahoy_events_helper_test.rb
@@ -228,4 +228,18 @@ class AhoyEventsHelperTest < ActionView::TestCase
 
     assert_match pattern, event_name_detail(event)
   end
+
+  test 'returns api_resource_path' do
+    api_resource = api_resources(:one)
+
+    expected_output = api_namespace_resource_path(api_namespace_id: api_resource.api_namespace.id ,id: api_resource.id)
+
+    event = Ahoy::Visit.last.events.create!(
+      name: 'api-resource-create',
+      time: Time.zone.now,
+      properties: { api_resource_id: api_resource.id }
+    )
+
+    assert_equal expected_output, event_name_detail(event)
+  end
 end

--- a/test/models/api_resource_test.rb
+++ b/test/models/api_resource_test.rb
@@ -18,4 +18,30 @@ class ApiResourceTest < ActiveSupport::TestCase
 
     assert_includes api_resource.errors.messages[:properties], 'name is required'
   end
+
+  test 'tracked_event' do
+    api_resource = api_resources(:one)
+    current_visit = ahoy_visits(:public)
+
+    event = Ahoy::Event.create(
+      name: "api-resource-create",
+      visit_id: current_visit.id,
+      properties: { api_resource_id: api_resource.id }
+    )
+    assert_equal api_resource.tracked_event, event
+  end
+
+  test 'tracked_user' do
+    api_resource = api_resources(:one)
+    user = users(:public)
+    current_visit = ahoy_visits(:public)
+
+    event = Ahoy::Event.create(
+      name: "api-resource-create",
+      visit_id: current_visit.id,
+      properties: { api_resource_id: api_resource.id, user_id: user.id }
+    )
+
+    assert_equal api_resource.tracked_user, user
+  end
 end


### PR DESCRIPTION
## [feature] attach current_visit and current_user to created API Resource
Addresses: https://github.com/restarone/violet_rails/issues/900 by @Pralish 

https://user-images.githubusercontent.com/35935196/180570997-d3ebd298-0972-4e01-9a36-9b44dfe2528d.mov


## [feature] Render rich text or file content on a new line in API

Addresses #848 by @Ayon95 

![Capture](https://user-images.githubusercontent.com/73725297/180314387-c92e4ff5-0769-460d-ae7a-0bfaecbc9e79.PNG)

