### PR TITLE
[Dev workflow] minimal config for nginx in docker + rails, [Plugin] Create External API Connection that backfills attributes on API Namespace + API Resources

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,4 +101,15 @@ services:
       RAILS_ENV: test
     depends_on:
       - solutions_db
+      - solutions_app
+  nginx:
+    build:
+      context: .
+      dockerfile: ./nginx.Dockerfile
+    depends_on:
+      - solutions_app
+    ports:
+      - 80:80
+    networks:
+      - development
       

--- a/nginx.Dockerfile
+++ b/nginx.Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx
+RUN apt-get update -qq && apt-get -y install apache2-utils
+ENV APP_PATH /var/app
+WORKDIR $APP_PATH
+COPY public public/
+COPY nginx.conf /tmp/docker.nginx
+RUN envsubst '$APP_PATH' < /tmp/docker.nginx > /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD [ "nginx", "-g", "daemon off;" ]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,58 @@
+upstream app {
+  server 'solutions_app:5250';
+}
+server {
+  listen 80;
+  server_name localhost;
+  # ~2 seconds is often enough for most folks to parse HTML/CSS and
+  # retrieve needed images/icons/frames, connections are cheap in
+  # nginx so increasing this is generally safe...
+  keepalive_timeout 5;
+  # path for static files
+  root public;
+  access_log off;
+  error_log off;
+  # this rewrites all the requests to the maintenance.html
+  # page if it exists in the doc root. This is for capistrano's
+  # disable web task
+  if (-f $document_root/maintenance.html) {
+    rewrite  ^(.*)$  /maintenance.html last;
+    break;
+  }
+  location / {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    # If the file exists as a static file serve it directly without
+    # running all the other rewrite tests on it
+    if (-f $request_filename) {
+      break;
+    }
+    # check for index.html for directory index
+    # if it's there on the filesystem then rewrite
+    # the url to add /index.html to the end of it
+    # and then break to send it to the next config rules.
+    if (-f $request_filename/index.html) {
+      rewrite (.*) $1/index.html break;
+    }
+    # this is the meat of the rack page caching config
+    # it adds .html to the end of the url and then checks
+    # the filesystem for that file. If it exists, then we
+    # rewrite the url to have explicit .html on the end
+    # and then send it on its way to the next config rule.
+    # if there is no file on the fs then it sets all the
+    # necessary headers and proxies to our upstream pumas
+    if (-f $request_filename.html) {
+      rewrite (.*) $1.html break;
+    }
+    if (!-f $request_filename) {
+      proxy_pass http://app;
+      break;
+    }
+  }
+
+  # Error pages
+  # error_page 500 502 503 504 /500.html;
+  location = /500.html {
+    root /app/current/public;
+  }
+}

--- a/test/fixtures/external_api_clients.yml
+++ b/test/fixtures/external_api_clients.yml
@@ -310,3 +310,53 @@ mailchimp_plugin:
 
     # at the end of the file we have to implicitly return the class 
     SyncToMailchimp
+
+sync_attribute_to_api_namespace_plugin:
+  api_namespace: one
+  slug: sync-attribute-to-api-namespace
+  label: SyncAttributeToApiNamespace
+  enabled: true
+  metadata: {
+            'ATTRIBUTE_NAME': 'test_attribute',
+            'DEFAULT_VALUE': 'test_value',
+          }
+  model_definition: |
+    class SyncAttributeToApiNamespace
+      def initialize(parameters)  
+        @external_api_client = parameters[:external_api_client]
+        @api_namespace = @external_api_client.api_namespace
+        @api_form = @api_namespace.api_form
+      end
+
+      def start
+        # Fetching provided inputs (attribute_name, default_value)
+        attribute_name = @external_api_client.metadata["ATTRIBUTE_NAME"]
+        default_value = @external_api_client.metadata["DEFAULT_VALUE"].nil? ? '' : @external_api_client.metadata["DEFAULT_VALUE"]
+
+        raise 'ATTRIBUTE_NAME is missing!' if attribute_name.nil?
+        raise 'The provided attribute is already defined in the ApiNamespace' if @api_namespace.properties.keys.include?(attribute_name)
+
+        # Adding the new-attribute in ApiNamespace
+        new_properties = @api_namespace.properties.merge(attribute_name => default_value)
+        @api_namespace.has_form = @api_namespace.api_form.present? ? '1' : '0'
+        @api_namespace.update!(properties: new_properties)
+
+        # Making the new-attribute non-renderable
+        form_properties = @api_form.properties
+        form_properties[attribute_name]['renderable'] = '0'
+        @api_form.update!(properties: form_properties)
+
+        # Adding the new-attribute to its ApiResources
+        @api_namespace.api_resources.find_in_batches(batch_size: 500).each do |resources_batch|
+          resources_batch.each do |api_resource|
+            # Does not mutate the api-resource if it already has the provided new-attribute
+            next if api_resource.properties.keys.include?(attribute_name)
+
+            new_resource_properties = api_resource.properties.merge(attribute_name => default_value)
+            api_resource.update!(properties: new_resource_properties)
+          end
+        end
+      end
+    end
+    # at the end of the file we have to implicitly return the class 
+    SyncAttributeToApiNamespace

--- a/test/plugins/sync_attribute_to_api_namespace_plugin_test.rb
+++ b/test/plugins/sync_attribute_to_api_namespace_plugin_test.rb
@@ -1,0 +1,238 @@
+require "test_helper"
+
+class SyncAttributeToApiNamespacePluginTest < ActiveSupport::TestCase
+  setup do
+    @sync_attribute_to_api_namespace_plugin = external_api_clients(:sync_attribute_to_api_namespace_plugin)
+    @api_namespace = @sync_attribute_to_api_namespace_plugin.api_namespace
+    @api_form = @api_namespace.api_form
+    Sidekiq::Testing.fake!
+  end
+
+  test "adds provided new attribute to api namespace and backfills the default value to its api-resources successfully" do
+    metadata = {
+      'ATTRIBUTE_NAME' => 'new_attribute',
+      'DEFAULT_VALUE' => 'test_value',
+    }
+    @sync_attribute_to_api_namespace_plugin.update!(metadata: metadata)
+    api_resource = api_resources(:one)
+
+    (1..5).each do
+      new_api_resource = api_resource.dup
+      new_api_resource.save!
+    end
+
+    # Initially, the api_namespace and its api-resources does not have the new 'new_attribute'
+    refute_includes @api_namespace.properties.keys, 'new_attribute'
+    @api_namespace.api_resources.each do |resource|
+      refute_includes resource.properties.keys, 'new_attribute'
+    end
+
+    perform_enqueued_jobs do
+      assert_no_difference 'ApiNamespace.count' do
+        assert_no_difference 'ApiResource.count' do
+          @sync_attribute_to_api_namespace_plugin.run
+          Sidekiq::Worker.drain_all
+        end
+      end
+    end
+
+    # The api-namespace and all api-resources are backfilled with provided 'DEFAULT_VALUE'
+    assert_equal metadata['DEFAULT_VALUE'], @api_namespace.reload.properties['new_attribute']
+    @api_namespace.reload.api_resources.each do |resource|
+      assert_equal metadata['DEFAULT_VALUE'], resource.properties['new_attribute']
+    end
+
+    # The newly added attribute is non-renderable
+    assert_equal '0', @api_form.reload.properties['new_attribute']['renderable']
+  end
+
+  test "adds provided new attribute to api namespace and backfills with empty string to its api-resources if DEFAULT_VALUE was not provided" do
+    metadata = {
+      'ATTRIBUTE_NAME' => 'new_attribute',
+    }
+    @sync_attribute_to_api_namespace_plugin.update!(metadata: metadata)
+    api_resource = api_resources(:one)
+
+    (1..5).each do
+      new_api_resource = api_resource.dup
+      new_api_resource.save!
+    end
+
+    # Initially, the api_namespace and its api-resources does not have the new 'new_attribute'
+    refute_includes @api_namespace.properties.keys, 'new_attribute'
+    @api_namespace.api_resources.each do |resource|
+      refute_includes resource.properties.keys, 'new_attribute'
+    end
+
+    perform_enqueued_jobs do
+      assert_no_difference 'ApiNamespace.count' do
+        assert_no_difference 'ApiResource.count' do
+          @sync_attribute_to_api_namespace_plugin.run
+          Sidekiq::Worker.drain_all
+        end
+      end
+    end
+
+    # The api-namespace and all api-resources are backfilled with provided empty-string: ''
+    assert_equal '', @api_namespace.reload.properties['new_attribute']
+    @api_namespace.api_resources.reload.each do |resource|
+      assert_equal '', resource.properties['new_attribute']
+    end
+
+    # The newly added attribute is non-renderable
+    assert_equal '0', @api_form.reload.properties['new_attribute']['renderable']
+  end
+
+  test "adds provided new attribute to api namespace and backfills the default value to its api-resources only if that api-resource does not have the provided new-attribute" do
+    metadata = {
+      'ATTRIBUTE_NAME' => 'new_attribute',
+      'DEFAULT_VALUE'=> 'test_value',
+    }
+    @sync_attribute_to_api_namespace_plugin.update!(metadata: metadata)
+    api_resource = api_resources(:one)
+
+    (1..5).each do
+      new_api_resource = api_resource.dup
+      new_api_resource.save!
+    end
+
+    # One of the api-resource already has the new-attribute
+    new_attribute_existing_resource = @api_namespace.api_resources.last
+    properties = new_attribute_existing_resource.properties.merge('new_attribute' => 'dummy_value')
+    new_attribute_existing_resource.update!(properties: properties)
+
+    # Initially, the api_namespace and its api-resources does not have the new 'new_attribute'
+    refute_includes @api_namespace.properties.keys, 'new_attribute'
+    @api_namespace.api_resources.where.not(id: new_attribute_existing_resource.id).each do |resource|
+      refute_includes resource.properties.keys, 'new_attribute'
+    end
+
+    perform_enqueued_jobs do
+      assert_no_difference 'ApiNamespace.count' do
+        assert_no_difference 'ApiResource.count' do
+          assert_no_changes -> { new_attribute_existing_resource.reload.properties['new_attribute'] } do
+            @sync_attribute_to_api_namespace_plugin.run
+            Sidekiq::Worker.drain_all
+          end
+        end
+      end
+    end
+
+    # The api-namespace and all api-resources that do not have the new-attribute are backfilled
+    assert_equal 'test_value', @api_namespace.reload.properties['new_attribute']
+    @api_namespace.api_resources.reload.where.not(id: new_attribute_existing_resource.id).each do |resource|
+      assert_equal 'test_value', resource.properties['new_attribute']
+    end
+
+    # Does not mutate the api-resource that already has the provided new-attribute
+    assert_equal 'dummy_value', new_attribute_existing_resource.reload.properties['new_attribute']
+
+    # The newly added attribute is non-renderable
+    assert_equal '0', @api_form.reload.properties['new_attribute']['renderable']
+  end
+
+  test "returns error if the api_namespace already has the provided attribute" do
+    metadata = {
+      'ATTRIBUTE_NAME' => 'new_attribute',
+      'DEFAULT_VALUE' => 'test_value',
+    }
+    @sync_attribute_to_api_namespace_plugin.update!(metadata: metadata)
+    api_resource = api_resources(:one)
+
+    (1..5).each do
+      new_api_resource = api_resource.dup
+      new_api_resource.save!
+    end
+
+    # @api_namespace already has the provided new-attribute
+    new_properties = @api_namespace.properties.merge('new_attribute' => 'test 1')
+    @api_namespace.update!(properties: new_properties)
+
+    assert_includes @api_namespace.properties.keys, 'new_attribute'
+
+    perform_enqueued_jobs do
+      assert_no_difference 'ApiNamespace.count' do
+        assert_no_difference 'ApiResource.count' do
+          assert_no_changes -> { @api_namespace.reload.properties['new_attribute'] } do
+            @sync_attribute_to_api_namespace_plugin.run
+            Sidekiq::Worker.drain_all
+          end
+        end
+      end
+    end
+
+    expected_message = 'The provided attribute is already defined in the ApiNamespace'
+    assert_match expected_message, @sync_attribute_to_api_namespace_plugin.reload.error_message
+  end
+
+  test "returns error if the ATTRIBUTE_NAME is not provided" do
+    metadata = {
+      'DEFAULT_VALUE' => 'test_value',
+    }
+    @sync_attribute_to_api_namespace_plugin.update!(metadata: metadata)
+    api_resource = api_resources(:one)
+
+    (1..5).each do
+      new_api_resource = api_resource.dup
+      new_api_resource.save!
+    end
+
+    # @api_namespace already has the provided new-attribute
+    new_properties = @api_namespace.properties.merge('new_attribute' => 'test 1')
+    @api_namespace.update!(properties: new_properties)
+
+    assert_includes @api_namespace.properties.keys, 'new_attribute'
+
+    perform_enqueued_jobs do
+      assert_no_difference 'ApiNamespace.count' do
+        assert_no_difference 'ApiResource.count' do
+          assert_no_changes -> { @api_namespace.reload.properties['new_attribute'] } do
+            @sync_attribute_to_api_namespace_plugin.run
+            Sidekiq::Worker.drain_all
+          end
+        end
+      end
+    end
+
+    expected_message = 'ATTRIBUTE_NAME is missing!'
+    assert_match expected_message, @sync_attribute_to_api_namespace_plugin.reload.error_message
+  end
+
+  test "adds provided new attribute to api namespace and backfills the default value: false(boolean) to its api-resources successfully" do
+    metadata = {
+      'ATTRIBUTE_NAME' => 'new_attribute',
+      'DEFAULT_VALUE' => false,
+    }
+    @sync_attribute_to_api_namespace_plugin.update!(metadata: metadata)
+    api_resource = api_resources(:one)
+
+    (1..5).each do
+      new_api_resource = api_resource.dup
+      new_api_resource.save!
+    end
+
+    # Initially, the api_namespace and its api-resources does not have the new 'new_attribute'
+    refute_includes @api_namespace.properties.keys, 'new_attribute'
+    @api_namespace.api_resources.each do |resource|
+      refute_includes resource.properties.keys, 'new_attribute'
+    end
+
+    perform_enqueued_jobs do
+      assert_no_difference 'ApiNamespace.count' do
+        assert_no_difference 'ApiResource.count' do
+          @sync_attribute_to_api_namespace_plugin.run
+          Sidekiq::Worker.drain_all
+        end
+      end
+    end
+
+    # The api-namespace and all api-resources are backfilled with provided 'DEFAULT_VALUE'
+    assert_equal metadata['DEFAULT_VALUE'], @api_namespace.reload.properties['new_attribute']
+    @api_namespace.reload.api_resources.each do |resource|
+      assert_equal metadata['DEFAULT_VALUE'], resource.properties['new_attribute']
+    end
+
+    # The newly added attribute is non-renderable
+    assert_equal '0', @api_form.reload.properties['new_attribute']['renderable']
+  end
+end


### PR DESCRIPTION
# Development changes only, no deploy required :heavy_check_mark: 

## [Dev workflow] minimal config for nginx in docker + rails


resolves: https://github.com/restarone/violet_rails/issues/976

### Use Nginx in Violet Rails dev! 


<img width="1728" alt="Screen Shot 2022-07-28 at 8 40 00 AM" src="https://user-images.githubusercontent.com/35935196/181507459-bf84bb54-86ad-48d5-8c26-49502565ca14.png">

## [Plugin] Create External API Connection that backfills attributes on API Namespace + API Resources

Addresses: https://github.com/restarone/violet_rails/issues/870
### Documentation: https://github.com/restarone/violet_rails/issues/972
Co-authored-by: Prashant <alish.khadka@gmail.com>