### PR TITLE
[feature] Conditional render snippet based on user session

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,2 +1,19 @@
 module ContentHelper
+  # Usgae 1: {{ cms:helper logged_in_user_render, snippet_identifier }}
+  # Usage 2: {{ cms:helper logged_in_user_render, "<span>I am logged in</span>", html: true }}  
+  def logged_in_user_render(snippet, options = {})
+    # pass either html string or snippet identifier
+    return unless current_user.present?
+
+    options['html'] == 'true' ? snippet.html_safe : cms_snippet_render(snippet)
+  end
+
+  # Usgae 1: {{ cms:helper logged_out_user_render, snippet_identifier }}
+  # Usage 2: {{ cms:helper logged_out_user_render, "<span>I am logged in</span>", html: true }}  
+  def logged_out_user_render(snippet, options = {})
+    # pass either html string or snippet identifier
+    return if current_user.present?
+
+    options['html'] == 'true' ? snippet.html_safe : cms_snippet_render(snippet)
+  end
 end

--- a/test/fixtures/comfy/cms/snippets.yml
+++ b/test/fixtures/comfy/cms/snippets.yml
@@ -1,0 +1,6 @@
+public:
+  site: public
+  label: Default Snippet
+  identifier: default
+  content: snippet content
+  position: 0

--- a/test/helpers/content_helper_test.rb
+++ b/test/helpers/content_helper_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class ContentHelperTest < ActionView::TestCase
+  include Comfy::CmsHelper
+
+  setup do
+    @user = users(:public)
+    @snippet = comfy_cms_snippets(:public)
+    @cms_site = comfy_cms_sites(:public)
+  end
+
+  test 'logged_in_user_render when used is logged in and snippet is html string' do
+    @current_user = @user
+    snippet = logged_in_user_render("<h1>This is test</h1>", { "html" => "true"})
+    assert_equal "<h1>This is test</h1>", snippet
+  end
+
+  test 'logged_in_user_render when used is logged in and snippet identifer is passed' do
+    @current_user = @user
+    snippet = logged_in_user_render(@snippet.identifier)
+    assert_equal @snippet.content, snippet
+  end
+
+  test 'logged_in_user_render when used is logged out and snippet identifer is passed' do
+    refute logged_in_user_render(@snippet.identifier)
+  end
+
+  test 'logged_in_user_render when used is logged out and snippet is html string' do
+    refute logged_in_user_render("<h1>This is test</h1>", { "html" => "true"})
+  end
+
+  test 'logged_out_user_render when used is logged in and snippet is html string' do
+    snippet = logged_out_user_render("<h1>This is test</h1>", { "html" => "true"})
+    assert_equal "<h1>This is test</h1>", snippet
+  end
+
+  test 'logged_out_user_render when used is logged in and snippet identifer is passed' do
+    snippet = logged_out_user_render(@snippet.identifier)
+    assert_equal @snippet.content, snippet
+  end
+
+  test 'logged_out_user_render when used is logged out and snippet identifer is passed' do
+    @current_user = @user
+    refute logged_out_user_render(@snippet.identifier)
+  end
+
+  test 'logged_out_user_render when used is logged out and snippet is html string' do
+    @current_user = @user
+    refute logged_out_user_render("<h1>This is test</h1>", { "html" => "true"})
+  end
+
+  def current_user
+    @current_user
+  end
+end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/271

## Demo

https://user-images.githubusercontent.com/35935196/183777190-e9c330e1-f89a-4751-a34f-4a8de1abda23.mov

## conditional rendering snippets / HTML strings
For showing a piece of UI for a logged in user:
``` ruby
{{ cms:helper logged_in_user_render, snippet_identifier }}
{{ cms:helper logged_in_user_render, "<span>I am logged in</span>", html: true }}  
```
For showing a piece of UI for a visitor:
``` ruby
{{ cms:helper logged_out_user_render, snippet_identifier }}
{{ cms:helper logged_out_user_render, "<span>I am logged in</span>", 
```

## Usage example

### I want to show admin controls if a user is logged in
1. Create a snippet with the content you want:
<img width="1167" alt="Screen Shot 2022-08-11 at 8 25 27 PM" src="https://user-images.githubusercontent.com/35935196/184263844-2186b26c-d9d9-486d-9156-17cceba93cfa.png">
2. Pass the snippet identifier to the `logged_in_user_render` function: 
<img width="1125" alt="Screen Shot 2022-08-11 at 8 25 41 PM" src="https://user-images.githubusercontent.com/35935196/184263877-d446d776-2457-4945-962b-159cfc1a30af.png">
3. Result 🥳 
<img width="1728" alt="Screen Shot 2022-08-11 at 8 25 47 PM" src="https://user-images.githubusercontent.com/35935196/184263892-1a60494e-ef0e-43c0-b257-20dc5767fafa.png">