### PR TITLE
revert [feature] rerender recaptcha if recaptcha verification fails

### DIFF
--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -186,9 +186,4 @@ module ApiActionable
     @flash = { error: error_message }
     render 'shared/fallback_to_recaptcha_v2.js.erb'
   end
-
-  def reset_recaptcha_with_error(error_message)
-    @flash = { error: error_message }
-    render 'shared/reset_recaptcha_with_error.js.erb'
-  end
 end

--- a/app/controllers/resource_controller.rb
+++ b/app/controllers/resource_controller.rb
@@ -12,7 +12,7 @@ class ResourceController < ApplicationController
         execute_api_actions
       else
         execute_error_actions
-        reset_recaptcha_with_error(@api_resource.errors.full_messages.to_sentence)
+        render_error(@api_resource.errors.full_messages.to_sentence)
       end
     elsif @api_namespace&.api_form&.show_recaptcha_v3
       if verify_recaptcha(model: @api_resource, action: helpers.sanitize_recaptcha_action_name(@api_namespace.name), minimum_score: ApiForm::RECAPTCHA_V3_MINIMUM_SCORE, secret_key: ENV['RECAPTCHA_SECRET_KEY_V3']) && @api_resource.save

--- a/app/views/comfy/admin/api_forms/_render.haml
+++ b/app/views/comfy/admin/api_forms/_render.haml
@@ -31,7 +31,7 @@
 
     %div{id: "recaptcha_section_#{@api_namespace.id}"}
       - if @api_form.show_recaptcha || session[:recaptcha_v2_fallback]
-        = recaptcha_tags callback: "ctaSuccessHandler_#{@api_namespace.id}", noscript: false
+        = recaptcha_tags callback: "ctaSuccessHandler_#{@api_namespace.id}"
       - elsif @api_form.show_recaptcha_v3
         -# Hiding the recaptch v3 badge.
         -# reference: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed

--- a/app/views/shared/reset_recaptcha_with_error.js.erb
+++ b/app/views/shared/reset_recaptcha_with_error.js.erb
@@ -1,2 +1,0 @@
-if (window.grecaptcha) grecaptcha.reset();
-$("#flash").html("<%= j render(partial: 'shared/flash_content', locals: { flash: @flash }) %>");

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -77,7 +77,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'should not allow #create when recaptcha is enabled and reset recaptcha if recaptcha verification failed' do
+  test 'should not allow #create when recaptcha is enabled and recaptcha verification failed' do
     @api_namespace.api_form.update(show_recaptcha: true)
     payload = {
       data: {
@@ -93,9 +93,6 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       post api_namespace_resource_index_url(api_namespace_id: @api_namespace.id), params: payload
       assert_response :success
     end
-
-    assert_match "if (window.grecaptcha) grecaptcha.reset();", response.parsed_body
-    assert_match "reCAPTCHA verification failed, please try again.", response.parsed_body
 
     Recaptcha.configuration.skip_verify_env.push("test")
   end


### PR DESCRIPTION
This reverts commit a6806aa4d90bb7edc2ca380a2a3a6a99f5538398.

PR that introduced the change: https://github.com/restarone/violet_rails/pull/1019




https://user-images.githubusercontent.com/35935196/184727578-d5c68a4b-bab6-4314-8511-7d429faaf685.mov

<img width="936" alt="Screen Shot 2022-08-15 at 6 15 28 PM" src="https://user-images.githubusercontent.com/35935196/184727598-3c98b14e-9f43-4a75-baeb-da5a895bd30e.png">


Co-authored-by: donrestarone <shashikejayatunge@gmail.com>