### PR TITLE
[feature] Run sidekiq in forked process on Heroku dyno (#1032)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 release: bundle exec rails db:migrate
+web: bundle exec puma -C config/puma.rb

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,20 +24,34 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+if ENV["INLINE_SIDEKIQ_WITH_PUMA"] == "true"
+  # Specifies the number of `workers` to boot in clustered mode.
+  # Workers are forked web server processes. If using threads and workers together
+  # the concurrency of the application would be max `threads` * `workers`.
+  # Workers do not work on JRuby or Windows (both of which do not support
+  # processes).
+  #
+  workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-# preload_app!
+  # Use the `preload_app!` method when specifying a `workers` number.
+  # This directive tells Puma to first boot the application and load code
+  # before forking the application. This takes advantage of Copy On Write
+  # process behavior so workers use less memory.
+  #
+  preload_app!
+
+  before_fork do
+      @sidekiq_pid ||= spawn('bundle exec sidekiq -t 25')
+  end
+
+  on_worker_boot do
+    ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+  end
+
+  on_restart do
+    Sidekiq.redis.shutdown { |conn| conn.close }
+  end
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/665

## To run Sidekiq on Heroku free tier

set environment variable `INLINE_SIDEKIQ_WITH_PUMA` to `true` in Heroku.
<img width="1728" alt="Screen Shot 2022-08-19 at 5 52 49 PM" src="https://user-images.githubusercontent.com/35935196/185712129-68ee1c0b-c885-4aec-912a-83b48de697f9.png">

