### PR TITLE
[Bug fix]: API form success flash message randomly showing in admin UI & creating an API resource from admin results in broken page

### DIFF
--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -48,7 +48,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
         # Preventing double render error
         return if @redirect_action.present?
 
-        format.html { redirect_to edit_api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully updates." }
+        format.html { redirect_to edit_api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully updated." }
         format.json { render :show, status: :ok, location: @api_resource }
       else
         execute_error_actions

--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -64,8 +64,6 @@ module ApiActionable
         handle_redirection if @redirect_action.present?
       end
     end if api_actions.present?
-
-    flash[:notice] = @api_resource.api_namespace.api_form.success_message_evaluated if @api_namespace.api_form&.success_message&.present?
   end
 
   def handle_error(e)

--- a/app/views/comfy/admin/api_resources/_form.html.haml
+++ b/app/views/comfy/admin/api_resources/_form.html.haml
@@ -2,7 +2,7 @@
 - path = @api_resource.persisted? ? api_namespace_resource_url : api_namespace_resources_url
 - is_edit = @api_resource.persisted? ? true : false
 - form_properties = @api_resource.api_namespace&.api_form&.properties&.symbolize_keys
-= form_for @api_resource, url: path, method: action, html: {multipart: true, onsubmit: 'return checkRequiredRichTextFields()'} do |f|
+= form_for @api_resource, url: path, method: action, html: {multipart: true, onsubmit: 'return checkRequiredRichTextFields()'}, remote: true do |f|
   - if @api_resource.errors.any?
     #error_explanation
       %h2= "#{pluralize(@api_resource.errors.count, "error")} prohibited this api_resource from being saved:"

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -330,6 +330,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
     end
 
+    # ApiForm's custom success-message is only shown when the form submitted by end-user.
     assert_equal 'test success message', flash[:notice]
     refute flash[:error]
   end
@@ -351,6 +352,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
     end
 
+    # ApiForm's custom success-message is only shown when the form submitted by end-user.
     assert_equal 'test success message', flash[:notice]
     refute flash[:error]
   end
@@ -369,6 +371,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
 
     assert_response :success
+    # ApiForm's custom success-message is only shown when the form submitted by end-user.
     assert_equal "<div class=\"custom-class\">test success message #{api_namespace.id}</div>", flash[:notice]
   end
 
@@ -387,6 +390,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
 
     assert_response :success
+    # ApiForm's custom success-message is only shown when the form submitted by end-user.
     assert_equal "<div class=\"custom-class\">test success message #{api_namespace.id}</div>", flash[:notice]
   end
 


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/949 and https://github.com/restarone/violet_rails/issues/1043

**Demo for creating an API resource from admin results in broken page**

https://user-images.githubusercontent.com/25191509/187018834-7f2ca39f-2020-4755-b0c5-74aebb856380.mp4

**Demo for API form success flash message randomly showing in admin UI**

https://user-images.githubusercontent.com/25191509/187018864-32ed9a84-fa01-4040-b8b7-9bbc954771d9.mp4



