### PR TITLE
[Bug fix]: API form success flash message randomly showing in admin UI & creating an API resource from admin results in broken page

### DIFF
--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -48,7 +48,7 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
         # Preventing double render error
         return if @redirect_action.present?
 
-        format.html { redirect_to edit_api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully updates." }
+        format.html { redirect_to edit_api_namespace_resource_path(api_namespace_id: @api_resource.api_namespace_id,id: @api_resource.id), notice: "Api resource was successfully updated." }
         format.json { render :show, status: :ok, location: @api_resource }
       else
         execute_error_actions

--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -44,7 +44,13 @@ module ApiActionable
     if @redirect_action.present?
       redirect_url = @redirect_action.dynamic_url? ? @redirect_action.redirect_url_evaluated : @redirect_action.redirect_url
       if @redirect_action.update!(lifecycle_stage: 'complete', lifecycle_message: redirect_url)
-        redirect_with_js(redirect_url) and return
+        # Redirecting with JS is only needed when dealing with reCaptcha.
+        # reCaptcha related request is handled by ResourceController
+        if controller_name == "resource"
+          redirect_with_js(redirect_url) and return
+        else
+          redirect_to redirect_url and return
+        end
       else
         @redirect_action.update!(lifecycle_stage: 'failed', lifecycle_message: redirect_url)
         execute_error_actions
@@ -64,8 +70,6 @@ module ApiActionable
         handle_redirection if @redirect_action.present?
       end
     end if api_actions.present?
-
-    flash[:notice] = @api_resource.api_namespace.api_form.success_message_evaluated if @api_namespace.api_form&.success_message&.present?
   end
 
   def handle_error(e)
@@ -86,7 +90,13 @@ module ApiActionable
 
     if redirect_action
       redirect_action.update(lifecycle_stage: 'complete', lifecycle_message: redirect_action.redirect_url)
-      redirect_with_js(redirect_action.redirect_url) and return
+      # Redirecting with JS is only needed when dealing with reCaptcha.
+      # reCaptcha related request is handled by ResourceController
+      if controller_name == "resource"
+        redirect_with_js(redirect_url) and return
+      else
+        redirect_to redirect_url and return
+      end
     end
 
     @error_api_actions_exectuted = true

--- a/test/controllers/admin/comfy/api_resources_controller_test.rb
+++ b/test/controllers/admin/comfy/api_resources_controller_test.rb
@@ -23,6 +23,8 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
     redirect_action = @api_namespace.create_api_actions.where(action_type: 'redirect').last
     redirect_action.update(redirect_url: '/')
 
+    @api_namespace.api_form.update(success_message: 'test success message')
+
     perform_enqueued_jobs do
       assert_difference('ApiResource.count') do
         post api_namespace_resources_url(api_namespace_id: @api_namespace.id), params: { api_resource: { properties: payload_as_stringified_json } }
@@ -32,13 +34,20 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
 
     assert ApiResource.last.properties
     assert_equal JSON.parse(payload_as_stringified_json).symbolize_keys.keys, ApiResource.last.properties.symbolize_keys.keys
-    assert_equal "window.location.replace('#{redirect_action.redirect_url}')", response.parsed_body
+    assert_redirected_to '/'
+    
+    # ApiForm's custom success-message is not shown when the form is submitted by from admin-side.
+    refute_equal'test success message', flash[:notice]
   end
 
   test "should show api_resource" do
+    @api_namespace.api_form.update(success_message: 'test success message')
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
     assert_response :success
+
+    # ApiForm's custom success-message is not shown when viewed from admin-side.
+    refute_equal'test success message', flash[:notice]
   end
 
   test "should get edit" do
@@ -54,6 +63,23 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
       Sidekiq::Worker.drain_all
     end
     assert_redirected_to edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_resource.id)
+    assert_equal 'Api resource was successfully updated.', flash[:notice]
+  end
+
+  test "should update api_resource and redirect properly according to defined redirect-api-action" do
+    @api_namespace.api_form.update(success_message: 'test success message')
+
+    redirect_action = @api_resource.update_api_actions.create!(action_type: 'redirect', redirect_url: root_url)
+
+    sign_in(@user)
+    perform_enqueued_jobs do
+      patch api_namespace_resource_url(@api_resource, api_namespace_id: @api_resource.api_namespace_id), params: { api_resource: { properties: @api_resource.properties } }, headers: { 'HTTP_REFERER': edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_resource.id) }
+      Sidekiq::Worker.drain_all
+    end
+
+    assert_redirected_to root_url
+    # ApiForm's custom success-message is not shown when viewed from admin-side.
+    refute_equal 'test success message', flash[:notice]
   end
 
   test "should execute failed response api_resource" do

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -330,6 +330,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
     end
 
+    # ApiForm's custom success-message is only shown when the form submitted by end-user.
     assert_equal 'test success message', flash[:notice]
     refute flash[:error]
   end
@@ -351,6 +352,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
       post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
     end
 
+    # ApiForm's custom success-message is only shown when the form submitted by end-user.
     assert_equal 'test success message', flash[:notice]
     refute flash[:error]
   end
@@ -369,6 +371,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
 
     assert_response :success
+    # ApiForm's custom success-message is only shown when the form submitted by end-user.
     assert_equal "<div class=\"custom-class\">test success message #{api_namespace.id}</div>", flash[:notice]
   end
 
@@ -387,6 +390,7 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
 
     assert_response :success
+    # ApiForm's custom success-message is only shown when the form submitted by end-user.
     assert_equal "<div class=\"custom-class\">test success message #{api_namespace.id}</div>", flash[:notice]
   end
 


### PR DESCRIPTION
# [Bug fix]: API form success flash message randomly showing in admin UI & creating an API resource from admin results in broken page

Addresses: https://github.com/restarone/violet_rails/issues/949 and https://github.com/restarone/violet_rails/issues/1043

**Demo for creating an API resource from admin results in broken page**

https://user-images.githubusercontent.com/25191509/187018834-7f2ca39f-2020-4755-b0c5-74aebb856380.mp4

**Demo for API form success flash message randomly showing in admin UI**

https://user-images.githubusercontent.com/25191509/187018864-32ed9a84-fa01-4040-b8b7-9bbc954771d9.mp4

Co-authored-by: Prashant <alish.khadka@gmail.com>
Co-authored-by: Prashant Khadka <prashant.khadka052@gmail.com>