### PR TITLE
[Bug Fix]: if there are slashes in the API Namespace name, the generated documentation is wrong

### DIFF
--- a/app/helpers/api_namespaces_helper.rb
+++ b/app/helpers/api_namespaces_helper.rb
@@ -1,6 +1,6 @@
 module ApiNamespacesHelper
   def api_base_url(subdomain, namespace)
-    "#{subdomain.hostname}/api/#{namespace.version}/#{namespace.name}"
+    "#{subdomain.hostname}/api/#{namespace.version}/#{namespace.slug}"
   end
 
   def graphql_base_url(subdomain, namespace)

--- a/test/fixtures/api_namespaces.yml
+++ b/test/fixtures/api_namespaces.yml
@@ -155,3 +155,8 @@ no_api_actions:
               }
   requires_authentication: false
   namespace_type: create-read-update-delete
+
+namespace_with_slash:
+  name: slash/namespace
+  slug: slash-namespace
+  version: 1

--- a/test/helpers/api_namespaces_helper_test.rb
+++ b/test/helpers/api_namespaces_helper_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class ApiNamespacesHelperTest < ActionView::TestCase
+  test 'should use slug of api_namespace to contruct the url instead of using name' do
+    namespace = api_namespaces(:namespace_with_slash)
+    assert_includes(api_base_url(Subdomain.current, namespace), namespace.slug)
+    refute_includes(api_base_url(Subdomain.current, namespace), namespace.name)
+  end
+end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/1018

![image](https://user-images.githubusercontent.com/25191509/189281941-dd5bc407-fafd-470c-84a0-1744ee10f02f.png)
