### PR TITLE
Api HTML renderer: Allow ALL/ANY match on array + limit resources

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -20,20 +20,22 @@ module ContentHelper
   # render resource index
   # available variables on view: @api_resources, @api_namespace
   def render_api_namespace_resource_index(slug, options = {})
-    scope = options["scope"]
+    scope = options["scope"] || {}
 
     api_namespace = ApiNamespace.find_by(slug: slug)
     response = api_namespace.api_resources
 
     response = response.where.not(user_id: nil).where(user_id: current_user&.id) if scope&.dig('current_user') == 'true'
 
-    response = response.jsonb_search(:properties, scope["properties"]) if scope&.has_key?("properties")
+    response = response.jsonb_search(:properties, scope["properties"]) if scope["properties"]
 
     response = response.jsonb_search(:properties, JSON.parse(params[:properties]).to_hash) if params[:properties]
 
     response = response.jsonb_order(options["order"]) if options["order"]
 
     response = response.jsonb_order(JSON.parse(params[:order]).to_hash) if params[:order].present?
+
+    response = response.limit(options["limit"]) if options["limit"]
 
     cms_dynamic_snippet_render(slug, nil, { api_resources: response, api_namespace: api_namespace })
   end

--- a/test/helpers/content_helper_test.rb
+++ b/test/helpers/content_helper_test.rb
@@ -9,11 +9,11 @@ class ContentHelperTest < ActionView::TestCase
     @cms_site = comfy_cms_sites(:public)
 
     @api_namespace = api_namespaces(:one) 
-    @api_resource = ApiResource.create(api_namespace_id: @api_namespace.id, properties: { name: 'test user 0' })
+    @api_resource = ApiResource.create(api_namespace_id: @api_namespace.id, properties: { name: 'test user 0', tags: ['action', 'comedy'], json: {'foo': 'bar', 'abc': 'xyz'} })
     
     Current.user = @user
-    @api_resource_1 = ApiResource.create(api_namespace_id: @api_namespace.id, properties: { name: 'test user 1' })
-    @api_resource_2 = ApiResource.create(api_namespace_id: @api_namespace.id, properties: { name: 'test user 2' })
+    @api_resource_1 = ApiResource.create(api_namespace_id: @api_namespace.id, properties: { name: 'test user 1', tags: ['action', 'superhero'], json: {'bar': 'baz'} })
+    @api_resource_2 = ApiResource.create(api_namespace_id: @api_namespace.id, properties: { name: 'test user 2', tags: ['action', 'comedy', 'superhero'], json: {'abc': 'xyz'} })
   end
 
   test 'logged_in_user_render when used is logged in and snippet is html string' do
@@ -253,6 +253,210 @@ class ContentHelperTest < ActionView::TestCase
 
     response = render_api_namespace_resource_index(@api_namespace.slug, {'order' => { 'properties' => { 'name' => 'DESC' } } } )
     excepted_response = "#{@api_resource.properties['name']}#{@api_resource_1.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+  end
+
+  test 'render_api_namespace_resource_index - array search - properties scope - exact match' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['action', 'comedy'], option: 'EXACT' } } } })
+    excepted_response = "#{@api_resource.properties['name']}"
+    assert_equal excepted_response, response
+
+    # should work irrespective of order of array elements
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['comedy', 'action'], option: 'EXACT' } } } })
+    excepted_response = "#{@api_resource.properties['name']}"
+    assert_equal excepted_response, response
+
+    # atleast 1 match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['comedy', 'not action'], option: 'EXACT' } } } })
+    assert_equal "", response
+
+    # no match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['not comedy', 'not action'], option: 'EXACT' } } } })
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - array search - properties scope - partial match ALL' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    
+    # all match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['action', 'comedy'], option: 'PARTIAL', match: 'ALL'} } } })
+    excepted_response = "#{@api_resource.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+
+    # at least 1 match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['not action', 'comedy'], option: 'PARTIAL', match: 'ALL'} } } })
+    assert_equal "", response
+
+    # no match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['not action', 'not comedy'], option: 'PARTIAL', match: 'ALL'} } } })
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - array search - properties scope - partial match ANY' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+
+    # all match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['superhero', 'comedy'], option: 'PARTIAL', match: 'ANY'} } } })
+    excepted_response = "#{@api_resource.properties['name']}#{@api_resource_1.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response   
+    
+    # atleast 1 match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['superhero', 'not comedy'], option: 'PARTIAL', match: 'ANY'} } } })
+    excepted_response = "#{@api_resource_1.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+
+    # no match at all
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['no superhero', 'not comedy'], option: 'PARTIAL', match: 'ANY' } } } })
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - array search by params - exact match' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    
+    params[:properties] = { 'tags': { 'value': ['action', 'comedy'], option: 'EXACT' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource.properties['name']}"
+    assert_equal excepted_response, response
+
+    # should work irrespective of order of array elements
+    params[:properties] = { 'tags': { 'value': ['comedy', 'action'], option: 'EXACT' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource.properties['name']}"
+    assert_equal excepted_response, response
+
+    # atleast 1 match
+    params[:properties] = { 'tags': { 'value': ['not comedy', 'action'], option: 'EXACT' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    assert_equal "", response
+
+    # no match
+    params[:properties] = { 'tags': { 'value': ['not comedy', 'not action'], option: 'EXACT' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - array search by params - partial match ALL' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    
+    # all match
+    params[:properties] = { 'tags': { 'value': ['action', 'comedy'], option: 'PARTIAL', match: 'ALL'} }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+
+    # at least 1 match
+    params[:properties] = { 'tags': { 'value': ['not action', 'comedy'], option: 'PARTIAL', match: 'ALL'} }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    assert_equal "", response
+
+    # no match
+    params[:properties] = { 'tags': { 'value': ['not action', 'not comedy'], option: 'PARTIAL', match: 'ALL'} }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - array search by params - partial match ANY' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+
+    # all match
+    params[:properties] = { 'tags': { 'value': ['superhero', 'comedy'], option: 'PARTIAL', match: 'ANY'} }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource.properties['name']}#{@api_resource_1.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response   
+    
+    # atleast 1 match
+    params[:properties] = { 'tags': { 'value': ['superhero', 'not comedy'], option: 'PARTIAL', match: 'ANY'} }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource_1.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+
+    # no match at all
+    params[:properties] = { 'tags': { 'value': ['no superhero', 'not comedy'], option: 'PARTIAL', match: 'ANY' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - json search - properties scope - exact match' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'json': { 'value': {'foo': 'bar', 'abc': 'xyz'}, option: 'EXACT' } } } })
+    excepted_response = "#{@api_resource.properties['name']}"
+    assert_equal excepted_response, response
+
+    # should work irrespective of keys order
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'json': { 'value': {'abc': 'xyz', 'foo': 'bar' }, option: 'EXACT' } } } })
+    excepted_response = "#{@api_resource.properties['name']}"
+    assert_equal excepted_response, response
+
+    # atleast 1 match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'json': { 'value': {'abc': 'xyz' }, option: 'EXACT' } } } })
+    excepted_response = "#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+
+    # no match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'json': { 'value': {'abc': 'something else', 'foo': 'something else' }, option: 'EXACT' } } } })
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - json search - properties scope - partial match' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+  
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'json': { 'value': {'abc': 'xyz'}, option: 'PARTIAL', match: 'ALL'} } } })
+    excepted_response = "#{@api_resource.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+
+    # no match
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'json': { 'value': {'abc': 'something else'}, option: 'PARTIAL', match: 'ALL'} } } })
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - json search by params - exact match' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    
+    params[:properties] = { 'json': { 'value': {'foo': 'bar', 'abc': 'xyz'}, option: 'EXACT' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource.properties['name']}"
+    assert_equal excepted_response, response
+
+    # should work irrespective of keys order
+    params[:properties] = { 'json': { 'value': {'abc': 'xyz', 'foo': 'bar' }, option: 'EXACT' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource.properties['name']}"
+    assert_equal excepted_response, response
+
+    # atleast 1 match
+    params[:properties] = { 'json': { 'value': {'abc': 'xyz' }, option: 'EXACT' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+
+    # no match
+    params[:properties] = { 'json': { 'value': {'abc': 'something else' }, option: 'EXACT' } }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - json search by params - partial match' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+  
+    params[:properties] = { 'json': { 'value': {'abc': 'xyz'}, option: 'PARTIAL', match: 'ALL'} }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    excepted_response = "#{@api_resource.properties['name']}#{@api_resource_2.properties['name']}"
+    assert_equal excepted_response, response
+
+    # no match
+    params[:properties] = { 'json': { 'value': {'abc': 'something else'}, option: 'PARTIAL', match: 'ALL'} }.to_json
+    response = render_api_namespace_resource_index(@api_namespace.slug)
+    assert_equal "", response
+  end
+
+  test 'render_api_namespace_resource_index - limit resource' do
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'limit' => 2 })
+    excepted_response = "#{@api_resource.properties['name']}#{@api_resource_1.properties['name']}"
     assert_equal excepted_response, response
   end
 

--- a/test/helpers/content_helper_test.rb
+++ b/test/helpers/content_helper_test.rb
@@ -453,10 +453,11 @@ class ContentHelperTest < ActionView::TestCase
   end
 
   test 'render_api_namespace_resource_index - limit resource' do
-    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
     
-    response = render_api_namespace_resource_index(@api_namespace.slug, { 'limit' => 2 })
-    excepted_response = "#{@api_resource.properties['name']}#{@api_resource_1.properties['name']}"
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'limit' => '2', 'order' => { 'created_at': 'DESC' } })
+    excepted_response = "#{@api_resource_2.properties['name']}#{@api_resource_1.properties['name']}"
+
     assert_equal excepted_response, response
   end
 

--- a/test/models/concerns/jsonb_search/query_builder_test.rb
+++ b/test/models/concerns/jsonb_search/query_builder_test.rb
@@ -5,76 +5,101 @@ class JsonbSearch::QueryBuilderTest < ActiveSupport::TestCase
     query = { name: 'violet' } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "lower(properties ->> 'name') = lower('violet')"
+    assert_equal "lower(properties ->> 'name') = lower('violet')", jsonb_query
   end
 
   test 'query string - extended format' do
     query = { name: { value: 'violet', option: 'EXACT' } } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "lower(properties ->> 'name') = lower('violet')"
+    assert_equal "lower(properties ->> 'name') = lower('violet')", jsonb_query
   end
 
   test 'query string - partial' do
     query = { name: { value: 'violet', option: 'PARTIAL' } } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "lower(properties ->> 'name') LIKE lower('%violet%')"
+    assert_equal "lower(properties ->> 'name') LIKE lower('%violet%')", jsonb_query
   end
 
   test 'query string - multiple properties' do
     query = { name: { value: 'violet' }, age: 20 } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "lower(properties ->> 'name') = lower('violet') AND lower(properties ->> 'age') = lower('20')"
+    assert_equal "lower(properties ->> 'name') = lower('violet') AND lower(properties ->> 'age') = lower('20')", jsonb_query
   end
 
   test 'query string - nested' do
     query = { foo: { bar: 'baz' }  } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "lower(properties -> 'foo' ->> 'bar') = lower('baz')"
+    assert_equal "lower(properties -> 'foo' ->> 'bar') = lower('baz')", jsonb_query
   end
 
   test 'query json - exact' do
     query = { object: { value: { foo: 'bar' }, option: 'EXACT'} } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "properties -> 'object' = '#{query[:object][:value].to_json}'"
+    assert_equal "properties -> 'object' = '#{query[:object][:value].to_json}'", jsonb_query
   end
 
   test 'query json - partial' do
     query = { object: { value: { foo: 'bar' }, option: 'PARTIAL'} } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "properties -> 'object' @> '#{query[:object][:value].to_json}'"
+    assert_equal "properties -> 'object' @> '#{query[:object][:value].to_json}'", jsonb_query
   end
 
   test 'query array - exact' do
     query = { array: ['foo', 'bar'] } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "properties -> 'array' @> '#{query[:array].to_json}' AND properties -> 'array' <@ '#{query[:array].to_json}'"
+    assert_equal "properties -> 'array' @> '#{query[:array].to_json}' AND properties -> 'array' <@ '#{query[:array].to_json}'", jsonb_query
   end
 
-  test 'query array - partial' do
+  test 'query array - partial - no match option' do
     query = { array: { value: ['foo', 'bar'], option: 'PARTIAL' } } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "properties -> 'array' @> '#{query[:array][:value].to_json}'"
+    assert_equal "properties -> 'array' @> '#{query[:array][:value].to_json}'", jsonb_query
+  end
+
+  test 'query array - partial match all' do
+    query = { array: { value: ['foo', 'bar'], option: 'PARTIAL', match: 'ALL' } } 
+    jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
+
+    assert_equal "properties -> 'array' @> '#{query[:array][:value].to_json}'", jsonb_query
+  end
+
+  test 'query array - partial match any' do
+    query = { array: { value: ['foo', 'bar'], option: 'PARTIAL', match: 'ANY' } } 
+    jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
+
+    assert_equal "properties -> 'array' ? '#{query[:array][:value][0]}' OR properties -> 'array' ? '#{query[:array][:value][1]}'", jsonb_query
   end
 
   test 'query array - nested' do
-
     query = { foo: { array: ['foo', 'bar'] } } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
-    assert_equal jsonb_query, "properties -> 'foo' -> 'array' @> '#{query[:foo][:array].to_json}' AND properties -> 'foo' -> 'array' <@ '#{query[:foo][:array].to_json}'"
+    assert_equal "properties -> 'foo' -> 'array' @> '#{query[:foo][:array].to_json}' AND properties -> 'foo' -> 'array' <@ '#{query[:foo][:array].to_json}'", jsonb_query 
 
     # extended query 
     query = { foo: { array: { value: ['foo', 'bar'], option: 'PARTIAL' } } } 
     jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
 
     assert_equal jsonb_query, "properties -> 'foo' -> 'array' @> '#{query[:foo][:array][:value].to_json}'"
+
+    # extended query - match all
+    query = { foo: { array: { value: ['foo', 'bar'], option: 'PARTIAL', match: 'ALL' } } } 
+    jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
+
+    assert_equal "properties -> 'foo' -> 'array' @> '#{query[:foo][:array][:value].to_json}'", jsonb_query
+
+    # extended query - match any
+    query = { foo: { array: { value: ['foo', 'bar'], option: 'PARTIAL', match: 'ANY' } } } 
+    jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query)
+
+    assert_equal "properties -> 'foo' -> 'array' ? '#{query[:foo][:array][:value][0]}' OR properties -> 'foo' -> 'array' ? '#{query[:foo][:array][:value][1]}'", jsonb_query
   end
 end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/267, https://github.com/restarone/violet_rails/pull/1047#issuecomment-1249379969

### How to use

Returns records that contains both of given values
`render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['not action', 'comedy'], option: 'PARTIAL', match: 'ALL'} } } })`

Returns records that contains atleast one of given values
`render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'properties' => { 'tags': { 'value': ['not action', 'comedy'], option: 'PARTIAL', match: 'ANY'} } } })`


#### Limit Usage
`render_api_namespace_resource_index(@api_namespace.slug, { 'limit': 10 })`
