### PR TITLE
Transcript parser plugin

### DIFF
--- a/test/fixtures/api_namespaces.yml
+++ b/test/fixtures/api_namespaces.yml
@@ -155,3 +155,13 @@ no_api_actions:
               }
   requires_authentication: false
   namespace_type: create-read-update-delete
+
+namespace_with_transcript:
+  name: namespace_with_transcript
+  slug: namespace_with_transcript
+  version: 1
+  properties: {
+    "raw_transcript": "",
+    "transcript": "",
+    "transcript_parsed": false
+  }

--- a/test/fixtures/api_resources.yml
+++ b/test/fixtures/api_resources.yml
@@ -73,3 +73,11 @@ resource_with_all_types_two:
     'number': 666,
     'null': false
   }
+
+transcript:
+  api_namespace: namespace_with_transcript
+  properties: {
+    "raw_transcript": "1\n00:00:00,300 --> 00:00:02,167\n[sally]: i'm in los angeles and\n\n2\n00:00:01,920 --> 00:00:02,102\n[bobby]: okay\n\n3\n00:00:03,151 --> 00:00:04,737\n[sally]: maybe possibly\n\n4\n00:00:05,780 --> 00:00:13,613\n[bobby78]: $ oh maybe ye so nice an is a\nsupporter financial supporter of hollows\n\n5\n00:00:13,345 --> 00:00:15,510\n[sally]: 10 s yeah",
+    "transcript": "",
+    "transcript_parsed": false
+  }

--- a/test/fixtures/external_api_clients.yml
+++ b/test/fixtures/external_api_clients.yml
@@ -360,3 +360,43 @@ sync_attribute_to_api_namespace_plugin:
     end
     # at the end of the file we have to implicitly return the class 
     SyncAttributeToApiNamespace
+
+transcript_parser_plugin:
+  api_namespace: namespace_with_transcript
+  slug: transcript-parser
+  label: TranscriptParser
+  enabled: true
+  metadata: {
+            'INPUT_STRING_PROPERTY': 'raw_transcript',
+            'OUTPUT_STRING_PROPERTY': 'transcript',
+          }
+  model_definition: |
+    class TranscriptParser
+      def initialize(parameters)
+        @external_api_client = parameters[:external_api_client]
+        @api_namespace = @external_api_client.api_namespace
+        @api_resources_with_no_parsed_transcript = @api_namespace.api_resources.where("properties @> ?", {transcript_parsed: false}.to_json)
+      end
+
+      def start
+        input_string_property = @external_api_client.metadata["INPUT_STRING_PROPERTY"]
+        output_string_property = @external_api_client.metadata["OUTPUT_STRING_PROPERTY"]
+
+        raise "Input and output string properties cannot be the same (no overwriting allowed)" if input_string_property == output_string_property 
+        raise "The specified input string property does not exist" unless @api_namespace.properties.key?(input_string_property)
+        raise "The specified output string property does not exist" unless @api_namespace.properties.key?(output_string_property)
+
+        @api_resources_with_no_parsed_transcript.each do |api_resource|
+          raw_transcript = api_resource.properties[input_string_property]
+          # ^([\d\n][0-9:,->\s]*\n) matches numbers and timestamps at the beginning or newline characters at the beginning or end of a line
+          # ^(\[\w*\]:\s) matches names within [], e.g. [sally], [sally32]
+          # gsub(/\n/, " ") is used to add whitespace between lines of text
+          parsed_transcript = raw_transcript.strip.gsub(/^([\d\n][0-9:,->\s]*\n)|^(\[\w*\]:\s)/i, "").gsub(/\n/, " ")
+          api_resource.properties[output_string_property] = parsed_transcript
+          api_resource.properties["transcript_parsed"] = true
+          api_resource.save
+        end
+      end
+    end
+    # at the end of the file we have to implicitly return the class 
+    TranscriptParser

--- a/test/fixtures/external_api_clients.yml
+++ b/test/fixtures/external_api_clients.yml
@@ -511,7 +511,7 @@ transcript_parser_plugin:
           # gsub(/\n/, " ") is used to add whitespace between lines of text
           parsed_transcript = raw_transcript.strip.gsub(/^([\d\n][0-9:,->\s]*\n)|^(\[\w*\]:\s)/i, "").gsub(/\n/, " ")
           api_resource.properties[output_string_property] = parsed_transcript
-          api_resource.properties["transcript_parsed"] = true
+          api_resource.properties["transcript_parsed"] = true unless parsed_transcript.blank?
           api_resource.save
         end
       end

--- a/test/plugins/transcript_parser_plugin_test.rb
+++ b/test/plugins/transcript_parser_plugin_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class TranscriptParserPluginTest < ActiveSupport::TestCase
+    setup do
+        @transcript_parser_plugin = external_api_clients(:transcript_parser_plugin)
+        @api_namespace = @transcript_parser_plugin.api_namespace
+        @transcript = api_resources(:transcript)
+        Sidekiq::Testing.fake!
+    end
+
+    # How test fixtures are set up:
+    # By default, transcript_parsed is set to false
+    # By default, transcript property is empty, i.e. no parsed transcript
+
+    test "Should raise an error if the provided input and output string properties are the same" do
+        metadata = {
+            "INPUT_STRING_PROPERTY": "raw_transcript",
+            "OUTPUT_STRING_PROPERTY": "raw_transcript",
+        }
+        @transcript_parser_plugin.update(metadata: metadata)
+
+        perform_enqueued_jobs do
+            @transcript_parser_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        expected_error_message = "Input and output string properties cannot be the same (no overwriting allowed)"
+        assert_equal expected_error_message, @transcript_parser_plugin.reload.error_message
+    end
+
+    test "Should raise an error if the provided input string property does not exist" do
+        metadata = @transcript_parser_plugin.metadata
+        metadata["INPUT_STRING_PROPERTY"] = "non-existent property"
+        @transcript_parser_plugin.update(metadata: metadata)
+
+        perform_enqueued_jobs do
+            @transcript_parser_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        expected_error_message = "The specified input string property does not exist"
+        assert_equal expected_error_message, @transcript_parser_plugin.reload.error_message
+    end
+
+    test "Should raise an error if the provided output string property does not exist" do
+        metadata = @transcript_parser_plugin.metadata
+        metadata["OUTPUT_STRING_PROPERTY"] = "non-existent property"
+        @transcript_parser_plugin.update(metadata: metadata)
+
+        perform_enqueued_jobs do
+            @transcript_parser_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        expected_error_message = "The specified output string property does not exist"
+        assert_equal expected_error_message, @transcript_parser_plugin.reload.error_message
+    end
+
+    test "Should not parse transcript if it has already been parsed" do
+        @transcript.properties["transcript_parsed"] = true
+        @transcript.save
+
+        perform_enqueued_jobs do
+            @transcript_parser_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        assert(@transcript.reload.properties["transcript"].empty?)
+    end
+
+    test "Transcript is parsed correctly" do
+        raw_transcript = "1\n00:00:00,300 --> 00:00:02,167\n[sally]: i'm in los angeles and\n\n2\n00:00:01,920 --> 00:00:02,102\n[bobby]: okay\n\n3\n00:00:03,151 --> 00:00:04,737\n[sally]: maybe possibly\n\n4\n00:00:05,780 --> 00:00:13,613\n[bobby78]: $ oh maybe ye so nice an is a\nsupporter financial supporter of hollows\n\n5\n00:00:13,345 --> 00:00:15,510\n[sally]: 10 s yeah\n10 hello world\nhi there\n$10 in my wallet"
+        properties = {"raw_transcript": raw_transcript, "transcript": "", "transcript_parsed": false}
+        transcript_resource = ApiResource.create(api_namespace_id: @api_namespace.id, properties: properties)
+        expected_parsed_transcript = "i'm in los angeles and okay maybe possibly $ oh maybe ye so nice an is a supporter financial supporter of hollows 10 s yeah 10 hello world hi there $10 in my wallet"
+        
+        perform_enqueued_jobs do
+            @transcript_parser_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+    
+        assert_equal expected_parsed_transcript, transcript_resource.reload.properties["transcript"]
+    end
+
+    test "Transcript with leading and trailing whitespace is parsed correctly" do
+        raw_transcript = "      1\n00:00:00,300 --> 00:00:02,167\n[sally]: i'm in los angeles and\n\n2\n00:00:01,920 --> 00:00:02,102\n[bobby]: okay\n\n3\n00:00:03,151 --> 00:00:04,737\n[sally]: maybe possibly\n\n4\n00:00:05,780 --> 00:00:13,613\n[bobby78]: $ oh maybe ye so nice an is a\nsupporter financial supporter of hollows\n\n5\n00:00:13,345 --> 00:00:15,510\n[sally]: 10 s yeah     "
+        properties = {"raw_transcript": raw_transcript, "transcript": "", "transcript_parsed": false}
+        transcript_resource = ApiResource.create(api_namespace_id: @api_namespace.id, properties: properties)
+        expected_parsed_transcript = "i'm in los angeles and okay maybe possibly $ oh maybe ye so nice an is a supporter financial supporter of hollows 10 s yeah"
+        
+        perform_enqueued_jobs do
+            @transcript_parser_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+    
+        assert_equal expected_parsed_transcript, transcript_resource.reload.properties["transcript"]
+    end
+end


### PR DESCRIPTION
Addresses #1120 

# Transcript parser plugin

This plugin takes a video transcript and generates a clean version of it by removing numbers, timestamps, and names. Given a transcript like this:

```
1
00:00:00,300 --> 00:00:02,167
[sally]: i'm in los angeles and

2
00:00:01,920 --> 00:00:02,102
[bobby]: okay

3
00:00:03,151 --> 00:00:04,737
[sally]: maybe possibly

4
00:00:05,780 --> 00:00:13,613
[bobby78]: $ oh maybe ye so nice an is a
supporter financial supporter of hollows

5
00:00:13,345 --> 00:00:15,510
[sally]: 10 s yeah
10 hello world
hi there
$10 in my wallet
```

The plugin will parse the transcript and generate a clean version of it:

```
i'm in los angeles and okay maybe possibly $ oh maybe ye so nice an is a supporter financial supporter of hollows 10 s yeah 10 hello world hi 
there $10 in my wallet
```

![raw-and-parsed-transcripts](https://user-images.githubusercontent.com/73725297/191982630-c91e994b-d1a5-4d9a-83f0-ecc9f267eaa0.PNG)

## Metadata

The plugin requires the following metadata:

INPUT_STRING_PROPERTY: the name of the property that points to the raw unchanged transcript
OUTPUT_STRING_PROPERTY: the name of the property to which the plugin will write the parsed clean version of the transcript

- `INPUT_STRING_PROPERTY` and `OUTPUT_STRING_PROPERTY` must exist on the API resources of the API namespace that the plugin will run against
- `INPUT_STRING_PROPERTY` and `OUTPUT_STRING_PROPERTY` cannot be the same property (no overwriting is allowed)

![transcript-parser-metadata](https://user-images.githubusercontent.com/73725297/191981733-9b3b6ac5-e0f6-48e5-a73d-47786ff15c1b.PNG)

## Deciding if a transcript needs to be parsed

Each API resource should have a boolean property called `transcript_parsed`. The plugin uses this property to check if a transcript needs to be parsed. If `transcript_parsed` is `true`, then the plugin will not parse that transcript. Once the transcript of an API resource is parsed, the plugin sets its `transcript_parsed` property to `true`.

## Video demo


https://user-images.githubusercontent.com/73725297/191982004-3e257496-c2f6-481a-8ecc-1812b3bac6c6.mp4

