### PR TITLE
[feature] Compliance visitor data request plugin

### DIFF
--- a/app/mailers/e_mailer.rb
+++ b/app/mailers/e_mailer.rb
@@ -10,6 +10,16 @@ class EMailer < ApplicationMailer
             end
     message_id = "#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@#{Apartment::Tenant.current}@#{ENV['APP_HOST']}"
     @message_thread.update(current_email_message_id: message_id)
+    
+    # if additional attachment params are passed, they are included in the email
+    unless params[:attachments].nil?
+      Array.wrap(params[:attachments]).each do |attachment|
+        attachments[attachment[:filename]] = {
+          mime_type: attachment[:mime_type],
+          content: attachment[:content]
+        }
+      end
+    end
 
     mail(
       # This will make the mail addresses visible to all (no Blank Carbon Copy)

--- a/app/services/violet/connection.rb
+++ b/app/services/violet/connection.rb
@@ -1,0 +1,15 @@
+# Utitlity class for external API connection plugins
+class Violet::Connection
+    def get_blob_url(attachment)
+        Rails.application.routes.url_helpers.rails_blob_url(attachment, subdomain: Apartment::Tenant.current, host: ENV['APP_HOST'])
+    end
+
+    def get_subdomain_email_address
+        subdomain = Subdomain.current
+        if subdomain.email_name.present?
+            "#{subdomain.email_name} <#{subdomain.name}@#{ENV["APP_HOST"]}>"
+        else
+            "#{subdomain.name}@#{ENV["APP_HOST"]}"
+        end
+    end
+end

--- a/test/fixtures/api_namespaces.yml
+++ b/test/fixtures/api_namespaces.yml
@@ -155,3 +155,37 @@ no_api_actions:
               }
   requires_authentication: false
   namespace_type: create-read-update-delete
+
+compliance_visitor_data_request:
+  name: compliance/visitor/request
+  slug: compliance-visitor-request
+  version: 1
+  properties: {
+    'name': '',
+    'email': '',
+    'compliance_message_sent': false
+  }
+  requires_authentication: false
+  namespace_type: create-read-update-delete
+
+namespace_with_email_one:
+  name: namespace_with_email_one
+  slug: namespace_with_email_one
+  version: 1
+  properties: {
+    'post': '',
+    'email': '',
+  }
+  requires_authentication: false
+  namespace_type: create-read-update-delete
+
+namespace_with_email_two:
+  name: namespace_with_email_two
+  slug: namespace_with_email_two
+  version: 1
+  properties: {
+    'email': '',
+    'name': '',
+  }
+  requires_authentication: false
+  namespace_type: create-read-update-delete

--- a/test/fixtures/api_resources.yml
+++ b/test/fixtures/api_resources.yml
@@ -55,6 +55,20 @@ mailchimp:
     'contact': '555-777',
     'synced_to_mailchimp': false
   }
+compliance_visitor_data_request_one:
+  api_namespace: compliance_visitor_data_request
+  properties: {
+    'name': 'Test Name 1',
+    'email': 'user1-compliance@example.com',
+    'compliance_message_sent': false
+  }
+compliance_visitor_data_request_two:
+  api_namespace: compliance_visitor_data_request
+  properties: {
+    'name': 'Test Name 2',
+    'email': 'user2-compliance@example.com',
+    'compliance_message_sent': false
+  }
 resource_with_all_types_one:
   api_namespace: namespace_with_all_types                
   properties: {

--- a/test/fixtures/external_api_clients.yml
+++ b/test/fixtures/external_api_clients.yml
@@ -1,4 +1,3 @@
-
 test:
   api_namespace: two
   slug: test-second
@@ -360,3 +359,122 @@ sync_attribute_to_api_namespace_plugin:
     end
     # at the end of the file we have to implicitly return the class 
     SyncAttributeToApiNamespace
+
+compliance_visitor_data_request_plugin:
+  api_namespace: compliance_visitor_data_request
+  slug: compliance-visitor-request
+  label: ComplianceVisitorDataRequest
+  enabled: true
+  metadata:
+    {
+      "EXCLUDE_API_NAMESPACES":
+        ["subdomain_events", "compliance-visitor-request"],
+      "MESSAGE": "This is your data request, please see it below",
+    }
+  model_definition: |
+    class ComplianceVisitorDataRequest
+      def initialize(parameters)
+        @external_api_client = parameters[:external_api_client]
+        @visitor_api_namespace = @external_api_client.api_namespace
+        @visitor_api_resources_with_no_message_sent = @visitor_api_namespace.api_resources.where("properties @> ?", {compliance_message_sent: false}.to_json)
+        @connection_service = Violet::Connection.new
+      end
+
+      def start
+        excluded_api_namespaces = @external_api_client.metadata["EXCLUDE_API_NAMESPACES"].nil? ? [] : @external_api_client.metadata["EXCLUDE_API_NAMESPACES"]
+        should_scan_all_namespaces = excluded_api_namespaces.length > 0 ? false : @external_api_client.metadata["SCAN_ALL_NAMESPACES"]
+        message = @external_api_client.metadata["MESSAGE"]
+
+        @visitor_api_resources_with_no_message_sent.each do |visitor_api_resource|
+          visitor_email = visitor_api_resource.properties["email"]
+          attachments = []
+
+          raise "Permission to scan all api namespaces is not given" if excluded_api_namespaces.length == 0 && !should_scan_all_namespaces
+          
+          # determine which api namespaces need to be scanned
+          included_api_namespaces = ApiNamespace.where.not(slug: excluded_api_namespaces)
+
+          included_api_namespaces.each do |api_namespace|
+            # api resources that the visitor submitted
+            api_resources = api_namespace.api_resources.where("properties @> ?", {email: visitor_email}.to_json)
+
+            # if there are no api resources for this api namespace, then no need to attach a CSV file
+            if api_resources.length > 0
+              attachment = {
+                filename: "api_namespace_#{api_namespace.slug}_#{DateTime.now.to_i}.csv",
+                mime_type: "text/csv",
+                content: generate_csv_with_api_resources(api_namespace, api_resources)
+              }
+              attachments << attachment
+            end
+          end
+
+          if (attachments.length > 0)
+            email_thread = MessageThread.create(subject: "#{visitor_email} compliance: visitor submitted data request", recipients: [visitor_email])
+            email_message = email_thread.messages.create(content: "<p>#{message}</p>#{get_action_text_content(attachments)}", from: @connection_service.get_subdomain_email_address)
+            EMailer.with(message: email_message, message_thread: email_thread, attachments: attachments).ship.deliver_later
+            # Currently sending emails asynchronously and not checking if they got sent successfully before setting compliance_message_sent to true
+            visitor_api_resource.properties["compliance_message_sent"] = true
+            visitor_api_resource.save
+          end
+        end
+      end
+
+      def get_action_text_content(attachments)
+        action_text_content = ""
+        attachments.each do |attachment|
+          blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new(attachment[:content]), filename: attachment[:filename], content_type: attachment[:mime_type], metadata: nil)
+          action_text_content += "<action-text-attachment sgid='#{blob.attachable_sgid}'></action-text-attachment>"
+        end
+        ActionText::Content.new(action_text_content).to_s
+      end
+
+      def generate_csv_with_api_resources(api_namespace, api_resources)
+        main_headers = ApiResource.column_names.reject {|header| header == "user_id"}
+        top_level_attributes = api_namespace.properties.keys
+        property_column_index = main_headers.index('properties')
+        effective_headers = main_headers.dup.insert(property_column_index, *top_level_attributes)
+        effective_headers.delete('properties')
+        non_primitive_columns = api_namespace.non_primitive_properties.pluck(:label)
+        effective_headers += non_primitive_columns
+
+        csv_content = CSV.generate do |csv|
+          # adding column headers
+          csv << effective_headers
+
+          api_resources.each do |api_resource|
+            row_data = []
+            # Populating primitive columns
+            main_headers.each do |header|
+              data = api_resource[header]
+              if header == "properties"
+                propsData = data
+                top_level_attributes.each do |attribute|
+                  row_data << (propsData[attribute].nil? ? "" : propsData[attribute])
+                end
+              else
+                row_data << data
+              end
+            end
+
+            # Populating non-primitive columns
+            non_primitive_columns.each do |label|
+              non_primitive_property = api_resource.non_primitive_properties.find_by(label: label)
+              if non_primitive_property.present? && non_primitive_property.richtext?
+                row_data << non_primitive_property.content.to_s
+              elsif non_primitive_property.present? && non_primitive_property.file?
+                blob_url = non_primitive_property.attachment.attached? ? @connection_service.get_blob_url(non_primitive_property.attachment) : ''
+                row_data << blob_url
+              else
+                row_data << ''
+              end
+            end
+
+            csv << row_data
+          end
+        end
+        csv_content.html_safe
+      end
+    end
+    # at the end of the file we have to implicitly return the class 
+    ComplianceVisitorDataRequest

--- a/test/plugins/compliance_visitor_data_request_plugin_test.rb
+++ b/test/plugins/compliance_visitor_data_request_plugin_test.rb
@@ -1,0 +1,212 @@
+require "test_helper"
+
+class ComplianceVisitorDataRequestPluginTest < ActiveSupport::TestCase
+    setup do
+        @data_request_plugin = external_api_clients(:compliance_visitor_data_request_plugin)
+        @visitor_api_namespace = api_namespaces(:compliance_visitor_data_request)
+        @visitor_one = api_resources(:compliance_visitor_data_request_one)
+        @visitor_two = api_resources(:compliance_visitor_data_request_two)
+
+        @namespace_with_email_one = api_namespaces(:namespace_with_email_one)
+        @namespace_with_email_two = api_namespaces(:namespace_with_email_two)
+
+        Sidekiq::Testing.fake!
+
+        # How test fixtures are set up:
+        # By default, "compliance_message_sent" of each visitor api resource is false
+        # By default, each visitor has no submission in an api namespace
+    end
+
+    test "Should not send email to visitor if they already received one" do
+        @visitor_one.properties["compliance_message_sent"] = true
+        @visitor_one.save
+        @visitor_two.properties["compliance_message_sent"] = true
+        @visitor_two.save
+
+        assert_no_difference "ActionMailer::Base.deliveries.size" do
+            perform_enqueued_jobs do
+                @data_request_plugin.run
+                Sidekiq::Worker.drain_all
+            end
+        end
+    end
+
+    test "Should send email if compliance_message_sent is set to false on the API resource" do
+        # Visitor one and two are making a submission under namespace_with_email_one
+        ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": @visitor_one.properties["email"]})
+        ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": @visitor_two.properties["email"]})
+        assert_difference "ActionMailer::Base.deliveries.size", +2 do
+            perform_enqueued_jobs do
+                @data_request_plugin.run
+                Sidekiq::Worker.drain_all
+            end 
+        end
+    end
+
+    test "Sender and recipient email addresses and body message are correct" do
+        visitor_email = @visitor_one.properties["email"]
+        ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": visitor_email})
+
+        expected_message = @data_request_plugin.metadata["MESSAGE"]
+
+        perform_enqueued_jobs do
+            @data_request_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        sent_email = ActionMailer::Base.deliveries.last
+        
+        # sent_email.from returns a string in development, but in production it returns an array
+        assert(Array.wrap(sent_email.from).first.include?(Subdomain.current.name))
+        assert(Array.wrap(sent_email.from).first.include?(ENV["APP_HOST"]))
+        assert(sent_email.to.include?(visitor_email))
+        assert(sent_email.parts.first.body.raw_source.include?(expected_message))
+    end
+
+    test "Should not scan excluded api namespaces" do
+        @data_request_plugin.metadata["EXCLUDE_API_NAMESPACES"] << @namespace_with_email_one.slug
+        @data_request_plugin.save
+        visitor_email = @visitor_one.properties["email"]
+        ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": visitor_email})
+        # Should not send an email even if a submission was made under a namespace since it's excluded
+        assert_no_difference "ActionMailer::Base.deliveries.size" do
+            perform_enqueued_jobs do
+                @data_request_plugin.run
+                Sidekiq::Worker.drain_all
+            end
+        end
+    end
+
+    test "Email should contain a CSV attachment per API Namespace" do
+        visitor_email = @visitor_one.properties["email"]
+        ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": visitor_email})
+        ApiResource.create(api_namespace_id: @namespace_with_email_two.id, properties: {"name": "Test Name", "email": visitor_email})
+
+        perform_enqueued_jobs do
+            @data_request_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        # Visitor one making submissions under two namespaces, so the email should contain two attachments
+        sent_email = ActionMailer::Base.deliveries.last
+        first_attachment_content = sent_email.attachments[0].body.raw_source.gsub(/\r/, "")
+        second_attachment_content = sent_email.attachments[1].body.raw_source.gsub(/\r/, "")
+
+        assert_equal 2, sent_email.attachments.length
+
+        sent_email.attachments.each do |attachment|
+            assert(attachment.content_type.start_with?("text/csv"))
+        end
+
+        assert_not(first_attachment_content == second_attachment_content)
+
+        @namespace_with_email_one.properties.each do |key, value|
+            assert(first_attachment_content.include?(key))
+            assert(first_attachment_content.include?(value))
+        end
+
+        @namespace_with_email_two.properties.each do |key, value|
+            assert(second_attachment_content.include?(key))
+            assert(second_attachment_content.include?(value))
+        end
+    end
+
+    test "CSV file should be named according to the API Namespace and have file extension .csv" do
+        visitor_email = @visitor_one.properties["email"]
+        ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": visitor_email})
+
+        perform_enqueued_jobs do
+            @data_request_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        sent_email = ActionMailer::Base.deliveries.last
+        assert(sent_email.attachments[0].filename.include?("api_namespace_#{@namespace_with_email_one.name}"))
+        assert(sent_email.attachments[0].filename.include?(".csv"))
+    end
+
+    test "CSV file should contain the right content" do
+        visitor_email = @visitor_one.properties["email"]
+        api_resource = ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": visitor_email})
+
+        @namespace_with_email_one.non_primitive_properties.create([
+            {
+                label: 'richtext',
+                field_type: 'richtext'
+            }
+        ])
+
+        api_resource.non_primitive_properties.create([
+            {
+                label: 'richtext',
+                field_type: 'richtext',
+                content: "<div>Hello World</div>"
+            }
+        ])
+
+        richtext = api_resource.non_primitive_properties.find_by(label: "richtext").content.to_s
+
+        expected_csv = CSV.generate do |csv|
+            csv << ["id", "api_namespace_id", "post", "email", "created_at", "updated_at", "richtext"]
+            csv << [api_resource.id, api_resource.api_namespace_id, api_resource.properties["post"], api_resource.properties["email"], api_resource.created_at, api_resource.updated_at, richtext]
+        end
+
+        perform_enqueued_jobs do
+            @data_request_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        sent_email = ActionMailer::Base.deliveries.last
+        assert_equal expected_csv, sent_email.attachments.first.body.raw_source.gsub(/\r/, "")
+    end
+
+    test "Should raise an exception if admin does not exclude any api namespace and does not grant explicit permission to scan all API Namespaces" do
+        @data_request_plugin.metadata["EXCLUDE_API_NAMESPACES"] = []
+        @data_request_plugin.metadata["SCAN_ALL_NAMESPACES"] = false
+        @data_request_plugin.save
+
+        perform_enqueued_jobs do
+            @data_request_plugin.run
+            Sidekiq::Worker.drain_all
+        end 
+
+        expected_error_message = "Permission to scan all api namespaces is not given"
+        assert_equal expected_error_message, @data_request_plugin.reload.error_message
+    end
+
+    test "A message thread with a message is created when email is sent" do
+        visitor_email = @visitor_one.properties["email"]
+        ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": visitor_email})
+        
+        assert_difference "MessageThread.all.length", +1 do
+            assert_difference "Message.all.length", +1 do
+                perform_enqueued_jobs do
+                    @data_request_plugin.run
+                    Sidekiq::Worker.drain_all
+                end 
+            end
+        end
+    end
+
+    test "Message contains rich text content with a CSV attachment per API namespace" do
+        visitor_email = @visitor_one.properties["email"]
+        ApiResource.create(api_namespace_id: @namespace_with_email_one.id, properties: {"post": "Hello world", "email": visitor_email})
+        ApiResource.create(api_namespace_id: @namespace_with_email_two.id, properties: {"name": "Test Name", "email": visitor_email})
+
+        perform_enqueued_jobs do
+            @data_request_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        rich_text_content = Message.last.rich_text_content
+        attachments = rich_text_content.body.attachments
+
+        assert_not(rich_text_content.blank?)
+        assert_equal 2, attachments.length
+        
+        attachments.each do |attachment|
+            assert_equal "text/csv", attachment[:content_type]
+            assert(attachment[:filename].include?(".csv"))
+        end
+    end
+end


### PR DESCRIPTION
Addresses #1073 

When a visitor submits a data request form, this plugin will send an email with CSV attachments (one attachment per API namespace that has visitor-submitted data) to that visitor.

An external API connection with this plugin should be set up for the API namespace that has the form for submitting data request.

Message thread with attachments:
![Capture2](https://user-images.githubusercontent.com/73725297/191607266-fc547eba-ae31-47b4-9294-9e37bfe3b2d6.PNG) Email with attachments:
![Capture](https://user-images.githubusercontent.com/73725297/191607267-5d9a1637-4456-4103-aa17-c5964fb6039d.PNG) ![email_with_attachments](https://user-images.githubusercontent.com/73725297/192550525-e124aaf5-a43d-4a6c-8f7a-d7ce8ab69a12.png)

## Metadata:

EXCLUDE_API_NAMESPACES: an array of slugs of API namespaces that will be excluded MESSAGE: the message that will be used in the email body SCAN_ALL_NAMESPACES: a boolean indicating whether or not all API namespaces should be scanned

- if `EXCLUDE_API_NAMESPACES` is omitted or if it's an empty array, then `SCAN_ALL_NAMESPACES` should be provided and its value should be `true`
- `SCAN_ALL_NAMESPACES` should be omitted if `EXCLUDE_API_NAMESPACES` is provided and it's not an empty array

![metadata](https://user-images.githubusercontent.com/73725297/192554692-b4abaa20-01b0-4fd8-a0c4-8b134089c236.PNG)

Note that, in the screenshot above, `SCAN_ALL_NAMESPACES` is not provided because there are some API namespaces that should be excluded from scanning for visitor-submitted data.

Co-authored-by: Mushfiq Rahman <mushfiqurrahman78@yahoo.com>