### PR TITLE
[feature] Allow active support / view helpers in API Renderer. (#1136)

### DIFF
--- a/app/models/concerns/dynamic_attribute.rb
+++ b/app/models/concerns/dynamic_attribute.rb
@@ -7,6 +7,10 @@
 module DynamicAttribute
     extend ActiveSupport::Concern
     include Rails.application.routes.url_helpers
+    include ActionView::Helpers::DateHelper
+    include ActionView::Helpers::TranslationHelper
+    include ActionView::Helpers::NumberHelper
+    include ActionView::Helpers::TextHelper
 
     included do
       def parse_dynamic_attribute(value, context = {})

--- a/test/helpers/content_helper_test.rb
+++ b/test/helpers/content_helper_test.rb
@@ -461,6 +461,42 @@ class ContentHelperTest < ActionView::TestCase
     assert_equal excepted_response, response
   end
 
+  test 'render_api_namespace_resource_index - using time_ago_in_words of DateHelper' do
+    @current_user = @user
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<ul><% @api_resources.each do |res| %><li><%= time_ago_in_words(res.created_at) %></li><% end %></ul>")
+    
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'current_user' => 'true' } })
+    expected_response = "<ul><li>#{time_ago_in_words(@api_namespace.api_resources.third.created_at)}</li><li>#{time_ago_in_words(@api_namespace.api_resources.last.created_at)}</li></ul>"
+    assert_equal expected_response, response
+  end
+
+  test 'render_api_namespace_resource_index - using number_to_currency of NumberHelper' do
+    @current_user = @user
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<ul><% @api_resources.each do |res| %><li><%= number_to_currency(res.id) %></li><% end %></ul>")
+    
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'current_user' => 'true' } })
+    expected_response = "<ul><li>#{number_to_currency(@api_namespace.api_resources.third.id)}</li><li>#{number_to_currency(@api_namespace.api_resources.last.id)}</li></ul>"
+    assert_equal expected_response, response
+  end
+
+  test 'render_api_namespace_resource_index - using simple_format of TextHelper' do
+    @current_user = @user
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<ul><% @api_resources.each do |res| %><li><%= simple_format(res.properties['string']) %></li><% end %></ul>")
+    
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'current_user' => 'true' } })
+    expected_response = "<ul><li>#{simple_format(@api_namespace.api_resources.third.properties['string'])}</li><li>#{simple_format(@api_namespace.api_resources.last.properties['string'])}</li></ul>"
+    assert_equal expected_response, response
+  end
+
+  test 'render_api_namespace_resource_index - using find_zone of Time helper' do
+    @current_user = @user
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<span><%= Time.find_zone('EST').name %></span>")
+    
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'current_user' => 'true' } })
+    expected_response = "<span>EST</span>"
+    assert_equal expected_response, response
+  end
+
   def current_user
     @current_user
   end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/1109 

Screenshots:

<img width="1007" alt="Screen Shot 2022-09-28 at 18 04 11" src="https://user-images.githubusercontent.com/39255317/192777015-813be0ed-80da-4e4f-9acb-57f7fbc9bd34.png">

<img width="648" alt="Screen Shot 2022-09-28 at 18 03 57" src="https://user-images.githubusercontent.com/39255317/192777016-3329150d-107a-41dd-81e0-d5c50499f4cd.png">



Co-authored-by: Sushmit Rajaure <Sushmit@Sushmits-MacBook-Pro.local>