### PR TITLE
[feature] API resource query match any one condition

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -27,9 +27,9 @@ module ContentHelper
 
     response = response.where.not(user_id: nil).where(user_id: current_user&.id) if scope&.dig('current_user') == 'true'
 
-    response = response.jsonb_search(:properties, scope["properties"]) if scope["properties"]
+    response = response.jsonb_search(:properties, scope["properties"], scope["match"]) if scope["properties"]
 
-    response = response.jsonb_search(:properties, JSON.parse(params[:properties]).to_hash) if params[:properties]
+    response = response.jsonb_search(:properties, JSON.parse(params[:properties]).to_hash, params[:match]) if params[:properties]
 
     response = response.jsonb_order(options["order"]) if options["order"]
 
@@ -50,7 +50,7 @@ module ContentHelper
 
     api_resources = api_resources.where.not(user_id: nil).where(user_id: current_user&.id) if scope&.dig('current_user') == 'true'
 
-    api_resources = api_resources.jsonb_search(:properties, scope["properties"]) if scope&.has_key?("properties")
+    api_resources = api_resources.jsonb_search(:properties, scope["properties"], scope["match"]) if scope&.has_key?("properties")
 
     api_resource = api_resources.find(params[:id])
 

--- a/app/models/concerns/jsonb_search/query_builder.rb
+++ b/app/models/concerns/jsonb_search/query_builder.rb
@@ -11,9 +11,9 @@ module JsonbSearch
   }.freeze
 
     class << self
-      def build_jsonb_query(column_name, query_params)
+      def build_jsonb_query(column_name, query_params, match = MATCH_OPTION[:ALL])
         parsed_params = parse_params(query_params.deep_symbolize_keys)
-        build(parsed_params, column_name)
+        build(parsed_params, column_name, match)
       end
 
       private
@@ -43,11 +43,11 @@ module JsonbSearch
         queries
       end
 
-      def build(queries, column_name)
+      def build(queries, column_name, match)
         queries_array = queries.map do |object|
           generate_query(object, column_name)
         end
-        queries_array.join(' AND ')
+        queries_array.join(match == MATCH_OPTION[:ANY] ? ' OR ' : ' AND ')
       end
 
       def generate_query(param, query_string)

--- a/app/models/concerns/jsonb_search/query_builder.rb
+++ b/app/models/concerns/jsonb_search/query_builder.rb
@@ -11,7 +11,7 @@ module JsonbSearch
   }.freeze
 
     class << self
-      def build_jsonb_query(column_name, query_params, match = MATCH_OPTION[:ALL])
+      def build_jsonb_query(column_name, query_params, match = nil)
         parsed_params = parse_params(query_params.deep_symbolize_keys)
         build(parsed_params, column_name, match)
       end

--- a/app/models/concerns/jsonb_search/searchable.rb
+++ b/app/models/concerns/jsonb_search/searchable.rb
@@ -8,7 +8,7 @@ module JsonbSearch
     include JsonbSearch::QueryBuilder
 
     included do 
-      scope :jsonb_search, ->(column_name, query) { where(JsonbSearch::QueryBuilder.build_jsonb_query(column_name, query)) }
+      scope :jsonb_search, ->(column_name, query, match = JsonbSearch::QueryBuilder::MATCH_OPTION[:ALL]) { where(JsonbSearch::QueryBuilder.build_jsonb_query(column_name, query, match)) }
     end
   end
 end

--- a/app/models/concerns/jsonb_search/searchable.rb
+++ b/app/models/concerns/jsonb_search/searchable.rb
@@ -8,7 +8,7 @@ module JsonbSearch
     include JsonbSearch::QueryBuilder
 
     included do 
-      scope :jsonb_search, ->(column_name, query, match = JsonbSearch::QueryBuilder::MATCH_OPTION[:ALL]) { where(JsonbSearch::QueryBuilder.build_jsonb_query(column_name, query, match)) }
+      scope :jsonb_search, ->(column_name, query, match = nil) { where(JsonbSearch::QueryBuilder.build_jsonb_query(column_name, query, match)) }
     end
   end
 end

--- a/test/models/concerns/jsonb_search/query_builder_test.rb
+++ b/test/models/concerns/jsonb_search/query_builder_test.rb
@@ -102,4 +102,18 @@ class JsonbSearch::QueryBuilderTest < ActiveSupport::TestCase
 
     assert_equal "properties -> 'foo' -> 'array' ? '#{query[:foo][:array][:value][0]}' OR properties -> 'foo' -> 'array' ? '#{query[:foo][:array][:value][1]}'", jsonb_query
   end
+
+  test 'query string - multiple properties - match any condition' do
+    query = { name: 'violet', age: 20 }
+    jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query, JsonbSearch::QueryBuilder::MATCH_OPTION[:ANY])
+
+    assert_equal "lower(properties ->> 'name') = lower('violet') OR lower(properties ->> 'age') = lower('20')", jsonb_query
+  end
+
+  test 'query string - extended format - multiple properties - match any condition' do
+    query = { name: { value: 'violet', option: 'PARTIAL' }, age: { value: 20, option: 'EXACT' } }
+    jsonb_query = JsonbSearch::QueryBuilder.build_jsonb_query(:properties, query, JsonbSearch::QueryBuilder::MATCH_OPTION[:ANY])
+
+    assert_equal "lower(properties ->> 'name') LIKE lower('%violet%') OR lower(properties ->> 'age') = lower('20')", jsonb_query
+  end
 end


### PR DESCRIPTION
Addresses: [#1137](https://github.com/restarone/violet_rails/issues/1137)

Screenshot:
<img width="1129" alt="Screenshot 2022-10-04 at 4 37 24 PM" src="https://user-images.githubusercontent.com/18470532/193805288-63ea22af-a799-4bc1-9da2-ac61f5649ee9.png">
<img width="1128" alt="Screenshot 2022-10-04 at 4 37 03 PM" src="https://user-images.githubusercontent.com/18470532/193805826-51071edb-0366-4edf-941a-76dfc2109767.png">

Passing the third argument, ``'ANY'``  in ``build_jsonb_query`` or ``jsonb_search`` method will generate the clause requiring only one condition to be satisfied. 