### PR TITLE
[feature] Unique string aggregator plugin (#1133) (#1143)

### DIFF
--- a/test/fixtures/api_namespaces.yml
+++ b/test/fixtures/api_namespaces.yml
@@ -189,3 +189,25 @@ namespace_with_email_two:
   }
   requires_authentication: false
   namespace_type: create-read-update-delete
+  
+movies:
+  name: movies
+  slug: movies
+  version: 1
+  properties: {
+                "title": "",
+                "tags": []
+              }
+  requires_authentication: false
+  namespace_type: create-read-update-delete
+
+movie_tags:
+  name: movie_tags
+  slug: movie_tags
+  version: 1
+  properties: {
+                "tags": "",
+                "representation": ""
+              }
+  requires_authentication: false
+  namespace_type: create-read-update-delete

--- a/test/fixtures/external_api_clients.yml
+++ b/test/fixtures/external_api_clients.yml
@@ -478,3 +478,77 @@ compliance_visitor_data_request_plugin:
     end
     # at the end of the file we have to implicitly return the class 
     ComplianceVisitorDataRequest
+
+unique_string_aggregator_plugin:
+  api_namespace: movies
+  slug: unique-string-aggregator
+  label: UniqueStringAggregator
+  enabled: true
+  metadata: {
+    'INPUT_PROPERTY': 'tags',
+    'OUTPUT_API_NAMESPACE': 'movie_tags',
+    'PRISTINE': true
+  }
+  model_definition: |
+    class UniqueStringAggregator
+      def initialize(parameters)
+        @external_api_client = parameters[:external_api_client]
+        @api_namespace = @external_api_client.api_namespace
+      end
+
+      def start
+        output_api_namespace_slug = @external_api_client.metadata["OUTPUT_API_NAMESPACE"]
+        pristine = @external_api_client.metadata["PRISTINE"]
+        input_property_name = @external_api_client.metadata["INPUT_PROPERTY"]
+
+        raise "API Namespace resource pollution detected. OUTPUT_API_NAMESPACE slug and the slug of the current API namespace cannot be the same." if output_api_namespace_slug == @api_namespace.slug
+        raise "Input property does not exist on the current API namespace" unless @api_namespace.properties.key?(input_property_name)
+
+        output_api_namespace = ApiNamespace.where(slug: output_api_namespace_slug).first
+
+        raise "An API namespace with the provided output API namespace slug does not exist" if output_api_namespace.nil?
+        raise "Input property does not exist on the output API namespace" unless output_api_namespace.properties.key?(input_property_name)
+
+        ids_of_existing_api_resources = []
+        unique_strings_hash = {}
+        existing_unique_strings_hash = {}
+
+        # if pristine is true, collect ID's of all existing API Resources in the target API Namespace and delete them after successful connection execution
+        # if pristine is false, collect existing unique strings so that they can be used to only add new ones
+        output_api_namespace.api_resources.each do |api_resource|
+            if pristine
+              ids_of_existing_api_resources << api_resource.id
+            else
+              unique_string = api_resource.properties[input_property_name]
+              existing_unique_strings_hash[unique_string] = true
+            end  
+        end
+
+        @api_namespace.api_resources.each do |api_resource|
+          Array.wrap(api_resource.properties[input_property_name]).each do |str|
+            processed_str = str.downcase.strip
+            unique_strings_hash[processed_str] = [] unless unique_strings_hash.key?(processed_str)
+            unique_strings_hash[processed_str] << api_resource.id
+          end
+        end
+
+        unique_strings_hash.keys.each do |key|
+          representation_text = key.split.map(&:capitalize).join(" ")
+          propertiesObj = {input_property_name => key, "representation" => representation_text}
+          if pristine || (!pristine && !existing_unique_strings_hash.key?(key))
+            ApiResource.create(api_namespace_id: output_api_namespace.id, properties: propertiesObj)
+          end
+        end
+
+        unless ids_of_existing_api_resources.empty?
+          api_resources_to_be_deleted = ApiResource.where(api_namespace_id: output_api_namespace.id, id: ids_of_existing_api_resources)
+          ActiveRecord::Base.transaction do
+            api_resources_to_be_deleted.each do |api_resource|
+              api_resource.destroy!
+            end
+          end
+        end
+      end
+    end
+    # at the end of the file we have to implicitly return the class 
+    UniqueStringAggregator

--- a/test/plugins/unique_string_aggregator_plugin_test.rb
+++ b/test/plugins/unique_string_aggregator_plugin_test.rb
@@ -1,0 +1,188 @@
+require "test_helper"
+
+class UniqueStringAggregatorPluginTest < ActiveSupport::TestCase
+    setup do
+        @unique_string_aggregator_plugin = external_api_clients(:unique_string_aggregator_plugin)
+        @api_namespace = @unique_string_aggregator_plugin.api_namespace
+        @output_api_namespace = api_namespaces(:movie_tags)
+        Sidekiq::Testing.fake!
+    end
+
+    # How test fixtures are set up:
+    # By default, PRISTINE is set to true in the plugin metadata
+    # By default, the plugin is connected to movies API namespace
+    # By default, the output API namespace is movie_tags and it has input property
+
+    test "Should raise an error if the output API namespace slug and the current API namespace slug are the same" do
+        metadata = @unique_string_aggregator_plugin.metadata
+        metadata["OUTPUT_API_NAMESPACE"] = "movies"
+        @unique_string_aggregator_plugin.update(metadata: metadata)
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        expected_error_message = "API Namespace resource pollution detected. OUTPUT_API_NAMESPACE slug and the slug of the current API namespace cannot be the same."
+        assert_equal expected_error_message, @unique_string_aggregator_plugin.reload.error_message
+    end
+
+    test "Should raise an error if the provided input property does not exist on the current API namespace" do
+        metadata = @unique_string_aggregator_plugin.metadata
+        metadata["INPUT_PROPERTY"] = "non-existent property"
+        @unique_string_aggregator_plugin.update(metadata: metadata)
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        expected_error_message = "Input property does not exist on the current API namespace"
+        assert_equal expected_error_message, @unique_string_aggregator_plugin.reload.error_message
+    end
+
+    test "Should raise an error if an API namespace with the provided output API namespace slug does not exist" do
+        metadata = @unique_string_aggregator_plugin.metadata
+        metadata["OUTPUT_API_NAMESPACE"] = "non-existent API namespace"
+        @unique_string_aggregator_plugin.update(metadata: metadata)
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        expected_error_message = "An API namespace with the provided output API namespace slug does not exist"
+        assert_equal expected_error_message, @unique_string_aggregator_plugin.reload.error_message
+    end
+
+    test "Should raise an error if the provided input property does not exist on the output API namespace" do
+        @output_api_namespace.properties.delete("tags")
+        @output_api_namespace.save
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        expected_error_message = "Input property does not exist on the output API namespace"
+        assert_equal expected_error_message, @unique_string_aggregator_plugin.reload.error_message
+    end
+
+    test "An API resource for output API namespace is created for each unique string" do
+        tags_one = ['animation', 'family', 'disney']
+        tags_two = ['animation', 'family', 'comedy']
+        unique_tags = ['animation', 'family', 'disney', 'comedy']
+
+        ApiResource.create(api_namespace_id: @api_namespace.id, properties: {"title" => "The Lion King", "tags" => tags_one})
+        ApiResource.create(api_namespace_id: @api_namespace.id, properties: {"title" => "Kung Fu Panda", "tags" => tags_two})
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        assert_equal unique_tags.length, @output_api_namespace.api_resources.length
+    end
+
+    test "New API resources are not created for duplicate strings with uppercase letters and whitespace" do
+        tags_one = ['animation', 'family', 'disney']
+        tags_two = ['   Animation   ', 'FAMILY', 'comedy']
+        unique_tags = ['animation', 'family', 'disney', 'comedy']
+
+        ApiResource.create(api_namespace_id: @api_namespace.id, properties: {"title" => "The Lion King", "tags" => tags_one})
+        ApiResource.create(api_namespace_id: @api_namespace.id, properties: {"title" => "Kung Fu Panda", "tags" => tags_two})
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        assert_equal unique_tags.length, @output_api_namespace.api_resources.length
+    end
+
+    test "Properties hash of each API resource of the output API namespace has the correct keys and values" do
+        tags_one = ['animation', 'family', 'disney']
+        tags_two = ['animation', 'family', 'comedy', 'martial arts']
+        unique_tags = ['animation', 'family', 'disney', 'comedy', 'martial arts']
+        input_property_name = @unique_string_aggregator_plugin.metadata["INPUT_PROPERTY"]
+        expected_api_resource_props = [
+            {"tags" => "animation", "representation" => "Animation"},
+            {"tags" => "family", "representation" => "Family"},
+            {"tags" => "disney", "representation" => "Disney"},
+            {"tags" => "comedy", "representation" => "Comedy"},
+            {"tags" => "martial arts", "representation" => "Martial Arts"}
+        ]
+
+        ApiResource.create(api_namespace_id: @api_namespace.id, properties: {"title" => "The Lion King", "tags" => tags_one})
+        ApiResource.create(api_namespace_id: @api_namespace.id, properties: {"title" => "Kung Fu Panda", "tags" => tags_two})
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        @output_api_namespace.api_resources.each_with_index do |api_resource, i|
+            assert_equal expected_api_resource_props[i], api_resource.properties
+        end
+    end
+
+    test "Existing API resources of the output API namespace are removed if PRISTINE is set to true" do
+        input_property_name = @unique_string_aggregator_plugin.metadata["INPUT_PROPERTY"]
+
+        resource_one = ApiResource.create(api_namespace_id: @output_api_namespace.id, properties: {input_property_name => "animation", "representation" => "animation"})
+        resource_two = ApiResource.create(api_namespace_id: @output_api_namespace.id, properties: {input_property_name => "family", "representation" => "family"})
+
+        ApiResource.create(api_namespace_id: @api_namespace.id, properties: {"title" => "The Lion King", "tags" => ['animation', 'family', 'disney']})
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        assert_equal 3, @output_api_namespace.api_resources.length
+        assert_not(@output_api_namespace.api_resources.include?(resource_one))
+        assert_not(@output_api_namespace.api_resources.include?(resource_two))
+    end
+
+    test "Existing API resources of the output API namespace are not removed If PRISTINE is set to false" do
+        metadata = @unique_string_aggregator_plugin.metadata
+        metadata["PRISTINE"] = false
+        @unique_string_aggregator_plugin.update(metadata: metadata)
+
+        input_property_name = metadata["INPUT_PROPERTY"]
+
+        resource_one = ApiResource.create(api_namespace_id: @output_api_namespace.id, properties: {input_property_name => "animation", "representation" => "animation"})
+        resource_two = ApiResource.create(api_namespace_id: @output_api_namespace.id, properties: {input_property_name => "family", "representation" => "family"})
+
+        perform_enqueued_jobs do
+            @unique_string_aggregator_plugin.run
+            Sidekiq::Worker.drain_all
+        end
+
+        assert(ApiResource.exists?(api_namespace_id: @output_api_namespace.id, id: resource_one.id))
+        assert(ApiResource.exists?(api_namespace_id: @output_api_namespace.id, id: resource_two.id))
+
+        assert_equal 2, @output_api_namespace.reload.api_resources.length
+    end
+
+    test "API resources under the output API namespace are created only for new unique strings If PRISTINE is set to false" do
+        metadata = @unique_string_aggregator_plugin.metadata
+        metadata["PRISTINE"] = false
+        @unique_string_aggregator_plugin.update(metadata: metadata)
+
+        input_property_name = metadata["INPUT_PROPERTY"]
+
+        resource_one = ApiResource.create(api_namespace_id: @output_api_namespace.id, properties: {input_property_name => "animation", "representation" => "animation"})
+        resource_two = ApiResource.create(api_namespace_id: @output_api_namespace.id, properties: {input_property_name => "family", "representation" => "family"})
+
+        ApiResource.create(api_namespace_id: @api_namespace.id, properties: {"title" => "The Lion King", "tags" => ['animation', 'family', 'disney']})
+
+        # disney is the new tag, so only 1 API resource should be created
+        assert_difference "@output_api_namespace.reload.api_resources.length", +1 do
+            perform_enqueued_jobs do
+                @unique_string_aggregator_plugin.run
+                Sidekiq::Worker.drain_all
+            end
+        end
+    end
+end


### PR DESCRIPTION
Addresses #1084

This plugin takes an array of strings and creates a list of API resources (one per unique string value) for an output API namespace. For example, for two arrays - `tags: ["animation", "family", "martial arts"]`,`tags: ["animation", "family"]`  - in `movies` API namespace, 3 API resources will be created under `movie_tags` (the output API namespace in this case):

```ruby
{ "tags" => "animation", "representation" => "Animation" },
{ "tags" => "family", "representation" => "Family" },
{ "tags" => "martial arts", "representation" => "Martial Arts" }
```


https://user-images.githubusercontent.com/73725297/192908391-21560b30-1977-4451-ae15-5564d4289eb4.mp4



## Metadata

The following metadata properties are required:

- `INPUT_PROPERTY`: the name of the property that is mapped to an array of strings in the input API namespace (the API namespace that the plugin will run against)
- `OUTPUT_API_NAMESPACE`: the slug of the API namespace under which API resources will be created
- `PRISTINE`: a boolean indicating whether or not the plugin will run in pristine mode

If `PRISTINE` is true, then existing API resources in the output API namespace will be deleted after creating new API resources. If `PRISTINE` is false, then old API resources will not be deleted and new ones will be created only for new unique strings.

![metadata](https://user-images.githubusercontent.com/73725297/192907721-5ae6f9fb-5fa4-4767-8713-9e526eec46da.PNG)

### Pristine mode


https://user-images.githubusercontent.com/73725297/192908436-351d44b3-c738-4973-b851-7f2529008aed.mp4

### Non-pristine mode


https://user-images.githubusercontent.com/73725297/193096865-63780536-dad0-4753-82ef-1e834c1ed362.mp4



## Shape of the output API namespace

Each API resource of the output API namespace must have the following two properties:

- `<INPUT_PROPERTY>`: this property must be the same as `INPUT PROPERTY` provided in the plugin metadata
- `representation`: the value of this property can be used as the display text for an `<option></option>` HTML element

![output-api-namespace](https://user-images.githubusercontent.com/73725297/192908296-dad3904b-88af-46c2-8dd1-97f6455dfe00.PNG)

Co-authored-by: Mushfiq Rahman <mushfiqurrahman78@yahoo.com>