### PR TITLE
[feature] enforce loading assets over https

### DIFF
--- a/config/initializers/force_ssl.rb
+++ b/config/initializers/force_ssl.rb
@@ -1,0 +1,2 @@
+# handles protocol everywhere that uses url_helpers
+Rails.application.routes.default_url_options[:protocol] = (Rails.env.production? || Rails.env.staging?) ? 'https': 'http'


### PR DESCRIPTION
Addresses: [#1149](https://github.com/restarone/violet_rails/issues/1149)
- Add config to load assets over https for staging and production.