### PR TITLE
Option added in settings to use own or restarone email for forum notifications.

### DIFF
--- a/app/controllers/comfy/admin/web_settings_controller.rb
+++ b/app/controllers/comfy/admin/web_settings_controller.rb
@@ -44,7 +44,8 @@ class Comfy::Admin::WebSettingsController < Comfy::Admin::Cms::BaseController
       :after_sign_up_path,
       :allow_external_analytics_query,
       :email_name,
-      :email_signature
+      :email_signature,
+      :email_strategy
     )
   end
 end

--- a/app/controllers/comfy/admin/web_settings_controller.rb
+++ b/app/controllers/comfy/admin/web_settings_controller.rb
@@ -45,7 +45,7 @@ class Comfy::Admin::WebSettingsController < Comfy::Admin::Cms::BaseController
       :allow_external_analytics_query,
       :email_name,
       :email_signature,
-      :email_strategy
+      :email_notification_strategy
     )
   end
 end

--- a/app/mailers/simple_discussion/user_mailer.rb
+++ b/app/mailers/simple_discussion/user_mailer.rb
@@ -19,9 +19,9 @@ class SimpleDiscussion::UserMailer < ApplicationMailer
     @forum_post = forum_post
     @forum_thread = forum_post.forum_thread
     @recipient = recipient
-    
+    mailer_address = Subdomain.current.email_strategy ? Subdomain.current.mailing_address : forum_post.user.email
     mail(
-      from: "#{forum_post.user.name} <#{forum_post.user.email}>",
+      from: "#{forum_post.user.name} <#{mailer_address}>",
       to: "#{@recipient.name} <#{@recipient.email}>",
       subject: "New post in #{@forum_thread.title}"
     )

--- a/app/mailers/simple_discussion/user_mailer.rb
+++ b/app/mailers/simple_discussion/user_mailer.rb
@@ -19,7 +19,7 @@ class SimpleDiscussion::UserMailer < ApplicationMailer
     @forum_post = forum_post
     @forum_thread = forum_post.forum_thread
     @recipient = recipient
-    mailer_address = Subdomain.current.email_strategy ? Subdomain.current.mailing_address : forum_post.user.email
+    mailer_address = Subdomain.current.system_email? ? Subdomain.current.mailing_address : forum_post.user.email
     mail(
       from: "#{forum_post.user.name} <#{mailer_address}>",
       to: "#{@recipient.name} <#{@recipient.email}>",

--- a/app/models/subdomain.rb
+++ b/app/models/subdomain.rb
@@ -16,6 +16,8 @@ class Subdomain < ApplicationRecord
   has_rich_text :email_signature
 
 
+  enum email_notification_strategy: { user_email: 'user_email', system_email: 'system_email' }
+
   # max 1GB by default storage allowance
   MAXIMUM_STORAGED_ALLOWANCE = 1073741824
   # www/domain apex maps to public schema. So to recieve email on public schema we need a subdomain. it will be www

--- a/app/views/comfy/admin/web_settings/_form.haml
+++ b/app/views/comfy/admin/web_settings/_form.haml
@@ -144,6 +144,20 @@
 .card.mt-5
   .card-header
     %strong
+     Forum Email Notifications
+  .card-body
+    .form-group
+      = f.radio_button :email_strategy, false, checked: !f.object.email_strategy
+      %label
+        Email Notifications via User Email
+    .form-group
+      = f.radio_button :email_strategy, true, checked: f.object.email_strategy
+      %label
+        Email Notifications via Restarone Solutions Email
+
+.card.mt-5
+  .card-header
+    %strong
       Redirections
   .card-body
     .form-group

--- a/app/views/comfy/admin/web_settings/_form.haml
+++ b/app/views/comfy/admin/web_settings/_form.haml
@@ -147,11 +147,11 @@
       Forum Email Notifications
   .card-body
     .form-group
-      = f.radio_button :email_strategy, false, checked: !f.object.email_strategy
+      = f.radio_button :email_notification_strategy, 'user_email', checked: f.object.user_email?
       %label
         Email Notifications via User Email
     .form-group
-      = f.radio_button :email_strategy, true, checked: f.object.email_strategy
+      = f.radio_button :email_notification_strategy, 'system_email', checked: f.object.system_email?
       %label
         Email Notifications via Subdomain Email
 

--- a/app/views/comfy/admin/web_settings/_form.haml
+++ b/app/views/comfy/admin/web_settings/_form.haml
@@ -153,7 +153,7 @@
     .form-group
       = f.radio_button :email_strategy, true, checked: f.object.email_strategy
       %label
-        Email Notifications via Restarone Solutions Email
+        Email Notifications via Subdomain Email
 
 .card.mt-5
   .card-header

--- a/app/views/comfy/admin/web_settings/_form.haml
+++ b/app/views/comfy/admin/web_settings/_form.haml
@@ -144,7 +144,7 @@
 .card.mt-5
   .card-header
     %strong
-     Forum Email Notifications
+      Forum Email Notifications
   .card-body
     .form-group
       = f.radio_button :email_strategy, false, checked: !f.object.email_strategy

--- a/db/migrate/20221025072655_add_email_strategy_to_subdomain.rb
+++ b/db/migrate/20221025072655_add_email_strategy_to_subdomain.rb
@@ -1,0 +1,5 @@
+class AddEmailStrategyToSubdomain < ActiveRecord::Migration[6.1]
+  def change
+    add_column :subdomains, :email_strategy, :boolean, default: false
+  end
+end

--- a/db/migrate/20221025072655_add_email_strategy_to_subdomain.rb
+++ b/db/migrate/20221025072655_add_email_strategy_to_subdomain.rb
@@ -1,5 +1,0 @@
-class AddEmailStrategyToSubdomain < ActiveRecord::Migration[6.1]
-  def change
-    add_column :subdomains, :email_strategy, :boolean, default: false
-  end
-end

--- a/db/migrate/20221104133642_add_email_notification_strategy_to_subdomain.rb
+++ b/db/migrate/20221104133642_add_email_notification_strategy_to_subdomain.rb
@@ -1,0 +1,5 @@
+class AddEmailNotificationStrategyToSubdomain < ActiveRecord::Migration[6.1]
+  def change
+    add_column :subdomains, :email_notification_strategy, :string, default: 'user_email'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_25_072655) do
+ActiveRecord::Schema.define(version: 2022_11_04_133642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -482,7 +482,7 @@ ActiveRecord::Schema.define(version: 2022_10_25_072655) do
     t.string "email_name"
     t.text "email_signature"
     t.text "cookies_consent_ui", default: "<div class=\"cookies-consent__overlay position-fixed\" style=\"top: 0; bottom: 0; left: 0; right: 0; background-color: black; opacity: 0.5; z-index: 1000;\"></div>\n  <div class=\"cookies-consent position-fixed bg-white d-md-flex justify-content-md-between\" style=\"bottom: 0; left: 0; width: 100%; padding: 2rem 1rem; z-index: 9000;\">\n    <div class=\"cookies-consent__text-content col-md-8\" style=\"max-width: 700px;\">\n      <h2 class=\"cookies-consent__title\" style=\"font-size: 1.4rem;\">We Value Your Privacy</h2>\n      <p class=\"mb-4 mb-md-0\">\n        We use cookies to enhance your browsing experience, serve personalized ads or content, and analyze our traffic. By clicking \"Accept All\", you consent to our use of cookies.\n      </p>\n    </div>\n    <div class=\"cookies-consent__buttons-container d-flex flex-column col-md-4 col-xl-3\">\n      <a class=\"btn btn-primary mb-3\" href=\"/cookies?cookies=true\">Accept All</a>\n      <a class=\"btn btn-outline-primary\" href=\"/cookies?cookies=false\">Reject All</a>\n    </div>  \n  </div>"
-    t.boolean "email_strategy", default: false
+    t.string "email_notification_strategy", default: "user_email"
     t.index ["deleted_at"], name: "index_subdomains_on_deleted_at"
     t.index ["name"], name: "index_subdomains_on_name"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_25_091924) do
+ActiveRecord::Schema.define(version: 2022_10_25_072655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -482,6 +482,7 @@ ActiveRecord::Schema.define(version: 2022_10_25_091924) do
     t.string "email_name"
     t.text "email_signature"
     t.text "cookies_consent_ui", default: "<div class=\"cookies-consent__overlay position-fixed\" style=\"top: 0; bottom: 0; left: 0; right: 0; background-color: black; opacity: 0.5; z-index: 1000;\"></div>\n  <div class=\"cookies-consent position-fixed bg-white d-md-flex justify-content-md-between\" style=\"bottom: 0; left: 0; width: 100%; padding: 2rem 1rem; z-index: 9000;\">\n    <div class=\"cookies-consent__text-content col-md-8\" style=\"max-width: 700px;\">\n      <h2 class=\"cookies-consent__title\" style=\"font-size: 1.4rem;\">We Value Your Privacy</h2>\n      <p class=\"mb-4 mb-md-0\">\n        We use cookies to enhance your browsing experience, serve personalized ads or content, and analyze our traffic. By clicking \"Accept All\", you consent to our use of cookies.\n      </p>\n    </div>\n    <div class=\"cookies-consent__buttons-container d-flex flex-column col-md-4 col-xl-3\">\n      <a class=\"btn btn-primary mb-3\" href=\"/cookies?cookies=true\">Accept All</a>\n      <a class=\"btn btn-outline-primary\" href=\"/cookies?cookies=false\">Reject All</a>\n    </div>  \n  </div>"
+    t.boolean "email_strategy", default: false
     t.index ["deleted_at"], name: "index_subdomains_on_deleted_at"
     t.index ["name"], name: "index_subdomains_on_name"
   end

--- a/test/mailers/simple_discussion/user_mailer_test.rb
+++ b/test/mailers/simple_discussion/user_mailer_test.rb
@@ -50,7 +50,7 @@ class SimpleDiscussion::UserMailerTest < ActionMailer::TestCase
     @user.update(name: "Test name")
  
     # Setting email strategy to send notifications using user personal email
-    Subdomain.current.update(email_strategy: false)
+    Subdomain.current.user_email!
 
     forum_post = ForumPost.create!(forum_thread_id: @forum_thread.id, user_id: @user.id, body: action_txt_content.to_s)
 
@@ -72,7 +72,7 @@ class SimpleDiscussion::UserMailerTest < ActionMailer::TestCase
     subdomain = Subdomain.current
  
     # Setting email strategy to send notifications using user's restarone email
-    subdomain.update(email_strategy: true)
+    subdomain.system_email!
 
     forum_post = ForumPost.create!(forum_thread_id: @forum_thread.id, user_id: @user.id, body: action_txt_content.to_s)
 

--- a/test/mailers/simple_discussion/user_mailer_test.rb
+++ b/test/mailers/simple_discussion/user_mailer_test.rb
@@ -40,7 +40,6 @@ class SimpleDiscussion::UserMailerTest < ActionMailer::TestCase
     assert_difference "SimpleDiscussion::UserMailer.deliveries.size", +1 do
       SimpleDiscussion::UserMailer.new_post(forum_post, @other_user).deliver_now
     end
-    byebug
     assert(action_txt_content.to_s, SimpleDiscussion::UserMailer.deliveries.first.body.to_s)
   end
 
@@ -60,7 +59,6 @@ class SimpleDiscussion::UserMailerTest < ActionMailer::TestCase
     end
     
     mailer_address = SimpleDiscussion::UserMailer.deliveries.last.from.last
-    byebug
     assert_equal mailer_address, forum_post.user.email
   end
 
@@ -82,7 +80,6 @@ class SimpleDiscussion::UserMailerTest < ActionMailer::TestCase
     end
     
     mailer_address = SimpleDiscussion::UserMailer.deliveries.last.from.last
-    byebug
     assert_equal mailer_address, subdomain.mailing_address
   end
 

--- a/test/mailers/simple_discussion/user_mailer_test.rb
+++ b/test/mailers/simple_discussion/user_mailer_test.rb
@@ -67,6 +67,7 @@ class SimpleDiscussion::UserMailerTest < ActionMailer::TestCase
     attachment = ActiveStorage::Blob.create_and_upload!(io: File.open(file_path), filename: 'fixture_image', content_type: 'image/png', metadata: nil)
     action_txt_content = ActionText::Content.new(%Q(<action-text-attachment sgid="#{attachment.attachable_sgid}"></action-text-attachment>))
     @user.update(name: "Test name")
+    ENV["APP_HOST"] = "example_mail.com"
 
     subdomain = Subdomain.current
  

--- a/test/mailers/simple_discussion/user_mailer_test.rb
+++ b/test/mailers/simple_discussion/user_mailer_test.rb
@@ -40,7 +40,50 @@ class SimpleDiscussion::UserMailerTest < ActionMailer::TestCase
     assert_difference "SimpleDiscussion::UserMailer.deliveries.size", +1 do
       SimpleDiscussion::UserMailer.new_post(forum_post, @other_user).deliver_now
     end
-
+    byebug
     assert(action_txt_content.to_s, SimpleDiscussion::UserMailer.deliveries.first.body.to_s)
   end
+
+  test 'Set mailer email to user own email when set in settings' do
+    file_path = Rails.root.join('test','fixtures', 'files', 'fixture_image.png')
+    attachment = ActiveStorage::Blob.create_and_upload!(io: File.open(file_path), filename: 'fixture_image', content_type: 'image/png', metadata: nil)
+    action_txt_content = ActionText::Content.new(%Q(<action-text-attachment sgid="#{attachment.attachable_sgid}"></action-text-attachment>))
+    @user.update(name: "Test name")
+ 
+    # Setting email strategy to send notifications using user personal email
+    Subdomain.current.update(email_strategy: false)
+
+    forum_post = ForumPost.create!(forum_thread_id: @forum_thread.id, user_id: @user.id, body: action_txt_content.to_s)
+
+    assert_difference "SimpleDiscussion::UserMailer.deliveries.size", +1 do
+      SimpleDiscussion::UserMailer.new_post(forum_post, @other_user).deliver_now
+    end
+    
+    mailer_address = SimpleDiscussion::UserMailer.deliveries.last.from.last
+    byebug
+    assert_equal mailer_address, forum_post.user.email
+  end
+
+  test 'Set mailer email to restarone email when set in settings' do
+    file_path = Rails.root.join('test','fixtures', 'files', 'fixture_image.png')
+    attachment = ActiveStorage::Blob.create_and_upload!(io: File.open(file_path), filename: 'fixture_image', content_type: 'image/png', metadata: nil)
+    action_txt_content = ActionText::Content.new(%Q(<action-text-attachment sgid="#{attachment.attachable_sgid}"></action-text-attachment>))
+    @user.update(name: "Test name")
+
+    subdomain = Subdomain.current
+ 
+    # Setting email strategy to send notifications using user's restarone email
+    subdomain.update(email_strategy: true)
+
+    forum_post = ForumPost.create!(forum_thread_id: @forum_thread.id, user_id: @user.id, body: action_txt_content.to_s)
+
+    assert_difference "SimpleDiscussion::UserMailer.deliveries.size", +1 do
+      SimpleDiscussion::UserMailer.new_post(forum_post, @other_user).deliver_now
+    end
+    
+    mailer_address = SimpleDiscussion::UserMailer.deliveries.last.from.last
+    byebug
+    assert_equal mailer_address, subdomain.mailing_address
+  end
+
 end

--- a/test/models/subdomain_test.rb
+++ b/test/models/subdomain_test.rb
@@ -140,4 +140,13 @@ class SubdomainTest < ActiveSupport::TestCase
       Sidekiq::Worker.drain_all
     end
   end
+
+  test "email_notification_strategy should not accept anything except user_email or system_email" do  
+    exception = assert_raises(Exception) { 
+      duplicate = Subdomain.new(
+        email_notification_strategy: 'restarone_email'
+      )
+     }
+    assert_equal( "'restarone_email' is not a valid email_notification_strategy", exception.message )
+  end
 end


### PR DESCRIPTION
Addresses : https://github.com/restarone/violet_rails/issues/1169

Changes : 

- Migration script added
- Test cases added
- Logic added to check boolean to set mailer address. ( Own or Restarone email)

<img width="930" alt="Screenshot 2022-11-04 at 20 05 07" src="https://user-images.githubusercontent.com/39255317/199997878-e980def0-10ae-4506-9abe-f5de55267ae8.png">


Demo video :

https://user-images.githubusercontent.com/39255317/198045816-b7ee4333-e5a3-4875-9a18-0ed5be1f9df4.mov



