### PR TITLE
[feature] Dokku integration for testnet (#1172)

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-ruby.git

--- a/.github/workflows/dokku-deploy.yml
+++ b/.github/workflows/dokku-deploy.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           git_remote_url: ${{ secrets.DOKKU_GIT_REMOTE }}
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          git_push_flags: '--force'
 
   review_app:
     runs-on: ubuntu-latest

--- a/.github/workflows/dokku-deploy.yml
+++ b/.github/workflows/dokku-deploy.yml
@@ -1,0 +1,144 @@
+name: Deploy to Dokku
+
+on:
+  pull_request:
+    branches: [ master, rc, dev ]
+    types: [ opened, reopened, synchronize, closed, labeled, unlabeled ]
+
+  push:
+    branches: [ master, rc, dev ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # only run when commit is pushed to master/rc/dev
+    if: github.event_name == 'push'
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Add public IP to AWS security group
+        uses: sohelamin/aws-security-group-add-ip-action@master
+        with:
+          aws-access-key-id: ${{ secrets.DOKKU_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DOKKU_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.DOKKU_AWS_REGION }}
+          aws-security-group-id: ${{ secrets.DOKKU_AWS_SECURITY_GROUP_ID }}
+          port: '22'
+          to-port: '30'
+          protocol: 'tcp'
+          description: 'GitHub Action'
+
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          git_remote_url: ${{ secrets.DOKKU_GIT_REMOTE }}
+          ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+
+  review_app:
+    runs-on: ubuntu-latest
+    # only run when a PR is opened/reopened/synchronize with label:deploy-review-app OR the label is added in open PR
+    if: github.event_name == 'pull_request' && github.event.pull_request.state == 'open' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' || github.event.action == 'labeled') && contains( github.event.pull_request.labels.*.name, 'deploy-review-app')
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Add public IP to AWS security group
+        uses: sohelamin/aws-security-group-add-ip-action@master
+        with:
+          aws-access-key-id: ${{ secrets.DOKKU_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DOKKU_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.DOKKU_AWS_REGION }}
+          aws-security-group-id: ${{ secrets.DOKKU_AWS_SECURITY_GROUP_ID }}
+          port: '22'
+          to-port: '30'
+          protocol: 'tcp'
+          description: 'GitHub Action'
+
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          # create a review app
+          command: review-apps:create
+          review_app_name: review-${{ github.event.pull_request.number }}
+          git_remote_url: ${{ secrets.DOKKU_GIT_REMOTE }}
+          ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          ssh_host_key: ${{ secrets.DOKKU_SSH_HOST_KEY }}
+          git_push_flags: '--force'
+
+      - name: Add TSL/SSL certificate to the review-app
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DOKKU_HOST }}
+          key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          username: ubuntu
+          script: dokku letsencrypt:active review-${{ github.event.pull_request.number }} || dokku letsencrypt:enable review-${{ github.event.pull_request.number }}
+
+      - name: Add deployed review-app link in PR comment
+        uses: mshick/add-pr-comment@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: |
+            Deployed review-app can be viewed at [https://review-${{ github.event.pull_request.number }}.violet-test.net](https://review-${{ github.event.pull_request.number }}.violet-test.net)
+          allow-repeats: true
+
+  checklabel:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && ((github.event.pull_request.state == 'open' && github.event.action == 'unlabeled') || github.event.action == 'closed')
+    outputs:
+      deploy_review_app_removed: ${{ steps.check.outputs.deploy_review_app_removed }}
+    steps:
+      - name: Check if label:deploy-review-app was removed
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          pr=${{ github.event.number }}
+          label=$(gh api "repos/$GITHUB_REPOSITORY/issues/$pr/events" \
+              --jq 'map(select(.event == "unlabeled"))[-1].label.name')
+
+          if [[ $label == 'deploy-review-app' ]]; then
+              echo "deploy_review_app_removed=true" >> $GITHUB_OUTPUT
+          fi
+
+  destroy_review_app:
+    needs: checklabel
+    runs-on: ubuntu-latest
+    # only run when a pull request with label:deploy-review-app is closed OR the label is removed from open PR
+    if: github.event_name == 'pull_request' && ((github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy-review-app')) || (github.event.pull_request.state == 'open' && github.event.action == 'unlabeled' && needs.checklabel.outputs.deploy_review_app_removed))
+    steps:
+      - name: Add public IP to AWS security group
+        uses: sohelamin/aws-security-group-add-ip-action@master
+        with:
+          aws-access-key-id: ${{ secrets.DOKKU_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DOKKU_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.DOKKU_AWS_REGION }}
+          aws-security-group-id: ${{ secrets.DOKKU_AWS_SECURITY_GROUP_ID }}
+          port: '22'
+          to-port: '30'
+          protocol: 'tcp'
+          description: 'GitHub Action'
+
+      - name: Destroy the review app
+        uses: dokku/github-action@master
+        with:
+          # destroy a review app
+          command: review-apps:destroy
+          review_app_name: review-${{ github.event.pull_request.number }}
+          git_remote_url: ${{ secrets.DOKKU_GIT_REMOTE }}
+          ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          ssh_host_key: ${{ secrets.DOKKU_SSH_HOST_KEY }}
+          git_push_flags: '--force'
+
+      - name: Destroy review-app-db
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DOKKU_HOST }}
+          key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          username: ubuntu
+          script: dokku postgres:exists review-${{ github.event.pull_request.number }}-db && dokku postgres:destroy review-${{ github.event.pull_request.number }}-db --force

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 release: bundle exec rails db:migrate
+worker: bundle exec sidekiq -C config/sidekiq.yml
 web: bundle exec puma -C config/puma.rb

--- a/bin/ci-pre-deploy
+++ b/bin/ci-pre-deploy
@@ -1,0 +1,12 @@
+#!/bin/sh -l
+if [ "$IS_REVIEW_APP" = "true" ]; then
+  REVIEW_APP_DB_NAME="${APP_NAME}-db"
+  MAIN_APP_DB_NAME="violet-rails-db"
+
+  ssh "ubuntu@$(parse-ssh-host)" "
+  dokku postgres:exists $REVIEW_APP_DB_NAME || dokku postgres:clone $MAIN_APP_DB_NAME $REVIEW_APP_DB_NAME
+  dokku postgres:linked $REVIEW_APP_DB_NAME $APP_NAME || (dokku postgres:link $REVIEW_APP_DB_NAME $REVIEW_APP_NAME && dokku postgres:promote $REVIEW_APP_DB_NAME $REVIEW_APP_NAME && dokku postgres:unlink $MAIN_APP_DB_NAME $REVIEW_APP_NAME)
+  "
+
+  echo "${REVIEW_APP_DB_NAME} linked to review-app: ${APP_NAME}"
+fi


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/1127

### Points to remember

- The base branch of the PR needs to be `master`/`dev`/`rc` for the dokku CI to run.
- The url of the new review-app will be: `review-[PR number].violet-test.net`. A comment will be added after the deployment of review-app is successful as in image below: ![image](https://user-images.githubusercontent.com/25191509/198102327-b0153d57-48fb-433f-af0f-e3b5476f9489.png)

- Since the database of review-app is a clone of database of heroku's violet-rails, you can use the same login credentials used in heroku to login.

### Conditions when review-apps is deployed

- While creating the PR which has label: `deploy-review-app`
- When a closed PR with label: `deploy-review-app` is reopened
- While labeling the open PR with `deploy-review-app`
- When new commits are pushed to the open PR which already have the label: `deploy-review-app`

### Conditions when review-apps is destroyed

- While closing/mergin the PR which has label: `deploy-review-app`
- While unlabeling the open PR with `deploy-review-app`

### Conditions when changes from the PR is deployed to the main-app _(violet-test.net)_

- When a new commit is pushed to the branch: `master`/`dev`/`rc`

### Demo

https://user-images.githubusercontent.com/25191509/198102072-7ad7a35a-8287-4a49-9a27-43a9495478a0.mp4





Co-authored-by: Prashant <alish.khadka@gmail.com>
Co-authored-by: Prashant Khadka <prashant.khadka052@gmail.com>