### PR TITLE
[Fix]: Dokku ci minor change

### DIFF
--- a/.github/workflows/dokku-deploy.yml
+++ b/.github/workflows/dokku-deploy.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
+parse_dynamic_attribute
       - name: Add public IP to AWS security group
         uses: sohelamin/aws-security-group-add-ip-action@master
         with:
@@ -36,6 +36,7 @@ jobs:
         with:
           git_remote_url: ${{ secrets.DOKKU_GIT_REMOTE }}
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          git_push_flags: '--force'
 
   review_app:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Address: https://github.com/restarone/violet_rails/issues/1127

The deploying of main dokku app failed in [here](https://github.com/restarone/violet_rails/actions/runs/3337287686/jobs/5523442195). It failed while pushing the changes. The `--force` flag was missing.
![image](https://user-images.githubusercontent.com/25191509/198318669-7496ca68-9bc6-4f5f-a2f2-b816317d62ac.png)

