### PR TITLE
[feature] link to associated CMS entity in API (#1189)

### DIFF
--- a/app/views/comfy/admin/api_namespaces/index.html.haml
+++ b/app/views/comfy/admin/api_namespaces/index.html.haml
@@ -21,6 +21,8 @@
         = sort_link @api_namespaces_q, :namespace_type
       %th 
         = 'Snippet'
+      %th 
+        = sort_link @api_namespaces_q, 'CMS Associations'
       %th
       %th
 
@@ -36,7 +38,8 @@
         %td= api_namespace.properties
         %td= api_namespace.requires_authentication
         %td= api_namespace.namespace_type
-        %td= "{{ cms:helper render_form, #{api_namespace.api_form.id} }}" if api_namespace.api_form.present?
+        %td= api_namespace.snippet
+        %td= api_namespace.cms_associations.present? ? '<i class="fa fa-solid fa-check text-success" style="width: 30px; height: 30px;"></i>'.html_safe : '<i class="fa fa-solid fa-times text-danger" style="width: 30px; height: 30px;"></i>'.html_safe
         %td= link_to 'Edit', edit_api_namespace_path(api_namespace)
         %td= link_to 'Destroy', api_namespace, method: :delete, data: { confirm: 'Are you sure?' }
 

--- a/app/views/comfy/admin/api_namespaces/show.html.haml
+++ b/app/views/comfy/admin/api_namespaces/show.html.haml
@@ -35,6 +35,9 @@
     %a#export-tab.nav-link{"aria-controls" => "export", "aria-selected" => "false", "data-toggle" => "tab", :href => "#export", :role => "tab"} 
       Export
   %li.nav-item
+    %a#cms-associations-tab.nav-link{"aria-controls" => "export", "aria-selected" => "false", "data-toggle" => "tab", :href => "#cms-associations", :role => "tab"} 
+      CMS Associations
+  %li.nav-item
     %a#social-tab.nav-link{"aria-controls" => "social", "aria-selected" => "false", "data-toggle" => "tab", :href => "#social", :role => "tab"} 
       Social Share Mapping
 
@@ -143,6 +146,51 @@
       = link_to 'Export JSON with associations', export_with_associations_as_json_api_namespace_path(id: @api_namespace.id), method: :get, class: 'btn btn-info'
     .my-3
       = link_to 'Export JSON without associations', export_without_associations_as_json_api_namespace_path(id: @api_namespace.id), method: :get, class: 'btn btn-info'
+  #cms-associations.tab-pane.fade{"aria-labelledby" => "cms-associations-tab", :role => "tabpanel"} 
+    - if (cms_associations = @api_namespace.cms_associations).present?
+      - page_associations = cms_associations.select { |association| association.class.to_s == 'Comfy::Cms::Page' }
+      - snippet_associations = cms_associations.select { |association| association.class.to_s == 'Comfy::Cms::Snippet' }
+      - layout_associations = cms_associations.select { |association| association.class.to_s == 'Comfy::Cms::Layout' }
+
+      .card.my-1
+        .card-body
+          .card-title.font-weight-bold
+            CMS Pages
+          - if page_associations.present?
+            %ul.list-group.ml-3
+              - page_associations.each do |page|
+                %li
+                  = link_to page.label, edit_comfy_admin_cms_site_page_path(site_id: page.site.id, id: page.id), target: '_blank'
+          - else
+            No Cms::Page associations for this api-namespace
+      .card.my-1
+        .card-body
+          .card-title.font-weight-bold
+            CMS Snippet
+          - if snippet_associations.present?
+            %ul.list-group.ml-3
+              - snippet_associations.each do |snippet|
+                %li
+                  = link_to snippet.label, edit_comfy_admin_cms_site_snippet_path(site_id: snippet.site.id, id: snippet.id), target: '_blank'
+          - else
+            No Cms::Snippet associations for this api-namespace
+      .card.my-1
+        .card-body
+          .card-title.font-weight-bold
+            CMS Layouts
+          - if layout_associations.present?
+            %ul.list-group.ml-3
+              - layout_associations.each do |layout|
+                %li
+                  = link_to layout.label, edit_comfy_admin_cms_site_layout_path(site_id: layout.site.id, id: layout.id), target: '_blank'
+          - else
+            No Cms::Layout associations for this api-namespace
+
+    - else
+      .card.my-1
+        .card-body
+          No CMS associations for this api-namespace
+
   #social.tab-pane.fade{"aria-labelledby" => "social-tab", :role => "tabpanel"} 
     = form_with(method: :patch , url: api_namespace_path(@api_namespace))  do |f|
       .form-group

--- a/test/controllers/admin/comfy/api_namespaces_controller_test.rb
+++ b/test/controllers/admin/comfy/api_namespaces_controller_test.rb
@@ -660,4 +660,27 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
       assert_includes rows[1].to_s, "Don"
     end
   end
+
+  test "show# should include the link of associated CMS entities: Page, Snippet and Layout" do
+    api_form = api_forms(:one)
+    api_form.update!(api_namespace: @api_namespace)
+
+    layout = comfy_cms_layouts(:default)
+    page = comfy_cms_pages(:root)
+    snippet = comfy_cms_snippets(:public)
+
+    namespace_snippet = @api_namespace.snippet
+
+    layout.update!(content: namespace_snippet)
+    snippet.update!(content: namespace_snippet)
+    page.fragments.create!(content: namespace_snippet, identifier: 'content')
+
+    sign_in(@user)
+    get api_namespace_url(@api_namespace)
+
+    assert_response :success
+    assert_select "a[href='#{edit_comfy_admin_cms_site_page_path(site_id: page.site.id, id: page.id)}']", { count: 1 }
+    assert_select "a[href='#{edit_comfy_admin_cms_site_snippet_path(site_id: snippet.site.id, id: snippet.id)}']", { count: 1 }
+    assert_select "a[href='#{edit_comfy_admin_cms_site_layout_path(site_id: layout.site.id, id: layout.id)}']", { count: 1 }
+  end
 end

--- a/test/models/api_namespace_test.rb
+++ b/test/models/api_namespace_test.rb
@@ -35,4 +35,59 @@ class ApiNamespaceTest < ActiveSupport::TestCase
     end
     assert_equal @subdomain_events_api.executed_api_actions.first.reload.lifecycle_stage, 'failed'
   end
+
+  test "should check the associated CMS entities: Page, Layout and Snippet for the api-namespace if the api-form snippet is content of them" do
+    namespace = api_namespaces(:users)
+    api_form = api_forms(:one)
+    api_form.update!(api_namespace: namespace)
+
+    layout = comfy_cms_layouts(:default)
+    page = comfy_cms_pages(:root)
+    snippet = comfy_cms_snippets(:public)
+
+    namespace_snippet = namespace.snippet
+
+    layout.update!(content: namespace_snippet)
+    snippet.update!(content: namespace_snippet)
+    page.fragments.create!(content: namespace_snippet, identifier: 'content')
+
+    associations = namespace.cms_associations
+
+    assert_includes associations, layout
+    assert_includes associations, page
+    assert_includes associations, snippet
+  end
+
+  test "should check the associated CMS Snippet if snippet's identifier is namespace_slug or namespace_slug-show" do
+    namespace = api_namespaces(:users)
+
+    snippet = comfy_cms_snippets(:public)
+    snippet.update!(identifier: namespace.slug)
+    associations = namespace.cms_associations
+
+    assert_includes associations, snippet
+
+    snippet.update!(identifier: "#{namespace.slug}-show")
+    associations = namespace.cms_associations
+
+    assert_includes associations, snippet
+  end
+
+  test "should check the associated CMS Page of the api-namespace if the API HTML renderer is content of the page" do
+    namespace = api_namespaces(:users)
+    page = comfy_cms_pages(:root)
+    page.fragments.create!(content: "{{ cms:helper render_api_namespace_resource '#{namespace.slug}', scope: { properties: { published: 'true' } }, order: { created_at: 'DESC' } }}", identifier: 'content')
+    associations = namespace.cms_associations
+
+    assert_includes associations, page
+  end
+
+  test "should check the associated CMS Page of the api-namespace if the API HTML renderer is content of the page with newlines" do
+    namespace = api_namespaces(:users)
+    page = comfy_cms_pages(:root)
+    page.fragments.create!(content: "<div class=\"p-4 details-page\">\r\n\t<div class=\"restrictive-container main__content-container\">\r\n\t\t{{cms:helper render_api_namespace_resource '#{namespace.slug}', scope: { properties: { published: 'true' } }}}\r\n\t</div>\r\n</div>", identifier: 'content')
+    associations = namespace.cms_associations
+
+    assert_includes associations, page
+  end
 end


### PR DESCRIPTION
* [feature] link to associated CMS entity in API

Addresses: https://github.com/restarone/violet_rails/issues/974

**Demo**

https://user-images.githubusercontent.com/25191509/199165299-25d1e0fb-0cd1-49a4-8e66-224bca2fa660.mov

* feat(): sortable by CMS associations in api-namespaces/index view

* feat(): show snippets used under API HTML renderer as associated cms-entities

* feat(): fix for some API HTML renderer not being detected in CMS associations

Co-authored-by: Prashant <alish.khadka@gmail.com>
Co-authored-by: Prashant Khadka <prashant.khadkda052@gmail.com>