### PR TITLE
[feature] associate multiple snippets with API #show and #index

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -37,7 +37,9 @@ module ContentHelper
 
     response = response.limit(options["limit"]) if options["limit"]
 
-    cms_dynamic_snippet_render(slug, nil, { api_resources: response, api_namespace: api_namespace })
+    snippet_identifier = options["snippet"] ? options["snippet"] : slug
+
+    cms_dynamic_snippet_render(snippet_identifier, nil, { api_resources: response, api_namespace: api_namespace })
   end
 
   # render resource show
@@ -54,8 +56,10 @@ module ContentHelper
     api_resources = api_resources.jsonb_search(:properties, scope["properties"], scope["match"]) if scope&.has_key?("properties")
     
     @api_resource_to_render = api_resources.find(params[:id])
+
+    snippet_name = options["snippet"] ? options["snippet"] : api_namespace_slug
     
-    cms_dynamic_snippet_render("#{api_namespace_slug}-show", nil, { api_resource: @api_resource_to_render, api_namespace: api_namespace })
+    cms_dynamic_snippet_render("#{snippet_name}-show", nil, { api_resource: @api_resource_to_render, api_namespace: api_namespace })
   end
 
   private

--- a/test/helpers/content_helper_test.rb
+++ b/test/helpers/content_helper_test.rb
@@ -509,6 +509,48 @@ class ContentHelperTest < ActionView::TestCase
     assert_equal excepted_response, response
   end
 
+  test 'render_api_namespace_resource_index - render default snippet if snippet option is not provided' do
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-staging", position: 0, content: "staging<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'order' => { 'created_at': 'DESC' } })
+    expected_response = "#{@api_resource_2.properties['name']}#{@api_resource_1.properties['name']}#{@api_resource.properties['name']}"
+
+    assert_equal expected_response, response
+  end
+
+  test 'render_api_namespace_resource_index - render an alternative snippet' do
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-staging", position: 0, content: "staging<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    response = render_api_namespace_resource_index(@api_namespace.slug, { 'snippet' => "#{@api_namespace.slug}-staging", 'order' => { 'created_at': 'DESC' } })
+    expected_response = "staging#{@api_resource_2.properties['name']}#{@api_resource_1.properties['name']}#{@api_resource.properties['name']}"
+
+    assert_equal expected_response, response
+  end
+
+  test 'render_api_namespace_resource - render default snippet if snippet option is not provided' do
+    params[:id] = @api_resource.id
+
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-staging-show", position: 0, content: "staging<%= @api_resource.properties['name'] %>")
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-show", position: 0, content: "<%= @api_resource.properties['name'] %>")
+
+    response = render_api_namespace_resource(@api_namespace.slug)
+    expected_response = @api_resource.properties['name']
+
+    assert_equal expected_response, response
+  end
+
+  test 'render_api_namespace_resource - render an alternative snippet' do
+    params[:id] = @api_resource.id
+
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-staging-show", position: 0, content: "staging<%= @api_resource.properties['name'] %>")
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-show", position: 0, content: "<%= @api_resource.properties['name'] %>")
+
+    response = render_api_namespace_resource(@api_namespace.slug, { 'snippet' => "#{@api_namespace.slug}-staging" })
+    expected_response = "staging#{@api_resource.properties['name']}"
+
+    assert_equal expected_response, response
+  end
+
   def current_user
     @current_user
   end


### PR DESCRIPTION
Addresses #1122

The `snippet` option needs to be provided in order to render a snippet other than the default index or show snippet. The default snippet will be rendered if `snippet` option is not provided.

## Rendering an alternative index snippet

An alternative snippet `movies-staging` for `movies` API namespace can be rendered in the following way:

```ruby
{{ cms:helper render_api_namespace_resource_index 'movies', { snippet: 'movies-staging' } }}
```

## Rendering an alternative show snippet

An alternative snippet `movies-staging-show` for `movies` API namespace can be rendered in the following way:

```ruby
{{ cms:helper render_api_namespace_resource 'movies', { snippet: 'movies-staging' } }}
```


https://user-images.githubusercontent.com/73725297/204227285-863ccc4a-536b-425d-865c-959e1f4e10bd.mp4