### PR TITLE
[CI] Job to delete all review apps (#1279)

### DIFF
--- a/.github/workflows/dokku-clean-review-apps.yml
+++ b/.github/workflows/dokku-clean-review-apps.yml
@@ -31,6 +31,13 @@ jobs:
               dokku postgres:exists "${APP_NAME}-db" && dokku postgres:destroy "${APP_NAME}-db" --force;
               dokku redis:exists "${APP_NAME}-redis" && dokku redis:destroy "${APP_NAME}-redis" --force;
 
+              if [ -d /home/dokku/$APP_NAME ]; then
+                echo "Folder of ${APP_NAME} still exists.\nDeleting it manually.";
+                sudo rm -rf /home/dokku/$APP_NAME;
+
+                [ -d /home/dokku/$APP_NAME ] && echo "Could not delete ${APP_NAME}." || echo "${APP_NAME} deleted successfully.";
+              fi
+
               echo "Deletion of ${APP_NAME} app, ${APP_NAME}-db and ${APP_NAME}-redis completed.";
             };
             done;


### PR DESCRIPTION
The code changes will delete the review-apps' folder on dokku EC2 instance if its folder still exists while cleaning up all review-apps.

Co-authored-by: Prashant Khadka <prashant.khadkda052@gmail.com>
Co-authored-by: Don Restarone <35935196+donrestarone@users.noreply.github.com>