### PR TITLE
[bug fix] don't raise error when API Resource ID is bad

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -62,6 +62,8 @@ module ContentHelper
     snippet_name = options["snippet"] ? options["snippet"] : api_namespace_slug
     
     cms_dynamic_snippet_render("#{snippet_name}-show", nil, { api_resource: @api_resource_to_render, api_namespace: api_namespace })
+  rescue ActiveRecord::RecordNotFound
+    render body: Rails.root.join('public', '404.html').read.html_safe, status: :not_found, layout: false
   end
 
   private

--- a/test/helpers/content_helper_test.rb
+++ b/test/helpers/content_helper_test.rb
@@ -164,14 +164,20 @@ class ContentHelperTest < ActionView::TestCase
     assert_equal @api_resource.properties['name'], response
   end
 
-  test 'render_api_namespace_resource - no scope - 404' do
-    params[:id] = 'not a id'
+  test "render_api_namespace_resource - no scope: should render 404 when the renderer ID is invalid or not provided and not raise error" do
+    Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-show", position: 0, content: "<%= @api_resource.properties['name'] %>")
 
-    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-show", position: 0, content: "<%= @api_resource.properties['name'] %>")
+    # When no ID is provided
+    assert_nothing_raised do
+      page_response = render_api_namespace_resource(@api_namespace.slug)
+      assert_match "<h1 class=\"main-title\">404</h1>", page_response
+    end
 
-    # should raise 404 if record not found 
-    assert_raises ActiveRecord::RecordNotFound do
-      response = render_api_namespace_resource(@api_namespace.slug)
+    # When invalid ID is provided
+    params[:id] = 0
+    assert_nothing_raised do
+      page_response = render_api_namespace_resource(@api_namespace.slug)
+      assert_match "<h1 class=\"main-title\">404</h1>", page_response
     end
   end
 
@@ -192,9 +198,10 @@ class ContentHelperTest < ActionView::TestCase
 
     snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: "#{@api_namespace.slug}-show", position: 0, content: "<%= @api_resource.properties['name'] %>")
 
-    # should not be able to find records blocked by scope
-    assert_raises ActiveRecord::RecordNotFound do
+    # should not be able to find records blocked by scope and show 404
+    assert_nothing_raised do
       response = render_api_namespace_resource(@api_namespace.slug, { 'scope' => { 'current_user' => 'true' } })
+      assert_match "<h1 class=\"main-title\">404</h1>", response
     end
   end
 


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/1278

**Demo**
 

https://user-images.githubusercontent.com/25191509/207099710-6da8a326-1109-4f10-9182-0b06c71c6393.mov