### PR TITLE
[bug fix] Run Error API actions (#1125)

### DIFF
--- a/app/controllers/concerns/api_actionable.rb
+++ b/app/controllers/concerns/api_actionable.rb
@@ -73,32 +73,12 @@ module ApiActionable
   end
 
   def handle_error(e)
-    clone_actions(:error_api_actions)
     execute_error_actions
     raise
   end
 
   def execute_error_actions
-    return if @api_resource.nil?
-
-    error_api_actions = @api_resource.error_api_actions
-
-    redirect_action = error_api_actions.where(action_type: 'redirect').last
-    error_api_actions.each do |action|
-      action.execute_action unless action.redirect?
-    end
-
-    if redirect_action
-      redirect_action.update(lifecycle_stage: 'complete', lifecycle_message: redirect_action.redirect_url)
-      # Redirecting with JS is only needed when dealing with reCaptcha.
-      # reCaptcha related request is handled by ResourceController
-      if controller_name == "resource"
-        redirect_with_js(redirect_url) and return
-      else
-        redirect_to redirect_url and return
-      end
-    end
-
+    ErrorApiAction.where(id: create_error_actions.map(&:id)).execute_model_context_api_actions
     @error_api_actions_exectuted = true
   end
 
@@ -116,6 +96,18 @@ module ApiActionable
 
     @api_namespace.send(action_name).each do |action|
       @api_resource.send(action_name).create(action.attributes.merge(custom_message: action.custom_message.to_s).except("id", "created_at", "updated_at", "api_namespace_id"))
+    end
+  end
+
+  # api_resource doesn't get saved if there's any error
+  def create_error_actions
+    @api_namespace.error_api_actions.map do |action|
+      api_resource_json = {
+        properties: @api_resource.properties,
+        api_namespace_id: @api_namespace.id,
+        errors: @api_resource.errors.full_messages.to_sentence
+      }
+      ErrorApiAction.create(action.attributes.merge(custom_message: action.custom_message.to_s, meta_data: { api_resource: api_resource_json }).except("id", "created_at", "updated_at", "api_namespace_id"))
     end
   end
 

--- a/app/models/api_action.rb
+++ b/app/models/api_action.rb
@@ -38,9 +38,39 @@ class ApiAction < ApplicationRecord
     ['new_api_actions', 'create_api_actions', 'show_api_actions', 'update_api_actions', 'destroy_api_actions', 'error_api_actions']
   end
 
-  def execute_action
+  def execute_action(run_error_action = true)
     self.update(lifecycle_stage: 'executing')
-    send(action_type)
+    send(action_type, run_error_action)
+  end
+
+  def self.execute_model_context_api_actions
+    api_actions = self.where(action_type: ApiAction::EXECUTION_ORDER[:model_level], lifecycle_stage: 'initialized')
+    
+    ApiAction::EXECUTION_ORDER[:model_level].each do |action_type|
+      if ApiAction.action_types[action_type] == ApiAction.action_types[:custom_action]
+        custom_actions = api_actions.where(action_type: 'custom_action')
+        custom_actions.each do |custom_action|
+          FireApiActionsJob.perform_async(custom_action.id, Current.user&.id, Current.visit&.id, Current.is_api_html_renderer_request)
+        end
+      elsif [ApiAction.action_types[:send_email], ApiAction.action_types[:send_web_request]].include?(ApiAction.action_types[action_type])
+        api_actions.where(action_type: ApiAction.action_types[action_type]).each do |api_action|
+          FireApiActionsJob.perform_async(api_action.id, Current.user&.id, Current.visit&.id, Current.is_api_html_renderer_request)
+        end
+      end
+    end if api_actions.present?
+  end
+
+
+  def execute_error_actions(error)
+    self.update(lifecycle_stage: 'failed', lifecycle_message: error)
+
+    p "sdd: #{self}"
+    return if type == 'ErrorApiAction' || api_resource.nil?
+
+    api_resource.api_namespace.error_api_actions.each do |action|
+      api_resource.error_api_actions.create(action.attributes.merge(custom_message: action.custom_message.to_s).except("id", "created_at", "updated_at", "api_namespace_id"))
+    end
+    api_resource.error_api_actions.each(&:execute_action)
   end
 
   private
@@ -49,33 +79,32 @@ class ApiAction < ApplicationRecord
     ApiAction.where(api_resource_id: api_namespace.api_resources.pluck(:id), payload_mapping: payload_mapping_previously_was, type: type, action_type: action_type).update_all(payload_mapping: payload_mapping)
   end
 
-  def send_email
+  def send_email(run_error_action = true)
     begin
       ApiActionMailer.send_email(self).deliver_now
       self.update(lifecycle_stage: 'complete', lifecycle_message: email)
-    rescue => e
-      self.update(lifecycle_stage: 'failed', lifecycle_message: e.message)
-      execute_error_actions
+    rescue Exception => e
+      execute_error_actions(e.message) if run_error_action
+      raise
     end
   end
 
-  def send_web_request
+  def send_web_request(run_error_action = true)
     begin
       response = HTTParty.send(http_method.to_s, request_url_evaluated, 
                     { body: payload_mapping_evaluated, headers: request_headers })
       if response.success?
         self.update(lifecycle_stage: 'complete', lifecycle_message: response.to_s)
       else
-        self.update(lifecycle_stage: 'failed', lifecycle_message: response.to_s)
-        execute_error_actions
+        execute_error_actions(response.to_s)
       end 
     rescue => e
-      self.update(lifecycle_stage: 'failed', lifecycle_message: e.message)
-      execute_error_actions
+      execute_error_actions(e.message) if run_error_action 
+      raise
     end
   end
 
-  def custom_action
+  def custom_action(run_error_action = true)
     begin
       custom_api_action = CustomApiAction.new
       eval("def custom_api_action.run_custom_action(api_action: , api_namespace: , api_resource: , current_visit: , current_user: nil); #{self.method_definition}; end")
@@ -84,27 +113,17 @@ class ApiAction < ApplicationRecord
 
       self.update(lifecycle_stage: 'complete', lifecycle_message: response.to_json)
     rescue => e
-      self.update(lifecycle_stage: 'failed', lifecycle_message: e.message)
-      execute_error_actions
+      execute_error_actions(e.message) if run_error_action
       raise
     end
   end
 
-  def redirect;end
+  def redirect(run_error_action = true);end
 
-  def serve_file;end
+  def serve_file(run_error_action = true);end
 
   def request_headers
-    headers = custom_headers_evaluated.gsub('SECRET_BEARER_TOKEN', bearer_token)
+    headers = custom_headers_evaluated.gsub('SECRET_BEARER_TOKEN', bearer_token.to_s)
     { 'Content-Type' => 'application/json' }.merge(JSON.parse(headers))
-  end
-
-  def execute_error_actions
-    return if type == 'ErrorApiAction' || api_resource.nil?
-
-    api_resource.api_namespace.error_api_actions.each do |action|
-      api_resource.error_api_actions.create(action.attributes.merge(custom_message: action.custom_message.to_s).except("id", "created_at", "updated_at", "api_namespace_id"))
-    end
-    api_resource.error_api_actions.each(&:execute_action)
   end
 end

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -25,8 +25,6 @@ class ApiNamespace < ApplicationRecord
  
   has_many :api_actions, dependent: :destroy
 
-  has_many :executed_api_actions, through: :api_resources, class_name: 'ApiAction', source: :api_actions
-
   has_many :new_api_actions, dependent: :destroy
   accepts_nested_attributes_for :new_api_actions, allow_destroy: true
 
@@ -324,6 +322,10 @@ class ApiNamespace < ApplicationRecord
     rescue => e
       { success: false, message: e.message }
     end
+  end
+
+  def executed_api_actions
+    ApiAction.where(api_resource_id: api_resources.pluck(:id)).or(ApiAction.where("meta_data->'api_resource' ->> 'api_namespace_id' = '#{self.id}'"))
   end
 
   def snippet(with_brackets: true)

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -75,25 +75,7 @@ class ApiResource < ApplicationRecord
   end
 
   def execute_model_context_api_actions(class_name)
-    api_actions = self.send(class_name).where(action_type: ApiAction::EXECUTION_ORDER[:model_level], lifecycle_stage: 'initialized')
-
-    ApiAction::EXECUTION_ORDER[:model_level].each do |action_type|
-      if ApiAction.action_types[action_type] == ApiAction.action_types[:custom_action]
-        begin
-          custom_actions = api_actions.where(action_type: 'custom_action')
-          custom_actions.each do |custom_action|
-            custom_action.execute_action
-          end
-        rescue
-          # error-actions are executed already in api-action level.
-          nil
-        end
-      elsif [ApiAction.action_types[:send_email], ApiAction.action_types[:send_web_request]].include?(ApiAction.action_types[action_type])
-        api_actions.where(action_type: ApiAction.action_types[action_type]).each do |api_action|
-          api_action.execute_action
-        end
-      end
-    end if api_actions.present?
+    self.send(class_name).execute_model_context_api_actions
   end
 
   private
@@ -122,11 +104,11 @@ class ApiResource < ApplicationRecord
 
   def execute_create_api_actions
     clone_api_actions('create_api_actions')
-    FireApiActionsJob.perform_async(self.id, 'create_api_actions', Current.user&.id, Current.visit&.id, Current.is_api_html_renderer_request)
+    CreateApiAction.where(id: self.create_api_actions.pluck(:id)).execute_model_context_api_actions
   end
 
   def execute_update_api_actions
     clone_api_actions('update_api_actions')
-    FireApiActionsJob.perform_async(self.id, 'update_api_actions', Current.user&.id, Current.visit&.id, Current.is_api_html_renderer_request)
+    UpdateApiAction.where(id: self.update_api_actions.pluck(:id)).execute_model_context_api_actions
   end
 end

--- a/app/sidekiq/fire_api_actions_job.rb
+++ b/app/sidekiq/fire_api_actions_job.rb
@@ -1,14 +1,26 @@
 class FireApiActionsJob
   include Sidekiq::Job
 
-  def perform(api_resource_id, action_class, current_user_id, current_visit_id, is_api_html_renderer_request)
+  # run error actions only after final retries
+  sidekiq_retries_exhausted do |msg, exception|
+    set_current_visit(msg['args'][1], msg['args'][2], msg['args'][3]) do
+      ApiAction.find(msg['args'][0]).execute_error_actions(exception.message)
+    end
+  end
+
+  def perform(action_id, current_user_id, current_visit_id, is_api_html_renderer_request)
+    FireApiActionsJob.set_current_visit(current_user_id, current_visit_id, is_api_html_renderer_request) do
+      api_action = ApiAction.find(action_id)
+      api_action.execute_action(false) if api_action.present?
+    end
+  end
+
+  def self.set_current_visit(current_user_id, current_visit_id, is_api_html_renderer_request)
     current_user = User.find_by(id: current_user_id)
     current_visit = Ahoy::Visit.find_by(id: current_visit_id)
 
     Current.set(user: current_user, visit: current_visit, is_api_html_renderer_request: is_api_html_renderer_request) do
-      api_resource = ApiResource.find(api_resource_id)
-  
-      api_resource.execute_model_context_api_actions(action_class)
+      yield
     end
   end
 end

--- a/app/views/comfy/admin/api_actions/index.html.haml
+++ b/app/views/comfy/admin/api_actions/index.html.haml
@@ -29,7 +29,14 @@
     - @api_actions.each do |api_action|
       %tr
         %td.px-3.py-2= link_to api_action.id, api_namespace_api_action_path(api_namespace_id: @api_namespace.id, id: api_action.id) 
-        %td.px-3.py-2= link_to api_action.api_resource_id, api_namespace_resource_path(api_namespace_id: @api_namespace.id, id: api_action.api_resource_id) 
+        %td.px-3.py-2
+          - if api_action.api_resource_id
+            = link_to api_action.api_resource_id, api_namespace_resource_path(api_namespace_id: @api_namespace.id, id: api_action.api_resource_id)
+          - else
+            %div= api_action.meta_data.dig('api_resource', 'properties')
+            %div
+              %strong Error:
+              = api_action.meta_data.dig('api_resource', 'errors')
         %td.px-3= api_action.type
         %td.px-3= api_action.action_type
         %td.px-3

--- a/db/migrate/20220906063031_add_additional_data_to_api_actions.rb
+++ b/db/migrate/20220906063031_add_additional_data_to_api_actions.rb
@@ -1,0 +1,5 @@
+class AddAdditionalDataToApiActions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_actions, :meta_data, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2022_11_28_055836) do
     t.text "method_definition", default: "raise StandardError"
     t.text "email_subject"
     t.integer "redirect_type", default: 0
+    t.jsonb "meta_data", default: {}
     t.index ["api_namespace_id"], name: "index_api_actions_on_api_namespace_id"
     t.index ["api_resource_id"], name: "index_api_actions_on_api_resource_id"
   end

--- a/test/controllers/resource_controller_test.rb
+++ b/test/controllers/resource_controller_test.rb
@@ -941,4 +941,92 @@ class ResourceControllerTest < ActionDispatch::IntegrationTest
     # When user is signed in
     assert_equal Ahoy::Event.last.properties['user_id'], user.id 
   end
+
+  test 'should run error api action if recaptcha verification failed' do
+    @api_namespace.api_form.update(show_recaptcha: true)
+    payload = {
+      data: {
+          properties: {
+            first_name: 'Don'
+          }
+      }
+    }
+    # Recaptcha is disabled for test env by deafult
+    Recaptcha.configuration.skip_verify_env.delete("test")
+    assert_no_difference "@api_namespace.api_resources.count" do
+      assert_difference "@api_namespace.reload.executed_api_actions.count", +@api_namespace.error_api_actions.count do 
+        post api_namespace_resource_index_url(api_namespace_id: @api_namespace.id), params: payload
+        assert_response :success
+      end
+    end
+
+    # should store user input with proper error message
+    expected_json = {"api_resource"=>{"errors"=>"reCAPTCHA verification failed, please try again.", "properties"=>{"first_name"=>"Don"}, "api_namespace_id"=>@api_namespace.id}}
+    assert_equal expected_json,  @api_namespace.executed_api_actions.order(:created_at).last.meta_data
+
+    Recaptcha.configuration.skip_verify_env.push("test")
+  end
+
+  test 'should run error api action if there are any error while saving api resources' do
+    @api_namespace.api_form.update(properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input', 'required': '1' }})
+    payload = {
+      data: {
+          properties: {
+            name: '',
+          }
+      }
+    }
+    assert_no_difference "@api_namespace.api_resources.count" do
+      assert_difference "@api_namespace.reload.executed_api_actions.count", +@api_namespace.error_api_actions.count do 
+        post api_namespace_resource_index_url(api_namespace_id: @api_namespace.id), params: payload
+      end
+    end
+
+    # should store user input with proper error message
+    expected_json = {"api_resource"=>{"errors"=>"Properties name is required", "properties"=>{"name"=>""}, "api_namespace_id"=>@api_namespace.id}}
+    assert_equal expected_json, @api_namespace.executed_api_actions.order(:created_at).last.meta_data
+  end
+
+  test 'should run all error api actions once for each failed api actions' do
+    api_namespace = api_namespaces(:no_api_actions)
+    # this api action will raise an error on execution
+    CreateApiAction.create(api_namespace_id: api_namespace.id, action_type: 'custom_action', method_definition: "raise StandardError")
+    # This api action should execute incase of any errors
+    ErrorApiAction.create(api_namespace_id: api_namespace.id, action_type: 'custom_action', method_definition: "p 'no errors here'")
+
+    payload = {
+      data: {
+          properties: {
+            name: 'test',
+          }
+      }
+    }
+
+    Sidekiq::Testing.inline! do
+      assert_difference "api_namespace.api_resources.count", +1 do
+        assert_difference "api_namespace.reload.executed_api_actions.where(type: 'ErrorApiAction').count", +1 do  
+          perform_enqueued_jobs do
+            assert_raises StandardError do
+              post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+            end
+          end
+        end
+      end
+    end
+
+    assert_equal ["\"no errors here\""], api_namespace.executed_api_actions.where(type: 'ErrorApiAction').pluck(:lifecycle_message)
+
+    # This api action should execute incase of any errors
+    ErrorApiAction.create(api_namespace_id: api_namespace.id, action_type: 'custom_action', method_definition: "p 'no error here either'")
+
+    Sidekiq::Testing.inline! do
+      assert_difference "api_namespace.reload.executed_api_actions.where(type: 'ErrorApiAction').count", +2 do  
+        perform_enqueued_jobs do
+          assert_raises StandardError do
+            post api_namespace_resource_index_url(api_namespace_id: api_namespace.id), params: payload
+          end
+        end
+      end
+    end
+  end
 end

--- a/test/fixtures/api_actions.yml
+++ b/test/fixtures/api_actions.yml
@@ -94,11 +94,12 @@ create_api_action_plugin_subdomain_events:
   action_type: send_web_request
   include_api_resource_data: true
   payload_mapping: {
-                      "content": "#{self.representation.body}"
+                      "content": "#{api_resource.properties&.dig('representation', 'body')}"
                     }
   request_url: "http://www.example.com/success"
   api_namespace: plugin_subdomain_events
   http_method: post
+  custom_headers: {"AUTHORIZATION":"SECRET_BEARER_TOKEN"}
 
 create_custom_api_action_three:
   type: CreateApiAction
@@ -112,11 +113,12 @@ create_api_action_plugin_bishop_monitoring_web_request:
   type: CreateApiAction
   action_type: send_web_request
   payload_mapping: {
-                      "content": "#{self.representation.body}"
+                      "content": "#{api_resource.properties&.dig('representation', 'body')}"
                     }
   request_url: "http://www.discord.com"
   api_namespace: monitoring_target_incident
   http_method: post
+  custom_headers: {"AUTHORIZATION":"SECRET_BEARER_TOKEN"}
 
 create_api_action_plugin_bishop_monitoring_email:
   type: CreateApiAction

--- a/test/helpers/content_helper_test.rb
+++ b/test/helpers/content_helper_test.rb
@@ -135,7 +135,7 @@ class ContentHelperTest < ActionView::TestCase
     @current_user = @user
     params[:properties] = {name: { value: 'test user', option: 'PARTIAL' }}.to_json
 
-    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.each do |res| %><%= res.properties['name'] %><% end %>")
+    snippet = Comfy::Cms::Snippet.create(site_id: @cms_site.id, label: 'clients', identifier: @api_namespace.slug, position: 0, content: "<% @api_resources.jsonb_order_pre({ properties: { name: 'ASC'}}).each do |res| %><%= res.properties['name'] %><% end %>")
     
     response = render_api_namespace_resource_index(@api_namespace.slug, { 'scope' => { 'current_user' => 'true' } })
     excepted_response = "#{@api_resource_1.properties['name']}#{@api_resource_2.properties['name']}"

--- a/test/models/api_namespace_test.rb
+++ b/test/models/api_namespace_test.rb
@@ -33,7 +33,8 @@ class ApiNamespaceTest < ActiveSupport::TestCase
       service.track_event
       Sidekiq::Worker.drain_all
     end
-    assert_equal @subdomain_events_api.executed_api_actions.first.reload.lifecycle_stage, 'failed'
+
+    assert_equal @subdomain_events_api.reload.executed_api_actions.first.lifecycle_stage, 'complete'
   end
 
   test "should check the associated CMS entities: Page, Layout and Snippet for the api-namespace if the api-form snippet is content of them" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,7 @@ class ActiveSupport::TestCase
     end
     stub_request(:post, "www.example.com/success").to_return(body: "success response", status: 200)
     stub_request(:post, "www.example.com/error").to_return(body: "error response", status: 500)
+    stub_request(:post, "http://www.discord.com/").to_return(body: "success response", status: 200)
   end
 
   teardown do


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/985

Addresses: https://github.com/restarone/violet_rails/issues/1071

### Demo:

https://user-images.githubusercontent.com/50227291/188673867-186d03e9-a8ec-4cb7-adb0-6a6483ba1cec.mov

Since api resource is not saved due to any error, api action will keep track of user input with proper error message under 

`additional_data['api_resource']['properties']` and `additional_data['api_resource']['errors']`

Demo shows error message and user input being accessed by api_action

### Demo fix dead set functionality


https://user-images.githubusercontent.com/50227291/189976658-e7c6fbe8-1f69-4740-9e98-98835a8fae26.mov

### Demo showing error message in API 
https://user-images.githubusercontent.com/50227291/196223270-e1d831f3-8403-43eb-84c2-d5419ea078d4.mov
Co-authored-by: Pralish Kayastha <50227291+Pralish@users.noreply.github.com>
Co-authored-by: Pralish Kayastha <pralishkayastha@gmail.com>