### PR TITLE
[feature] Web hook drive strategy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry'
 end
 
 group :development do
@@ -112,5 +113,7 @@ gem "turnout", "~> 2.5"
 gem "turbo-rails", "~> 1.1"
 
 gem "redis-namespace", "~> 1.8"
+
+gem 'stripe-rails'
 
 gem 'devise-two-factor', "4.0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
     climate_control (0.2.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
+    coderay (1.1.3)
     comfy_bootstrap_form (4.0.9)
       rails (>= 5.0.0)
     concurrent-ruby (1.1.10)
@@ -310,6 +311,9 @@ GEM
     orm_adapter (0.5.0)
     parallel (1.20.1)
     pg (1.2.3)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -443,6 +447,11 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stripe (7.1.0)
+    stripe-rails (2.3.5)
+      rails (>= 5.1)
+      responders
+      stripe (>= 3.15.0)
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.10)
@@ -534,6 +543,7 @@ DEPENDENCIES
   mocha
   net-ssh (>= 6.0.2)
   pg (~> 1.1)
+  pry
   puma (~> 5.6)
   rack-cors
   rack-mini-profiler (~> 2.0)
@@ -551,6 +561,7 @@ DEPENDENCIES
   sinatra
   sitemap_generator
   spring
+  stripe-rails
   turbo-rails (~> 1.1)
   turnout (~> 2.5)
   tzinfo-data

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,7 +4,7 @@ class Api::BaseController < ActionController::API
   def authenticate_request
     if @api_namespace.requires_authentication
       unless validate_bearer_token
-        render json: { status: 'unauthorized', code: 401 }
+        render json: { status: 'unauthorized', code: 401 }, status: 401
       end
     end
   end
@@ -15,8 +15,8 @@ class Api::BaseController < ActionController::API
     bearer_token = request.headers['Authorization']
     if bearer_token
       token = bearer_token.split(' ')[1]
-      api_client = @api_namespace.api_clients.find_by(bearer_token: token)
-      if api_client
+      api_key = @api_namespace.api_keys.any? { |api_key| api_key.token == token }
+      if api_key
         return true
       else
         return false

--- a/app/controllers/api/external_api_clients_controller.rb
+++ b/app/controllers/api/external_api_clients_controller.rb
@@ -1,0 +1,40 @@
+class Api::ExternalApiClientsController < Api::BaseController
+    before_action :find_external_api_client
+    after_action :unload_api_connection_class, only: :webhook
+    skip_before_action :authenticate_request
+
+    def webhook
+      # should only exist if drive strategy is webhook
+      raise ActionController::RoutingError.new('Not Found') unless @external_api_client.drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:webhook]
+
+      return render json: { message: 'Webhook not enabled', success: false }, status: 400 unless @external_api_client.enabled
+
+      if @external_api_client.webhook_verification_method.present?
+        verified, message = Webhook::Verification.new(request, @external_api_client.webhook_verification_method).call
+
+        return render json: { message: message, success: false }, status: 401 unless verified
+      end
+
+      @model_definition = @external_api_client.evaluated_model_definition
+
+      # add render method on model_definition
+      # render should only be available on controller context
+      @model_definition.define_method(:render) do |args|
+        return { render: true, args: args } 
+      end
+
+      response = @model_definition.new(external_api_client: @external_api_client, request: request).start
+
+      render response[:args] if response.is_a?(Hash) && response[:render]
+    end
+
+    private
+
+    def unload_api_connection_class
+      ExternalApiClient.send(:remove_const, @model_definition.name.split('::').last.to_sym) if @model_definition
+    end
+
+    def find_external_api_client
+      @external_api_client = ExternalApiClient.find_by(slug: params[:external_api_client])
+    end
+end

--- a/app/controllers/comfy/admin/api_keys_controller.rb
+++ b/app/controllers/comfy/admin/api_keys_controller.rb
@@ -1,0 +1,53 @@
+class Comfy::Admin::ApiKeysController < Comfy::Admin::Cms::BaseController
+  before_action :ensure_authority_for_read_api_keys_only_in_api, only: %i[ index ]
+  before_action :ensure_authority_for_view_api_keys_details_only_in_api, only: %i[ show ]
+  before_action :ensure_authority_for_delete_access_for_api_keys_only_in_api, only: %i[ destroy ]
+  before_action :ensure_authority_for_full_access_for_api_keys_only_in_api, only: %i[ new edit create update ]
+
+  before_action :set_api_key, only: [:update, :edit, :destroy, :show]
+
+  def index
+    @api_keys = ApiKey.all
+  end
+
+  def new
+    @api_key = ApiKey.new
+    @api_key.api_namespace_keys.build
+  end
+
+  def edit
+  end
+
+  def create
+    @api_key = ApiKey.new(api_key_params)
+
+    if @api_key.save
+      redirect_to api_key_path(id: @api_key.id), notice: "Api key was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @api_key.update(api_key_params)
+      redirect_to api_key_path(id: @api_key.id), notice: "Api key was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @api_key.destroy
+    redirect_to api_keys_path, notice: "Api key was successfully destroyed."
+  end
+
+  private
+
+  def set_api_key
+    @api_key = ApiKey.find_by(id: params[:id])
+  end
+
+  def api_key_params
+    params.require(:api_key).permit(:label, :authentication_strategy, api_namespace_ids: [])
+  end
+end

--- a/app/controllers/comfy/admin/external_api_clients_controller.rb
+++ b/app/controllers/comfy/admin/external_api_clients_controller.rb
@@ -16,10 +16,12 @@ class Comfy::Admin::ExternalApiClientsController < Comfy::Admin::Cms::BaseContro
     # GET /external_api_clients/new
     def new
       @external_api_client = ExternalApiClient.new(api_namespace_id: @api_namespace.id)
+      @external_api_client.build_webhook_verification_method
     end
   
     # GET /external_api_clients/1/edit
     def edit
+      @external_api_client.build_webhook_verification_method unless @external_api_client.webhook_verification_method.present?
     end
   
     # POST /external_api_clients or /external_api_clients.json
@@ -106,7 +108,9 @@ class Comfy::Admin::ExternalApiClientsController < Comfy::Admin::Cms::BaseContro
             :max_requests_per_minute,
             :max_workers,
             :model_definition,
-            :drive_every
+            :drive_every,
+            :require_webhook_verification,
+            webhook_verification_method_attributes: [:id, :webhook_type, :webhook_secret, :custom_method_definition]
           ).merge({
             api_namespace_id: @api_namespace.id,
           })

--- a/app/controllers/subdomains/base_controller.rb
+++ b/app/controllers/subdomains/base_controller.rb
@@ -166,9 +166,37 @@ class Subdomains::BaseController < ApplicationController
     end
   end
 
+  def ensure_authority_for_read_api_keys_only_in_api
+    unless user_authorized_for_api_keys_accessibility?(ApiNamespace::API_ACCESSIBILITIES[:read_api_keys_only])
+      flash.alert = "You do not have the permission to do that. Only users with full_access or read_access or delete_acess for ApiKeys are allowed to perform that action."
+      redirect_back(fallback_location: root_url)
+    end
+  end
+
+  def ensure_authority_for_view_api_keys_details_only_in_api
+    unless user_authorized_for_api_keys_accessibility?(ApiNamespace::API_ACCESSIBILITIES[:view_api_keys_details_only])
+      flash.alert = "You do not have the permission to do that. Only users with full_access or read_access for ApiKeys are allowed to perform that action."
+      redirect_back(fallback_location: root_url)
+    end
+  end
+
+  def ensure_authority_for_full_access_for_api_keys_only_in_api
+    unless user_authorized_for_api_keys_accessibility?(ApiNamespace::API_ACCESSIBILITIES[:full_access_for_api_keys_only])
+      flash.alert = "You do not have the permission to do that. Only users with full_access for ApiKeys are allowed to perform that action."
+      redirect_back(fallback_location: root_url)
+    end
+  end
+
+  def ensure_authority_for_delete_access_for_api_keys_only_in_api
+    unless user_authorized_for_api_keys_accessibility?(ApiNamespace::API_ACCESSIBILITIES[:delete_access_for_api_keys_only])
+      flash.alert = "You do not have the permission to do that. Only users with full_access or delete_access for ApiKeys are allowed to perform that action."
+      redirect_back(fallback_location: root_url)
+    end
+  end
+
   def ensure_authority_for_viewing_all_api
     unless user_authorized_to_view_all_api?(ApiNamespace::API_ACCESSIBILITIES[:full_read_access_in_api_namespace])
-      flash.alert = "You do not have the permission to do that. Only users with full_access or full_read_access or full_access_api_namespace_only are allowed to perform that action."
+      flash.alert = "You do not have the permission to do that. Only users with access in ApiNamespaces or access in ApiKeys are allowed to perform that action."
       redirect_back(fallback_location: root_url)
     end
   end
@@ -183,26 +211,26 @@ class Subdomains::BaseController < ApplicationController
 
   private
   def user_authorized_for_api_accessibility?(api_permissions, check_categories: true)
-    user_api_accessibility = current_user.api_accessibility
+    return false unless current_user.api_accessibility['api_namespaces'].present?
 
-    return false unless user_api_accessibility.present?
+    api_namespaces_accessibility = current_user.api_accessibility['api_namespaces']
 
     is_user_authorized = false
 
-    if user_api_accessibility.keys.include?('all_namespaces')
+    if api_namespaces_accessibility.keys.include?('all_namespaces')
       is_user_authorized = api_permissions.any? do |access_name|
-        user_api_accessibility.dig('all_namespaces', access_name).present? && user_api_accessibility.dig('all_namespaces', access_name) == 'true'
+        api_namespaces_accessibility.dig('all_namespaces', access_name).present? && api_namespaces_accessibility.dig('all_namespaces', access_name) == 'true'
       end
-    elsif user_api_accessibility.keys.include?('namespaces_by_category')
+    elsif api_namespaces_accessibility.keys.include?('namespaces_by_category')
       if check_categories && (categories = @api_namespace.categories.pluck(:label)) && categories.present?
         categories.any? do |category|
           is_user_authorized = api_permissions.any? do |access_name|
-            user_api_accessibility.dig('namespaces_by_category', category, access_name).present? && user_api_accessibility.dig('namespaces_by_category', category, access_name) == 'true'
+            api_namespaces_accessibility.dig('namespaces_by_category', category, access_name).present? && api_namespaces_accessibility.dig('namespaces_by_category', category, access_name) == 'true'
           end
         end
       else
         is_user_authorized = api_permissions.any? do |access_name|
-          user_api_accessibility.dig('namespaces_by_category', 'uncategorized', access_name).present? && user_api_accessibility.dig('namespaces_by_category', 'uncategorized', access_name) == 'true'
+          api_namespaces_accessibility.dig('namespaces_by_category', 'uncategorized', access_name).present? && api_namespaces_accessibility.dig('namespaces_by_category', 'uncategorized', access_name) == 'true'
         end
       end
     end
@@ -211,24 +239,40 @@ class Subdomains::BaseController < ApplicationController
   end
 
   def user_authorized_to_view_all_api?(api_permissions)
-    user_api_accessibility = current_user.api_accessibility
+    return false unless current_user.api_accessibility.keys.present?
 
-    return false unless user_api_accessibility.present?
+    api_namespaces_accessibility = current_user.api_accessibility['api_namespaces']
+    api_keys_accessibility = current_user.api_accessibility['api_keys']
 
     is_user_authorized = false
 
-    if user_api_accessibility.keys.include?('all_namespaces')
+    if api_namespaces_accessibility.present? && api_namespaces_accessibility.keys.include?('all_namespaces')
       is_user_authorized = api_permissions.any? do |access_name|
-        user_api_accessibility.dig('all_namespaces', access_name).present? && user_api_accessibility.dig('all_namespaces', access_name) == 'true'
+        api_namespaces_accessibility.dig('all_namespaces', access_name).present? && api_namespaces_accessibility.dig('all_namespaces', access_name) == 'true'
       end
-    elsif user_api_accessibility.keys.include?('namespaces_by_category')
-      categories = user_api_accessibility.dig('namespaces_by_category').keys
+    elsif api_namespaces_accessibility.present? && api_namespaces_accessibility.keys.include?('namespaces_by_category')
+      categories = api_namespaces_accessibility.dig('namespaces_by_category').keys
 
       categories.any? do |category|
         is_user_authorized = api_permissions.any? do |access_name|
-          user_api_accessibility.dig('namespaces_by_category', category, access_name).present? && user_api_accessibility.dig('namespaces_by_category', category, access_name) == 'true'
+          api_namespaces_accessibility.dig('namespaces_by_category', category, access_name).present? && api_namespaces_accessibility.dig('namespaces_by_category', category, access_name) == 'true'
         end
       end
+    elsif api_keys_accessibility.present?
+      is_user_authorized = ApiNamespace::API_ACCESSIBILITIES[:read_api_keys_only].any? do |access_name|
+        api_keys_accessibility.dig(access_name).present? && api_keys_accessibility.dig(access_name) == 'true'
+      end
+    end
+
+    is_user_authorized
+  end
+
+  def user_authorized_for_api_keys_accessibility?(api_permissions)
+    return false unless current_user.api_accessibility['api_keys'].present?
+
+    api_keys_accessibility = current_user.api_accessibility['api_keys']
+    is_user_authorized = api_permissions.any? do |access_name|
+      api_keys_accessibility[access_name].present? && api_keys_accessibility[access_name] == 'true'
     end
 
     is_user_authorized

--- a/app/helpers/api_accessibility_helper.rb
+++ b/app/helpers/api_accessibility_helper.rb
@@ -1,30 +1,30 @@
 module ApiAccessibilityHelper
   def has_access_to_main_category?(api_accessibility, top_category)
-    api_accessibility.dig(top_category).present?
+    api_accessibility.dig('api_namespaces', top_category).present?
   end
 
   def has_access_to_specific_category?(api_accessibility, category_label)
-    api_accessibility.dig('namespaces_by_category', category_label).present?
+    api_accessibility.dig('api_namespaces', 'namespaces_by_category', category_label).present?
   end
 
   def has_sub_access_to_specific_category?(api_accessibility, sub_access, top_category, category_label = nil)
     if top_category == 'all_namespaces'
-      api_accessibility.dig(top_category, sub_access).present?
+      api_accessibility.dig('api_namespaces', top_category, sub_access).present?
     else
-      api_accessibility.dig(top_category, category_label, sub_access).present?
+      api_accessibility.dig('api_namespaces', top_category, category_label, sub_access).present?
     end
   end
 
   def has_no_sub_access_to_specific_category?(api_accessibility, top_category, category_label = nil)
     if top_category == 'all_namespaces'
-      api_accessibility.dig(top_category)&.keys.present?
+      api_accessibility.dig('api_namespaces', top_category)&.keys.present?
     else
-      api_accessibility.dig(top_category, category_label)&.keys.present?
+      api_accessibility.dig('api_namespaces', top_category, category_label)&.keys.present?
     end
   end
 
   def has_access_to_api_accessibility?(api_permissions, user, api_namespace)
-    user_api_accessibility = user.api_accessibility
+    user_api_accessibility = user.api_accessibility['api_namespaces']
 
     return false unless user_api_accessibility.present?
 
@@ -52,11 +52,18 @@ module ApiAccessibilityHelper
 
     is_user_authorized
   end
+  
+  def has_access_to_api_keys?(api_accessibility, access_name)
+    api_accessibility.dig('api_keys', access_name).present? && api_accessibility.dig('api_keys', access_name) == 'true'
+  end
 
   def has_only_uncategorized_access?(api_accessibility)
-    return false if api_accessibility.keys.include?('all_namespaces')
-    if api_accessibility.keys.include?('namespaces_by_category')
-      categories = api_accessibility['namespaces_by_category'].keys
+    api_namespaces_accessibility = api_accessibility['api_namespaces']
+
+    return false if api_namespaces_accessibility.keys.include?('all_namespaces')
+
+    if api_namespaces_accessibility.keys.include?('namespaces_by_category')
+      categories = api_namespaces_accessibility['namespaces_by_category'].keys
       return true if categories.size == 1 && categories[0] == 'uncategorized'
     end
 
@@ -64,10 +71,12 @@ module ApiAccessibilityHelper
   end
 
   def filter_categories_by_api_accessibility(api_accessibility, categories)
-    if api_accessibility.keys.include?('all_namespaces')
+    api_namespaces_accessibility = api_accessibility['api_namespaces']
+
+    if api_namespaces_accessibility.keys.include?('all_namespaces')
       categories
-    elsif api_accessibility.keys.include?('namespaces_by_category')
-      accessible_categories = api_accessibility['namespaces_by_category'].keys - ['uncategorized']
+    elsif api_namespaces_accessibility.keys.include?('namespaces_by_category')
+      accessible_categories = api_namespaces_accessibility['namespaces_by_category'].keys - ['uncategorized']
 
       categories.where(label: accessible_categories)
     end

--- a/app/javascript/packs/comfy/admin/cms.js
+++ b/app/javascript/packs/comfy/admin/cms.js
@@ -4,6 +4,11 @@ window.addEventListener('DOMContentLoaded', (event) => {
     $('.js-sortable').each(function() {
         initializeSortable($(this).attr('id'))
     })
+
+    $('textarea[data-cms-cm-readOnly=true]').each(function () {
+        let editor = $(this).next('.CodeMirror')[0].CodeMirror;
+        editor.options.readOnly = 'nocursor';
+    })
 })
 
 function initializeSortable(containerId) {

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,25 @@
+class ApiKey < ApplicationRecord
+  include Encryptable
+  extend FriendlyId
+
+  friendly_id :label, use: :slugged
+
+  attr_encrypted :token
+
+  before_create :set_encrypted_token_if_applicable
+
+  has_many :api_namespace_keys, dependent: :destroy
+  accepts_nested_attributes_for :api_namespace_keys
+
+  has_many :api_namespaces, through: :api_namespace_keys
+
+  enum authentication_strategy: { bearer_token: 'bearer_token' }
+
+  private
+
+  def set_encrypted_token_if_applicable
+    if self.bearer_token? && token.nil?
+      self.token = SecureRandom.uuid
+    end
+  end
+end

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -43,6 +43,9 @@ class ApiNamespace < ApplicationRecord
   has_many :error_api_actions, dependent: :destroy
   accepts_nested_attributes_for :error_api_actions, allow_destroy: true
 
+  has_many :api_namespace_keys, dependent: :destroy
+  has_many :api_keys, through: :api_namespace_keys
+
   ransacker :properties do |_parent|
     Arel.sql("api_namespaces.properties::text") 
   end
@@ -73,20 +76,26 @@ class ApiNamespace < ApplicationRecord
     read_api_clients_only: ['full_access', 'full_read_access', 'full_access_for_api_clients_only', 'read_api_clients_only'],
     full_access_for_api_clients_only: ['full_access', 'full_access_for_api_clients_only'],
     full_access_for_api_form_only: ['full_access', 'full_access_for_api_form_only'],
+    read_api_keys_only: ['full_access', 'delete_access', 'read_access'],
+    view_api_keys_details_only: ['full_access', 'read_access'],
+    full_access_for_api_keys_only: ['full_access'],
+    delete_access_for_api_keys_only: ['full_access', 'delete_access'],
   }
 
   scope :filter_by_user_api_accessibility, ->(user) { 
-    api_accessibility = user.api_accessibility
+    api_accessibility = user.api_accessibility['api_namespaces']
 
-    if api_accessibility.keys.include?('all_namespaces')
+    if api_accessibility.present? && api_accessibility.keys.include?('all_namespaces')
       self
-    elsif api_accessibility.keys.include?('namespaces_by_category')
+    elsif api_accessibility.present? && api_accessibility.keys.include?('namespaces_by_category')
       category_specific_keys = api_accessibility['namespaces_by_category'].keys
       if category_specific_keys.include?('uncategorized')
         self.includes(:categories).left_outer_joins(categorizations: :category).where("comfy_cms_categories.id IS ? OR comfy_cms_categories.label IN (?)", nil, category_specific_keys)
       else
         self.includes(:categories).for_category(category_specific_keys)
       end
+    else
+      self.none
     end
    }
 
@@ -131,8 +140,9 @@ class ApiNamespace < ApplicationRecord
       ActiveRecord::Base.transaction do
         raise 'You cannot duplicate the api_namespace without associations if it has api_form' if duplicate_associations == false && self.api_form.present?
 
+        random_hex = SecureRandom.hex(4)
         new_api_namespace = self.dup
-        new_api_namespace.name = self.name + '-copy-' + SecureRandom.hex(4)
+        new_api_namespace.name = self.name + '-copy-' + random_hex
         new_api_namespace.save!
     
         if duplicate_associations
@@ -143,11 +153,11 @@ class ApiNamespace < ApplicationRecord
             new_api_form.save!
           end
     
-          # Duplicate ApiClients
-          self.api_clients.each do |api_client|
-            new_api_client = api_client.dup
-            new_api_client.api_namespace = new_api_namespace
-            new_api_client.save!
+          # Duplicate ApiKeys
+          self.api_keys.each do |api_key|
+            label = api_key.label + '-copy-' + random_hex
+            new_api_key = ApiKey.create(label: label, authentication_strategy: api_key.authentication_strategy)
+            ApiNamespaceKey.create(api_key_id: new_api_key.id, api_namespace_id: new_api_namespace.id )
           end
     
           # Duplicate ExternalApiClients
@@ -199,7 +209,6 @@ class ApiNamespace < ApplicationRecord
         root: 'api_namespace',
         include: [
           :api_form,
-          :api_clients,
           :external_api_clients,
           :non_primitive_properties,
           {
@@ -219,6 +228,12 @@ class ApiNamespace < ApplicationRecord
                 }
               ]
             }
+          },
+          {
+            api_keys: {
+              except: [:salt, :encrypted_token], # Copying salt raises error related to encoding and these are encypted data. So, we should not copy such values.
+              methods: [:token]
+            }
           }
         ]
       )
@@ -232,7 +247,7 @@ class ApiNamespace < ApplicationRecord
       ActiveRecord::Base.transaction do
         neglected_attributes = {
           api_action: ['id', 'created_at', 'updated_at', 'encrypted_bearer_token', 'salt', 'api_namespace_id', 'api_resource_id'],
-          api_client: ['id', 'created_at', 'updated_at', 'api_namespace_id', 'slug'],
+          api_key: ['id', 'created_at', 'updated_at', 'api_namespace_id', 'token'],
           api_form: ['id', 'created_at', 'updated_at', 'api_namespace_id'],
           api_namespace: ['id', 'created_at', 'updated_at', 'slug'],
           api_resource: ['id', 'created_at', 'updated_at', 'api_namespace_id'],
@@ -249,7 +264,8 @@ class ApiNamespace < ApplicationRecord
       
         # creating api_namespace
         if ApiNamespace.find_by(slug: hash['slug']).present?
-          hash['name'] = hash['name'] + '-' + SecureRandom.hex(4)
+          random_hex = SecureRandom.hex(4)
+          hash['name'] = hash['name'] + '-' + random_hex
         end
 
         api_namespace_hash = hash.except(*neglected_attributes[:api_namespace])
@@ -264,12 +280,14 @@ class ApiNamespace < ApplicationRecord
           api_form_hash = hash['api_form'].except(*neglected_attributes[:api_form]).merge({'api_namespace_id': new_api_namespace.id})
           ApiForm.create!(api_form_hash)
         end
-        
-        # Creating api_clients
-        if hash['api_clients'].present? && hash['api_clients'].is_a?(Array)
-          hash['api_clients'].each do |api_client_hash|
-            api_client_hash = api_client_hash.except(*neglected_attributes[:api_client]).merge({'api_namespace_id': new_api_namespace.id})
-            ApiClient.create!(api_client_hash)
+
+        # Creating api_keys
+        if hash['api_keys'].present? && hash['api_keys'].is_a?(Array)
+          hash['api_keys'].each do |api_key_hash|
+            api_key_hash = api_key_hash.except(*neglected_attributes[:api_key])
+            api_key_hash['label'] = api_key_hash['label'] + '_' + random_hex if random_hex.present?
+            api_key = ApiKey.create!(api_key_hash)
+            ApiNamespaceKey.create(api_key_id: api_key.id, api_namespace_id: new_api_namespace.id )
           end
         end
         

--- a/app/models/api_namespace_key.rb
+++ b/app/models/api_namespace_key.rb
@@ -1,0 +1,4 @@
+class ApiNamespaceKey < ApplicationRecord
+  belongs_to :api_namespace
+  belongs_to :api_key
+end

--- a/app/models/concerns/safe_executable_validator.rb
+++ b/app/models/concerns/safe_executable_validator.rb
@@ -29,7 +29,7 @@ class SafeExecutableValidator < ActiveModel::EachValidator
 
     def validate_each(record,attribute,value)
         keywords = value.to_s.split(Regexp.union(SPLIT_DELIMITERS)).reject(&:blank?)
-        blacklisted_keywords_in_attribute = keywords & BLACKLISTED_KEYWORDS
+        blacklisted_keywords_in_attribute = keywords & (BLACKLISTED_KEYWORDS - (options[:skip_keywords] || []))
         unless blacklisted_keywords_in_attribute.empty?
             record.errors.add(attribute, "contains disallowed keyword: #{blacklisted_keywords_in_attribute.to_s}. Please refactor #{attribute} accordingly")
         end

--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -1,6 +1,8 @@
 class ExternalApiClient < ApplicationRecord
   include JsonbFieldsParsable
 
+  attr_accessor :require_webhook_verification, :default_model_definition, :default_webhook_driven_model_definition
+
   STATUSES = {
     stopped: 'stopped',
     running: 'running',
@@ -10,7 +12,8 @@ class ExternalApiClient < ApplicationRecord
 
   DRIVE_STRATEGIES = {
     on_demand: 'on_demand',
-    cron: 'cron'
+    cron: 'cron',
+    webhook: 'webhook'
   }
 
   DRIVE_INTERVALS = {
@@ -31,7 +34,58 @@ class ExternalApiClient < ApplicationRecord
     one_year: '1.year',
   }
 
+  SKIPPABLE_KEYWORDS = ['render'].freeze
+
+  DEFAULT_MODEL_DEFINITION = 
+"class ExternalApiConnection
+  def initialize(parameters)
+    @external_api_client = parameters[:external_api_client]
+  end
+
+  def start
+    @external_api_client.api_namespace.api_resources.create(
+      properties: {
+        request_body: {}
+      }
+    )
+  end
+end
+
+ExternalApiConnection"
+
+  DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION = 
+"class WebhookDrivenConnection
+  def initialize(parameters)
+    @external_api_client = parameters[:external_api_client]
+  
+    # rails request object accessable for webhook, https://api.rubyonrails.org/classes/ActionDispatch/Request.html
+    @payload = parameters[:request]&.request_parameters
+  end
+  
+  def start
+    object = @external_api_client.api_namespace.api_resources.create(
+      properties: {
+        request_body: @payload
+      }
+    )
+    # render the object as the response
+    render json: { result: object }
+  end
+end
+
+WebhookDrivenConnection"
+
   extend FriendlyId
+
+  before_save :remove_webhook_verification_method, unless: -> { (require_webhook_verification.nil? || ActiveModel::Type::Boolean.new.cast(require_webhook_verification)) }
+
+  after_initialize do
+    self.default_webhook_driven_model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION
+    self.default_model_definition = DEFAULT_MODEL_DEFINITION
+
+    self.model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION if drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:webhook] && self.new_record?
+  end
+
   friendly_id :label, use: :slugged
   belongs_to :api_namespace
 
@@ -41,7 +95,11 @@ class ExternalApiClient < ApplicationRecord
   validates :drive_every, presence: true, if: -> { drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:cron] }
 
   validates :drive_every, inclusion: { in: ExternalApiClient::DRIVE_INTERVALS.keys.map(&:to_s) }, allow_blank: true, allow_nil: true
-  validates :model_definition, safe_executable: true
+  validates :model_definition, safe_executable: { skip_keywords: SKIPPABLE_KEYWORDS }
+
+  has_one :webhook_verification_method
+
+  accepts_nested_attributes_for :webhook_verification_method
 
   def self.cron_jobs
     intervals = ExternalApiClient.pluck(:drive_every).compact
@@ -60,12 +118,12 @@ class ExternalApiClient < ApplicationRecord
     return runnable_external_api_clients
   end
 
-  def run
+  def run(args = {})
     # prevent triggering if its not enabled or the status is error (means that the custom model definition raised an error and it bubbled up)
     return false if !self.enabled || self.status == ExternalApiClient::STATUSES[:error]
     # prevent race conditions, if a client is running already-- dont run
     return false if self.status == ExternalApiClient::STATUSES[:running]
-    ExternalApiClientJob.perform_async(self.id)
+    ExternalApiClientJob.perform_async(self.id, args.deep_stringify_keys)
   end
 
   def evaluated_model_definition
@@ -97,5 +155,9 @@ class ExternalApiClient < ApplicationRecord
 
   def set_metadata(hash)
     self.update(metadata: hash)
+  end
+
+  def remove_webhook_verification_method
+    self.webhook_verification_method&.destroy
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,7 @@ class User < ApplicationRecord
     can_manage_users: true,
     can_manage_blog: true,
     can_manage_subdomain_settings: true,
-    api_accessibility: {all_namespaces: {full_access: 'true'}},
+    api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}, api_keys: {full_access: 'true'}},
     can_view_restricted_pages: true,
     moderator: true
   }

--- a/app/models/webhook_verification_method.rb
+++ b/app/models/webhook_verification_method.rb
@@ -1,0 +1,14 @@
+class WebhookVerificationMethod < ApplicationRecord
+  include Encryptable
+
+  attr_encrypted :webhook_secret
+
+  belongs_to :external_api_client
+
+  validates :custom_method_definition, safe_executable: true
+
+  enum webhook_type: {
+    stripe: 'stripe',
+    custom: 'custom'
+  }
+end

--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -1,21 +1,21 @@
 class EncryptionService
-    ENCRYPT_KEY_BASE = Rails.application.secrets.secret_key_base
-    KEY_LEN = ActiveSupport::MessageEncryptor.key_len.freeze
+  ENCRYPT_KEY_BASE = Rails.application.secrets.secret_key_base
+  KEY_LEN = ActiveSupport::MessageEncryptor.key_len.freeze
   
-    delegate :encrypt_and_sign, :decrypt_and_verify, to: :encryptor
+  delegate :encrypt_and_sign, :decrypt_and_verify, to: :encryptor
   
-    def initialize(salt, value)
-      @value = value
-  
-      key = ActiveSupport::KeyGenerator.new(ENCRYPT_KEY_BASE).generate_key(salt, KEY_LEN)
-      @crypt = ActiveSupport::MessageEncryptor.new(key)
-    end
-  
-    def encrypt
-      @crypt.encrypt_and_sign(@value)
-    end
-  
-    def decrypt
-      @crypt.decrypt_and_verify(@value)
-    end
+  def initialize(salt, value)
+    @value = value
+
+    key = ActiveSupport::KeyGenerator.new(ENCRYPT_KEY_BASE).generate_key(salt, KEY_LEN)
+    @crypt = ActiveSupport::MessageEncryptor.new(key)
+  end
+
+  def encrypt
+    @crypt.encrypt_and_sign(@value)
+  end
+
+  def decrypt
+    @crypt.decrypt_and_verify(@value)
+  end
 end

--- a/app/services/webhook/verification.rb
+++ b/app/services/webhook/verification.rb
@@ -1,0 +1,22 @@
+module Webhook
+  class Verification
+    attr_accessor :request, :verification_method
+
+    def initialize(request, verification_method)
+      @request = request
+      @verification_method = verification_method
+    end
+
+    def call
+      case @verification_method.webhook_type
+
+      when WebhookVerificationMethod.webhook_types[:stripe]
+        Webhook::VerificationMethod::Stripe.new(request, @verification_method.webhook_secret).call
+      when WebhookVerificationMethod.webhook_types[:custom]
+        Webhook::VerificationMethod::Custom.new(request, @verification_method).call
+      else
+        [false, 'Webhook verification method not defined']
+      end
+    end
+  end
+end

--- a/app/services/webhook/verification_method/custom.rb
+++ b/app/services/webhook/verification_method/custom.rb
@@ -1,0 +1,18 @@
+module Webhook
+  module VerificationMethod
+    class Custom
+      attr_accessor :request, :verification_method
+
+      def initialize(request, verification_method)
+        @request = request
+        @verification_method = verification_method
+      end
+
+      def call
+        # TODO: validate that this method always returns array with verification status and message
+        # eg: [true, 'verification success']
+        eval(@verification_method.custom_method_definition)
+      end
+    end
+  end
+end

--- a/app/services/webhook/verification_method/stripe.rb
+++ b/app/services/webhook/verification_method/stripe.rb
@@ -1,0 +1,30 @@
+module Webhook
+  module VerificationMethod
+    class Stripe
+      attr_accessor :signature, :payload, :endpoint_secret
+
+      def initialize(request, endpoint_secret)
+        @signature = request.env['HTTP_STRIPE_SIGNATURE']
+        @payload = request.body.read
+        @endpoint_secret = endpoint_secret
+      end
+
+      def call
+        begin
+          ::Stripe::Webhook.construct_event(
+            payload, signature, endpoint_secret
+          )
+        rescue JSON::ParserError => e
+          # Invalid payload
+          return [false, 'Invalid json payload']
+        rescue ::Stripe::SignatureVerificationError => e
+          # Invalid signature
+          return [false, 'Signature verification failed']
+        end
+        return [true, 'Signature Verified']
+      end
+    end
+  end
+end
+
+

--- a/app/sidekiq/external_api_client_job.rb
+++ b/app/sidekiq/external_api_client_job.rb
@@ -1,11 +1,11 @@
 class ExternalApiClientJob
   include Sidekiq::Job
 
-  def perform(id)
+  def perform(id, args = {})
     external_api_client = ExternalApiClient.find_by(id: id)
     external_api_client.update(last_run_at: Time.now)
     external_api_interface = external_api_client.evaluated_model_definition
-    external_api_client_runner = external_api_interface.new(external_api_client: external_api_client)
+    external_api_client_runner = external_api_interface.new(external_api_client: external_api_client, request: args['request'])
     retries = 0
     begin
       external_api_client.reload

--- a/app/views/comfy/admin/api_keys/_form.html.haml
+++ b/app/views/comfy/admin/api_keys/_form.html.haml
@@ -1,0 +1,31 @@
+- action = @api_key.persisted? ? :put : :post
+- path = @api_key.persisted? ? api_key_path(id: @api_key.id) : api_keys_path
+
+= form_for @api_key, url: path, method: action do |f|
+  - if @api_key.errors.any?
+    #error_explanation
+      %h2= "#{pluralize(@api_key.errors.count, "error")} prohibited this api_key from being saved:"
+      %ul
+        - @api_key.errors.full_messages.each do |message|
+          %li= message
+  .field.mb-3
+    = f.label :label
+    = f.text_field :label
+  .field.mb-3
+    = f.label :authentication_strategy
+    = f.select :authentication_strategy, options_for_select(ApiKey.authentication_strategies)
+  .field.mb-3
+    = f.label :api_namespace_ids
+    = f.collection_select :api_namespace_ids, ApiNamespace.all, :id, :name,  {include_blank: false, include_hidden: false}, {:multiple => true, :class=>"multi_select"}
+  .actions
+    = f.submit 'Save'
+
+:javascript
+  $(document).ready( function() {
+    $(".multi_select").select2({
+      multiple: true,
+      required: false,
+      tags: true,
+      placeholder: "Select api namespaces that can be accessed by this key"
+    })
+  })

--- a/app/views/comfy/admin/api_keys/edit.html.haml
+++ b/app/views/comfy/admin/api_keys/edit.html.haml
@@ -1,0 +1,7 @@
+%h1 Editing API Key
+
+= render 'form'
+
+= link_to 'Show', api_key_path(id: @api_key.id)
+\|
+= link_to 'Back', api_keys_path

--- a/app/views/comfy/admin/api_keys/index.html.haml
+++ b/app/views/comfy/admin/api_keys/index.html.haml
@@ -1,0 +1,29 @@
+%h1
+  API Keys
+
+%table.table.table-responsive.mt-5
+  %thead
+    %tr
+      %th Id
+      %th Label
+      %th Api Key
+      %th Api Namespaces
+      %th
+      %th
+      %th
+  %tbody
+    - @api_keys.each do |api_key|
+      %tr
+        %td= link_to api_key.id, api_key_path(id: api_key.id)
+        %td= api_key.label
+        %td= api_key.token
+        %td
+          - api_key.api_namespaces.each do |api_namespace|
+            .mb-2
+              = link_to api_namespace.name, api_namespace_path(id: api_namespace.id), class: 'link badge badge-primary'
+        %td= link_to 'Show', api_key_path(id: api_key.id)
+        %td= link_to 'Edit', edit_api_key_path(id: api_key.id)
+        %td= link_to 'Destroy', api_key_path(id: api_key.id), method: :delete, data: { confirm: 'Are you sure?' }
+
+
+= link_to 'New Api Key', new_api_key_path

--- a/app/views/comfy/admin/api_keys/new.html.haml
+++ b/app/views/comfy/admin/api_keys/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New API Key
+
+= render 'form'
+
+= link_to 'Back', api_keys_path

--- a/app/views/comfy/admin/api_keys/show.html.haml
+++ b/app/views/comfy/admin/api_keys/show.html.haml
@@ -1,0 +1,22 @@
+%p#notice= notice
+
+%p
+  %b Label:
+  = @api_key.label
+%p
+  %b Authentication strategy:
+  = @api_key.authentication_strategy
+%p
+  %b Bearer token:
+  = @api_key.token
+
+%p
+  %b Accessable Api Namespaces:
+  - @api_key.api_namespaces.each do |api_namespace|
+    = link_to api_namespace.name, api_namespace_path(id: api_namespace.id), class: 'link badge badge-primary mr-2'
+
+= link_to 'Edit', edit_api_key_path(id: @api_key.id)
+\|
+= link_to 'Back', api_keys_path
+.my-3
+  = link_to 'Destroy', api_key_path(id: @api_key.id), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'

--- a/app/views/comfy/admin/api_namespaces/_rest_interface.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_rest_interface.html.haml
@@ -1,0 +1,78 @@
+.row 
+  .col.col-md-6
+    %h4
+      REST Interface
+    %strong
+      Request description endpoint:
+    %p
+      GET
+      %pre= "#{api_base_url(Subdomain.current, api_namespace)}/describe"
+
+    %strong
+      Request index endpoint:
+    %p
+      GET
+      %pre= api_base_url(Subdomain.current, api_namespace)
+
+    %strong
+      Request query endpoint:
+    %p
+      POST
+      %pre= "#{api_base_url(Subdomain.current, api_namespace)}/query"
+
+    %p
+      %small.text-info Please make sure that your parameters are provided under a data: {} top-level key
+
+    - if !api_namespace.requires_authentication
+      %p
+        %small.text-danger write access is disabled by default for public access namespaces
+
+    %p
+      %small.text-info
+        JSON API standard:
+        %a{href: 'https://jsonapi.org/format/#crud', target: '_blank'} 
+          https://jsonapi.org/format/#crud
+    %div{style: "#{!api_namespace.requires_authentication && 'cursor: not-allowed; color: grey;'}"}
+      %strong
+        Request create endpoint:
+      %p
+        POST
+        %pre= api_base_url(Subdomain.current, api_namespace)
+
+      %strong
+        Request update endpoint:
+      %p
+        PATCH
+        %pre= "#{api_base_url(Subdomain.current, api_namespace)}/edit/:api_resource_id"
+
+      %strong
+        Request destroy endpoint:
+      %p
+        DELETE
+        %pre= "#{api_base_url(Subdomain.current, api_namespace)}/destroy/:api_resource_id"
+
+  .col.col-md-6{style: "border-left: 1px solid rgba(0, 0, 0, 0.125);"}
+    %h4
+      Authentication
+
+    - if api_namespace.api_keys.present?
+      %p  
+        Use bearer token from one of the associated API keys:
+
+        .d-flex.mb-3
+          - api_namespace.api_keys.each do |key|
+            .mr-2
+              = link_to key.label, api_key_path(id: key.id), class: 'link badge badge-primary'
+
+        OR
+  
+    - else
+      %p This API namespace doesn't have any associated API keys.  
+
+
+    %p 
+      = link_to "Create API key", new_api_key_path
+      and associate the namespace , or associate to 
+      = link_to "already existing ones", api_keys_path
+      and use the bearer token for authentication
+

--- a/app/views/comfy/admin/api_namespaces/index.html.haml
+++ b/app/views/comfy/admin/api_namespaces/index.html.haml
@@ -3,6 +3,7 @@
 
 .page-header
   = link_to 'New Namespace', new_api_namespace_path, class: 'btn btn-secondary float-right'
+  = link_to 'Api Keys', api_keys_path, class: 'btn btn-secondary float-right mr-3'
   %h2 API Namespaces
 = render partial: 'search_filters', locals: { objects: @api_namespaces_q, path: api_namespaces_path }
 = render partial: 'pagination', locals: { objects: @api_namespaces }

--- a/app/views/comfy/admin/api_namespaces/show.html.haml
+++ b/app/views/comfy/admin/api_namespaces/show.html.haml
@@ -22,7 +22,7 @@
     %a#interface-tab.nav-link.active{"aria-controls" => "interface", "aria-selected" => "true", "data-toggle" => "tab", :href => "#interface", :role => "tab"} 
       Interface
   %li.nav-item
-    %a#connections-tab.nav-link{"aria-controls" => "connections", "aria-selected" => "false", "data-toggle" => "tab", :href => "#connections", :role => "tab"} 
+    %a#connections-tab.nav-link{:href => api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)} 
       Connections
   - if @api_namespace.api_form.present?
     %li.nav-item
@@ -56,29 +56,7 @@
 
       .card
         .card-body
-          %h4
-            REST Interface
-          %strong
-            Request description endpoint:
-          %p
-            GET
-          %pre
-            = "#{api_base_url(Subdomain.current, @api_namespace)}/describe"
-
-          %strong
-            Request index endpoint:
-          %p
-            GET
-          %pre
-
-            = api_base_url(Subdomain.current, @api_namespace)
-
-          %strong
-            Request query endpoint:
-          %p
-            POST
-          %pre
-            = "#{api_base_url(Subdomain.current, @api_namespace)}/query"
+          = render partial: 'rest_interface', locals: { api_namespace: @api_namespace } 
 
         .card-body
           %h4
@@ -108,20 +86,25 @@
             Payload (global)
           %pre
             = "query: { apiNamespaces { id } }"
-  #connections.tab-pane.fade{"aria-labelledby" => "connections-tab", :role => "tabpanel"} 
-    .card.p-3
-      .card-body
-        %h4
-          = link_to "External API connections", api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
-        .my-3
-          = link_to "Create new external API Client", new_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id)
-      %hr
-      - if @api_namespace.requires_authentication
         .card-body
           %h4
-            = link_to "API Clients", api_namespace_api_clients_path(api_namespace_id: @api_namespace.id)
-          .my-3
-            = link_to "Create new key for client", new_api_namespace_api_client_path(api_namespace_id: @api_namespace.id)
+            Webhook
+          .table-responsive
+            %table
+              %thead
+                %tr
+                  %th.px-3 API Connection
+                  %th.px-3 HTTP method
+                  %th.px-3 Webhook Interface
+                  %th.px-3 Verification Method
+              %tbody
+                - @api_namespace.external_api_clients.where(drive_strategy: ExternalApiClient::DRIVE_STRATEGIES[:webhook]).each do |external_api_client|
+                  %tr
+                    %td.px-3= link_to external_api_client.label, api_namespace_external_api_client_path(api_namespace_id: external_api_client.api_namespace.id, id: external_api_client.id)
+                    %td.px-3 POST
+                    %td.px-3= api_external_api_client_webhook_url(version: external_api_client.api_namespace.version, api_namespace: external_api_client.api_namespace.slug, external_api_client: external_api_client.slug)
+                    %td.px-3= external_api_client.webhook_verification_method&.webhook_type
+
   - if @api_namespace.api_form.present?
     #form.tab-pane.fade{"aria-labelledby" => "form-tab", :role => "tabpanel"}
       %p

--- a/app/views/comfy/admin/external_api_clients/_form.html.haml
+++ b/app/views/comfy/admin/external_api_clients/_form.html.haml
@@ -18,22 +18,71 @@
   .field
     = f.label :drive_strategy
     = f.select :drive_strategy, options_for_select(ExternalApiClient::DRIVE_STRATEGIES.keys, f.object.drive_strategy)
-  .field
-    = f.label :drive_every
-    = f.select :drive_every, options_for_select(ExternalApiClient::DRIVE_INTERVALS.keys, f.object.drive_every), include_blank: true
 
-  .field
-    = f.label :max_requests_per_minute
-    = f.number_field :max_requests_per_minute
-  .field
-    = f.label :max_workers
-    = f.number_field :max_workers
-  .field
-    = f.label :max_retries
-    = f.number_field :max_retries
+  -# conditionally render boilerplate model definition based on drive strategy
+  - unless @external_api_client.persisted?
+    = f.hidden_field  :default_webhook_driven_model_definition
+    = f.hidden_field  :default_model_definition
+
+  #webhook_verification_container
+    .field
+      = f.label :require_webhook_verification
+      = f.check_box :require_webhook_verification, checked: @external_api_client.webhook_verification_method.persisted?
+
+    .card.p-3#webhook_verification_method_container
+      = f.fields_for :webhook_verification_method do |webhook_form|
+        .field
+          = webhook_form.label "Webhook verification method"
+          = webhook_form.select :webhook_type, options_for_select(WebhookVerificationMethod.webhook_types, webhook_form.object&.webhook_type)
+      
+        .field
+          = webhook_form.label :webhook_secret
+          %small.text-muted
+            (Secret shared between webhook server and reciever)
+          %div 
+            = webhook_form.text_area :webhook_secret, class: "w-100"
+
+        .field#webhook_custom_method_definition
+          = webhook_form.label :custom_method_definition
+          %small.text-muted (must return an array containing verification status and message)
+          %br
+          %small.text-muted Accessable methods
+          %br
+          %small
+            %li.text-muted request: Instance of ActionDispatch::Request
+          %small
+            %li.text-muted verification_method: Instance of WebhookVerificationMethod
+          %small
+            %li.text-muted Example: request.headers['Authorization'] == verification_method.webhook_secret ? [true, 'Success'] : [false, 'Invalid Token']
+          %div= webhook_form.text_area :custom_method_definition, data: {'cms-cm-mode' => 'javascript'}, class: "w-100"
+
+  .hide-if-webhook
+    .field
+      = f.label :drive_every
+      = f.select :drive_every, options_for_select(ExternalApiClient::DRIVE_INTERVALS.keys, f.object.drive_every), include_blank: true
+
+    .field
+      = f.label :max_requests_per_minute
+      = f.number_field :max_requests_per_minute
+    .field
+      = f.label :max_workers
+      = f.number_field :max_workers
+    .field
+      = f.label :max_retries
+      = f.number_field :max_retries
 
   .field.mb-3
     = f.label :model_definition
+    %small
+      %li.text-muted Define your interface and connection rules in a plain Ruby class (PORO)
+    %small 
+      %li.text-muted
+        Wiki: 
+        %a{href: "https://github.com/restarone/violet_rails/wiki/API:-Entities,-Form-Rendering,-Interfaces-and-Actions#automation-connecting-and-extracting-data-from-external-systemsapis", target: '_blank'} External API Connection
+    %small
+      %li.text-muted 
+        Example: 
+        %a{href: "https://github.com/restarone/violet_rails/blob/141e942461e016991b18697211d2f44e4569cb4e/test/fixtures/external_api_clients.yml#L35", target: '_blank'} External API Connection Model definition
     = f.text_area :model_definition, data: {'cms-cm-mode' => 'javascript'}
 
   #jsoneditor
@@ -44,4 +93,53 @@
 
 
 = render 'comfy/admin/api_namespaces/init_editor', {read_only: false}
+
+:javascript
+  $(document).ready( function() {
+    $('#external_api_client_drive_strategy').change(function(event) {
+      if ($(this).val() === 'webhook') {
+        $('#webhook_verification_container').show();
+        $('.hide-if-webhook').hide();
+      } else {
+        $('#webhook_verification_container').hide();
+        $('#external_api_client_require_webhook_verification').prop("checked", false);
+        $('#webhook_verification_method_container').hide();
+        $('.hide-if-webhook').show();
+      }
+
+      var codeMirror = $('#external_api_client_model_definition').next('.CodeMirror')[0].CodeMirror;
+      var isPristine = (codeMirror.getValue() == $('#external_api_client_default_model_definition').val()) || (codeMirror.getValue() == $('#external_api_client_default_webhook_driven_model_definition').val())
+
+      if ($('#new_external_api_client').length && isPristine) {
+        if (($(this).val() === 'webhook')) {
+          codeMirror.setValue($('#external_api_client_default_webhook_driven_model_definition').val())
+        } else {
+          codeMirror.setValue($('#external_api_client_default_model_definition').val())
+        }
+      }
+    }).change();
+
+    $('#external_api_client_webhook_verification_method_attributes_webhook_type').change(function(event) {
+      if ($(this).val() === 'custom') {
+        $('#webhook_custom_method_definition').show();
+      } else {
+        $('#webhook_custom_method_definition').hide();
+      }
+
+      if ($(this).val() === 'stripe') {
+        $("label[for='external_api_client_webhook_verification_method_attributes_webhook_secret']").html('Webhook Signing Secret')
+      } else {
+        $("label[for='external_api_client_webhook_verification_method_attributes_webhook_secret']").html('Webhook Secret')
+      }
+    }).change();
+
+    $('#external_api_client_require_webhook_verification').change(function(event) {
+      if ($(this).is(':checked')) {
+        $('#webhook_verification_method_container').show();
+      } else {
+        $('#webhook_verification_method_container').hide();
+      }
+    }).change();
+  })
+  
 

--- a/app/views/comfy/admin/external_api_clients/show.html.haml
+++ b/app/views/comfy/admin/external_api_clients/show.html.haml
@@ -1,81 +1,106 @@
-= link_to 'Edit', edit_api_namespace_external_api_client_path(@api_namespace)
-\|
-= link_to 'Back', api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
+.container-fluid.mt-5
+  .d-flex.justify-content-between.py-2.page-header
+    %h2
+      =  @api_namespace.name.pluralize
+      > External API Connections > 
+      = @external_api_client.label
 
-%p#notice= notice
+  = link_to 'Edit', edit_api_namespace_external_api_client_path(@api_namespace)
+  \|
+  = link_to 'Back', api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
 
-%p
-  %b Name:
-  = @external_api_client.label
-%p
-  %b slug:
-  = @external_api_client.slug
-%p
-  %b status:
-  = @external_api_client.status
-  - if @external_api_client.status == ExternalApiClient::STATUSES[:running]
-    = link_to "Stop", stop_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Stopping the client will stop data ingestion"}
-  - else
-    = link_to "Start", start_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Starting this client will write to #{@external_api_client.api_namespace.slug}"}
-%p
-  %b enabled:
-  = @external_api_client.enabled
-%p
-  %b error message:
-  = @external_api_client.error_message
-  - if @external_api_client.error_message
-    = link_to "Clear Errors", clear_errors_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Please note down the error message and error state before clearing"}
-%p
-  %b drive strategy:
-  = @external_api_client.drive_strategy
-- if !@external_api_client.drive_every.blank?
+  %p#notice= notice
+
   %p
-    %b drive every:
-    = @external_api_client.drive_every
-%p
-  %b Max requests/minute:
-  = @external_api_client.max_requests_per_minute
-%p
-  %b Last run at:
-  = @external_api_client.last_run_at
-%p
-  %b Current requests/minute:
-  = @external_api_client.current_requests_per_minute
-%p
-  %b Max workers:
-  = @external_api_client.max_workers
-%p
-  %b Current workers:
-  = @external_api_client.current_workers
-%p
-  %b Current retries:
-  = @external_api_client.retries
-%p
-  %b Retry in seconds:
-  = @external_api_client.retry_in_seconds
-%p
-  %b Max retries:
-  = @external_api_client.max_retries
+    %b Name:
+    = @external_api_client.label
+  %p
+    %b slug:
+    = @external_api_client.slug
+  
+  - unless @external_api_client.drive_strategy == 'webhook'
+    %p
+      %b status:
+      = @external_api_client.status
+      - if @external_api_client.status == ExternalApiClient::STATUSES[:running]
+        = link_to "Stop", stop_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Stopping the client will stop data ingestion"}
+      - else
+        = link_to "Start", start_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Starting this client will write to #{@external_api_client.api_namespace.slug}"}
+  %p
+    %b enabled:
+    = @external_api_client.enabled
+  %p
+    %b error message:
+    = @external_api_client.error_message
+    - if @external_api_client.error_message
+      = link_to "Clear Errors", clear_errors_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Please note down the error message and error state before clearing"}
+  %p
+    %b drive strategy:
+    = @external_api_client.drive_strategy
 
-%p
-  %b model definition:
-  %code
-    = @external_api_client.model_definition
+  - if @external_api_client.drive_strategy == 'webhook'
+    %p
+      %b Required webhook verification:
+      = @external_api_client.webhook_verification_method.present?
+
+    - if @external_api_client.webhook_verification_method.present?
+      %p
+        %b  webhook Verification Type:
+        = @external_api_client.webhook_verification_method.webhook_type
+      
+    %p
+      %b Webhook url:
+      POST
+      = api_external_api_client_webhook_url(version: @external_api_client.api_namespace.version, api_namespace: @external_api_client.api_namespace.slug, external_api_client: @external_api_client.slug)
+
+  - else
+    - if !@external_api_client.drive_every.blank?
+      %p
+        %b drive every:
+        = @external_api_client.drive_every
+    %p
+      %b Max requests/minute:
+      = @external_api_client.max_requests_per_minute
+    %p
+      %b Last run at:
+      = @external_api_client.last_run_at
+    %p
+      %b Current requests/minute:
+      = @external_api_client.current_requests_per_minute
+    %p
+      %b Max workers:
+      = @external_api_client.max_workers
+    %p
+      %b Current workers:
+      = @external_api_client.current_workers
+    %p
+      %b Current retries:
+      = @external_api_client.retries
+    %p
+      %b Retry in seconds:
+      = @external_api_client.retry_in_seconds
+    %p
+      %b Max retries:
+      = @external_api_client.max_retries
+
+  %p
+    %b model definition:
+    = text_area_tag :model_definition, @external_api_client.model_definition, data: {'cms-cm-mode' => 'javascript', 'cms-cm-readOnly' => true}
 
 
-%p
-  %b State Metadata:
-  = @external_api_client.state_metadata
-  - if @external_api_client.error_metadata
-    = link_to "Clear State", clear_state_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Supervisor state is generated automatically and cannot be recovered"}
-%p
-  %b Error Metadata:
-  = @external_api_client.error_metadata
-  - if @external_api_client.error_metadata
-    = link_to "Clear Errors", clear_errors_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Please note down the error message and error state before clearing"}
-%p
-  %b Metadata:
-#jsoneditor
-= hidden_field_tag :api_namespace_properties, @external_api_client.metadata&.to_json
+  %p
+    %b State Metadata:
+    = @external_api_client.state_metadata
+    - if @external_api_client.error_metadata
+      = link_to "Clear State", clear_state_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Supervisor state is generated automatically and cannot be recovered"}
+  %p
+    %b Error Metadata:
+    = @external_api_client.error_metadata
+    - if @external_api_client.error_metadata
+      = link_to "Clear Errors", clear_errors_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id, id: @external_api_client.id), data: {confirm:"Are you sure? Please note down the error message and error state before clearing"}
+  %p
+    %b Metadata:
+  #jsoneditor
+  = hidden_field_tag :api_namespace_properties, @external_api_client.metadata&.to_json
 
-= render 'comfy/admin/api_namespaces/init_editor', {read_only: true}
+  = render 'comfy/admin/api_namespaces/init_editor', {read_only: true}

--- a/app/views/comfy/admin/users/_api_accessibility.haml
+++ b/app/views/comfy/admin/users/_api_accessibility.haml
@@ -3,194 +3,215 @@
     %strong
       Can manage API
   .card-body
-    .form-group
-      = check_box_tag '', nil, has_access_to_main_category?(@user.api_accessibility, 'all_namespaces'), data: { group: 'api-sub-settings', type: 'toggle-checkboxes' }
-      %label
-        All Namespaces
-      
-      %ul.mt-2{ style: "display: #{has_access_to_main_category?(@user.api_accessibility, 'all_namespaces') ? 'block' : 'none'}"}
-        %li
-          = check_box_tag 'user[api_accessibility][all_namespaces][full_access]', true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces'), class: 'full-access-option', disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces')
-          = label_tag nil, 'Full access'
-        %ul.mb-2.sub-options
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: { name: 'user[api_accessibility][all_namespaces][full_read_access]'}
-            = label_tag nil, 'Full read access'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: { name: 'user[api_accessibility][all_namespaces][full_access_api_namespace_only]'}
-            = label_tag nil, 'Full access for API Namespace only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: { name: 'user[api_accessibility][all_namespaces][delete_access_api_namespace_only]'}
-            = label_tag nil, 'Delete access for API Namespace only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][allow_exports]'}
-            = label_tag nil, 'Allow exports'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][allow_duplication]'}
-            = label_tag nil, 'Allow duplication'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][allow_social_share_metadata]'}
-            = label_tag nil, 'Allow social share metadata'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][read_api_resources_only]'}
-            = label_tag nil, 'Read API Resources only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][delete_access_for_api_resources_only]'}
-            = label_tag nil, 'Delete access for API Resources only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][full_access_for_api_resources_only]'}
-            = label_tag nil, 'Full access for API Resources only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][read_api_actions_only]'}
-            = label_tag nil, 'Read API Actions only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][full_access_for_api_actions_only]'}
-            = label_tag nil, 'Full access for API Actions only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][read_external_api_connections_only]'}
-            = label_tag nil, 'Read External API Connections only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][full_access_for_external_api_connections_only]'}
-            = label_tag nil, 'Full access for External API Connections only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][read_api_clients_only]'}
-            = label_tag nil, 'Read API Clients only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][full_access_for_api_clients_only]'}
-            = label_tag nil, 'Full access for API Clients only'
-          %li
-            = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][all_namespaces][full_access_for_api_form_only]'}
-            = label_tag nil, 'Full access for API Form only'
-
-    .form-group
-      = check_box_tag '', nil, has_access_to_main_category?(@user.api_accessibility, 'namespaces_by_category'), data: { group: 'api-sub-settings', type: 'toggle-checkboxes' }
-      %label
-        API Namespaces by category
-
-      - categories = Comfy::Cms::Category.of_type('ApiNamespace')
-      
-      %ul.mt-2{ style: "display: #{has_access_to_main_category?(@user.api_accessibility, 'namespaces_by_category') ? 'block' : 'none'}"}
-        - categories.each do |category|
-          %li
-            .form-group
-              = check_box_tag '', nil, has_access_to_specific_category?(@user.api_accessibility, category.label), data: { group: 'api-sub-settings' }
-              %label
-                = category.label
-              %ul.mt-2{ style:  "display: #{has_access_to_specific_category?(@user.api_accessibility, category.label) ? 'block' : 'none'}"}
-                %li
-                  = check_box_tag "user[api_accessibility][namespaces_by_category][#{category.label}][full_access]", true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label), class: 'full-access-option', disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label)
-                  = label_tag nil, 'Full access'
-                %ul.mb-2.sub-options
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][full_read_access]"}
-                    = label_tag nil, 'Full read access'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][full_access_api_namespace_only]"}
-                    = label_tag nil, 'Full access for API Namespace only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][delete_access_api_namespace_only]"}
-                    = label_tag nil, 'Delete access for API Namespace only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][allow_exports]"}
-                    = label_tag nil, 'Allow exports'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][allow_duplication]"}
-                    = label_tag nil, 'Allow duplication'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][allow_social_share_metadata]"}
-                    = label_tag nil, 'Allow social share metadata'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][read_api_resources_only]"}
-                    = label_tag nil, 'Read API Resources only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][full_access_for_api_resources_only]"}
-                    = label_tag nil, 'Full access for API Resources only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][delete_access_for_api_resources_only]"}
-                    = label_tag nil, 'Delete access for API Resources only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][read_api_actions_only]"}
-                    = label_tag nil, 'Read API Actions only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][full_access_for_api_actions_only]"}
-                    = label_tag nil, 'Full access for API Actions only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][read_external_api_connections_only]"}
-                    = label_tag nil, 'Read External API Connections only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][full_access_for_external_api_connections_only]"}
-                    = label_tag nil, 'Full access for External API Connections only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][read_api_clients_only]"}
-                    = label_tag nil, 'Read API Clients only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][full_access_for_api_clients_only]"}
-                    = label_tag nil, 'Full access for API Clients only'
-                  %li
-                    = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][namespaces_by_category][#{category.label}][full_access_for_api_form_only]"}
-                    = label_tag nil, 'Full access for API Form only'
-
-        %li
-          .form-group
-            = check_box_tag '', nil, has_access_to_specific_category?(@user.api_accessibility, 'uncategorized'), data: { group: 'api-sub-settings' }
-            %label.text-primary
-              uncategorized
-            %ul.mt-2{ style: "display: #{has_access_to_specific_category?(@user.api_accessibility, 'uncategorized') ? 'block' : 'none'}"}
+    .card.api-namespaces
+      .card-header
+        API Namespace
+      .card-body
+        .form-group
+          = check_box_tag '', nil, has_access_to_main_category?(@user.api_accessibility, 'all_namespaces'), data: { group: 'api-sub-settings', type: 'toggle-checkboxes' }
+          %label
+            All Namespaces
+          
+          %ul.mt-2{ style: "display: #{has_access_to_main_category?(@user.api_accessibility, 'all_namespaces') ? 'block' : 'none'}"}
+            %li
+              = check_box_tag 'user[api_accessibility][api_namespaces][all_namespaces][full_access]', true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces'), class: 'full-access-option', disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces')
+              = label_tag nil, 'Full access'
+            %ul.mb-2.sub-options
               %li
-                = check_box_tag "user[api_accessibility][namespaces_by_category][uncategorized][full_access]", true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized'), class: 'full-access-option', disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized')
-                = label_tag nil, 'Full access'
-              %ul.mb-2.sub-options
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][full_read_access]"}
-                  = label_tag nil, 'Full read access'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][full_access_api_namespace_only]"}
-                  = label_tag nil, 'Full access for API Namespace only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][delete_access_api_namespace_only]"}
-                  = label_tag nil, 'Delete access for API Namespace only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][allow_exports]"}
-                  = label_tag nil, 'Allow exports'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: 'user[api_accessibility][namespaces_by_category][uncategorized][allow_duplication]'}
-                  = label_tag nil, 'Allow duplication'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: 'user[api_accessibility][namespaces_by_category][uncategorized][allow_social_share_metadata]'}
-                  = label_tag nil, 'Allow social share metadata'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][read_api_resources_only]"}
-                  = label_tag nil, 'Read API Resources only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][full_access_for_api_resources_only]"}
-                  = label_tag nil, 'Full access for API Resources only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][delete_access_for_api_resources_only]"}
-                  = label_tag nil, 'Delete access for API Resources only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][read_api_actions_only]"}
-                  = label_tag nil, 'Read API Actions only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][full_access_for_api_actions_only]"}
-                  = label_tag nil, 'Full access for API Actions only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][read_external_api_connections_only]"}
-                  = label_tag nil, 'Read External API Connections only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][full_access_for_external_api_connections_only]"}
-                  = label_tag nil, 'Full access for External API Connections only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][read_api_clients_only]"}
-                  = label_tag nil, 'Read API Clients only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][full_access_for_api_clients_only]"}
-                  = label_tag nil, 'Full access for API Clients only'
-                %li
-                  = check_box_tag nil, true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][namespaces_by_category][uncategorized][full_access_for_api_form_only]"}
-                  = label_tag nil, 'Full access for API Form only'
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][full_read_access]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: { name: 'user[api_accessibility][api_namespaces][all_namespaces][full_read_access]'}
+                = label_tag nil, 'Full read access'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][full_access_api_namespace_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: { name: 'user[api_accessibility][api_namespaces][all_namespaces][full_access_api_namespace_only]'}
+                = label_tag nil, 'Full access for API Namespace only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][delete_access_api_namespace_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: { name: 'user[api_accessibility][api_namespaces][all_namespaces][delete_access_api_namespace_only]'}
+                = label_tag nil, 'Delete access for API Namespace only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][allow_exports]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][allow_exports]'}
+                = label_tag nil, 'Allow exports'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][allow_duplication]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][allow_duplication]'}
+                = label_tag nil, 'Allow duplication'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][allow_social_share_metadata]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][allow_social_share_metadata]'}
+                = label_tag nil, 'Allow social share metadata'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][read_api_resources_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][read_api_resources_only]'}
+                = label_tag nil, 'Read API Resources only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][delete_access_for_api_resources_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][delete_access_for_api_resources_only]'}
+                = label_tag nil, 'Delete access for API Resources only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_api_resources_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_api_resources_only]'}
+                = label_tag nil, 'Full access for API Resources only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][read_api_actions_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][read_api_actions_only]'}
+                = label_tag nil, 'Read API Actions only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_api_actions_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_api_actions_only]'}
+                = label_tag nil, 'Full access for API Actions only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][read_external_api_connections_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][read_external_api_connections_only]'}
+                = label_tag nil, 'Read External API Connections only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_external_api_connections_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_external_api_connections_only]'}
+                = label_tag nil, 'Full access for External API Connections only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][read_api_clients_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][read_api_clients_only]'}
+                = label_tag nil, 'Read API Clients only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_api_clients_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_api_clients_only]'}
+                = label_tag nil, 'Full access for API Clients only'
+              %li
+                = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'all_namespaces') ? 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_api_form_only]' : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'all_namespaces') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'all_namespaces'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'all_namespaces'), data: {name: 'user[api_accessibility][api_namespaces][all_namespaces][full_access_for_api_form_only]'}
+                = label_tag nil, 'Full access for API Form only'
+
+        .form-group
+          = check_box_tag '', nil, has_access_to_main_category?(@user.api_accessibility, 'namespaces_by_category'), data: { group: 'api-sub-settings', type: 'toggle-checkboxes' }
+          %label
+            API Namespaces by category
+
+          - categories = Comfy::Cms::Category.of_type('ApiNamespace')
+          
+          %ul.mt-2{ style: "display: #{has_access_to_main_category?(@user.api_accessibility, 'namespaces_by_category') ? 'block' : 'none'}"}
+            - categories.each do |category|
+              %li
+                .form-group
+                  = check_box_tag '', nil, has_access_to_specific_category?(@user.api_accessibility, category.label), data: { group: 'api-sub-settings' }
+                  %label
+                    = category.label
+                  %ul.mt-2{ style:  "display: #{has_access_to_specific_category?(@user.api_accessibility, category.label) ? 'block' : 'none'}"}
+                    %li
+                      = check_box_tag "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access]", true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label), class: 'full-access-option', disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label)
+                      = label_tag nil, 'Full access'
+                    %ul.mb-2.sub-options
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_read_access]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_read_access]"}
+                        = label_tag nil, 'Full read access'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_api_namespace_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_api_namespace_only]"}
+                        = label_tag nil, 'Full access for API Namespace only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][delete_access_api_namespace_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][delete_access_api_namespace_only]"}
+                        = label_tag nil, 'Delete access for API Namespace only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][allow_exports]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][allow_exports]"}
+                        = label_tag nil, 'Allow exports'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][allow_duplication]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][allow_duplication]"}
+                        = label_tag nil, 'Allow duplication'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][allow_social_share_metadata]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][allow_social_share_metadata]"}
+                        = label_tag nil, 'Allow social share metadata'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][read_api_resources_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][read_api_resources_only]"}
+                        = label_tag nil, 'Read API Resources only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_api_resources_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_api_resources_only]"}
+                        = label_tag nil, 'Full access for API Resources only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][delete_access_for_api_resources_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][delete_access_for_api_resources_only]"}
+                        = label_tag nil, 'Delete access for API Resources only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][read_api_actions_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][read_api_actions_only]"}
+                        = label_tag nil, 'Read API Actions only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_api_actions_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_api_actions_only]"}
+                        = label_tag nil, 'Full access for API Actions only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][read_external_api_connections_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][read_external_api_connections_only]"}
+                        = label_tag nil, 'Read External API Connections only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_external_api_connections_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_external_api_connections_only]"}
+                        = label_tag nil, 'Full access for External API Connections only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][read_api_clients_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][read_api_clients_only]"}
+                        = label_tag nil, 'Read API Clients only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_api_clients_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_api_clients_only]"}
+                        = label_tag nil, 'Full access for API Clients only'
+                      %li
+                        = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'namespaces_by_category', category.label) ? "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_read_access]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', category.label) || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'namespaces_by_category', category.label), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', category.label), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][#{category.label}][full_access_for_api_form_only]"}
+                        = label_tag nil, 'Full access for API Form only'
+
+            %li
+              .form-group
+                = check_box_tag '', nil, has_access_to_specific_category?(@user.api_accessibility, 'uncategorized'), data: { group: 'api-sub-settings' }
+                %label.text-primary
+                  uncategorized
+                %ul.mt-2{ style: "display: #{has_access_to_specific_category?(@user.api_accessibility, 'uncategorized') ? 'block' : 'none'}"}
+                  %li
+                    = check_box_tag "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access]", true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized'), class: 'full-access-option', disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized')
+                    = label_tag nil, 'Full access'
+                  %ul.mb-2.sub-options
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_read_access]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_read_access', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_read_access]"}
+                      = label_tag nil, 'Full read access'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_api_namespace_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_api_namespace_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_api_namespace_only]"}
+                      = label_tag nil, 'Full access for API Namespace only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][delete_access_api_namespace_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_api_namespace_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][delete_access_api_namespace_only]"}
+                      = label_tag nil, 'Delete access for API Namespace only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][allow_exports]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_exports', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][allow_exports]"}
+                      = label_tag nil, 'Allow exports'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][allow_duplication]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_duplication', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: 'user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][allow_duplication]'}
+                      = label_tag nil, 'Allow duplication'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][allow_social_share_metadata]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'allow_social_share_metadata', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: 'user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][allow_social_share_metadata]'}
+                      = label_tag nil, 'Allow social share metadata'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][read_api_resources_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_resources_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][read_api_resources_only]"}
+                      = label_tag nil, 'Read API Resources only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_api_resources_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_resources_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_api_resources_only]"}
+                      = label_tag nil, 'Full access for API Resources only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][delete_access_for_api_resources_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'delete_access_for_api_resources_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][delete_access_for_api_resources_only]"}
+                      = label_tag nil, 'Delete access for API Resources only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][read_api_actions_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_actions_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][read_api_actions_only]"}
+                      = label_tag nil, 'Read API Actions only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_api_actions_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_actions_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_api_actions_only]"}
+                      = label_tag nil, 'Full access for API Actions only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][read_external_api_connections_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_external_api_connections_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][read_external_api_connections_only]"}
+                      = label_tag nil, 'Read External API Connections only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_external_api_connections_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_external_api_connections_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_external_api_connections_only]"}
+                      = label_tag nil, 'Full access for External API Connections only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][read_api_clients_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'read_api_clients_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][read_api_clients_only]"}
+                      = label_tag nil, 'Read API Clients only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_api_clients_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_clients_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_api_clients_only]"}
+                      = label_tag nil, 'Full access for API Clients only'
+                    %li
+                      = check_box_tag (has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'namespaces_by_category', 'uncategorized') ? "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_api_form_only]" : nil), true, has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'uncategorized') || has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access_for_api_form_only', 'namespaces_by_category', 'uncategorized'), disabled: !has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'uncategorized'), data: {name: "user[api_accessibility][api_namespaces][namespaces_by_category][uncategorized][full_access_for_api_form_only]"}
+                      = label_tag nil, 'Full access for API Form only'
+
+    .card.mt-3.api-keys
+      .card-header
+        .d-inline
+          = check_box_tag 'user[api_accessibility][api_keys][full_access]', true, has_access_to_api_keys?(@user.api_accessibility, 'full_access'), class: 'api-keys-full-access-option'
+          %label
+            API Keys (Full Access)
+      .card-body
+        .form-group
+          %li.api-keys-sub-option
+            = check_box_tag (has_access_to_api_keys?(@user.api_accessibility, 'read_access') ? 'user[api_accessibility][api_keys][read_access]' : nil), true, (has_access_to_api_keys?(@user.api_accessibility, 'full_access') || has_access_to_api_keys?(@user.api_accessibility, 'read_access')) , data: { name: 'user[api_accessibility][api_keys][read_access]' }
+            = label_tag nil, 'Read access only'
+          %li.api-keys-sub-option
+            = check_box_tag (has_access_to_api_keys?(@user.api_accessibility, 'delete_access') ? 'user[api_accessibility][api_keys][delete_access]' : nil), true, (has_access_to_api_keys?(@user.api_accessibility, 'full_access') || has_access_to_api_keys?(@user.api_accessibility, 'delete_access')), data: { name: 'user[api_accessibility][api_keys][delete_access]' }
+            = label_tag nil, 'Delete access only'
+
+
 
 :css
-  .api-accessibility ul {
+  .api-accessibility ul, .api-keys {
     list-style-type: none;
 
     li {
@@ -200,11 +221,16 @@
 
 :javascript
   $(document).ready(function() {
-    toggleContent();
-    toggleCheckboxes();
-    toggleFullAccessAndSubOptions();
+    toggleApiNamespaceContent();
+    toggleApiNamespaceCheckboxes();
+    toggleApiNamespaceFullAccessAndSubOptions();
+    initializeApiNamespaceIndeterminateState();
 
-    // intialize indeterminate states for full-access checkboxes
+    toggleApiKeyFullAccessAndSubOptions();
+    initializeApiKeyIndeterminateState();
+  });
+
+  function initializeApiNamespaceIndeterminateState() {
     $("input.full-access-option[type='checkbox']:not([disabled='disabled'])").each(function() {
       const subOptions = $(this).parent().next().find("input[type='checkbox']");
       const totalSubOptions = subOptions.length;
@@ -213,9 +239,9 @@
       const shouldFullAccessBeIndeterminate = totalCheckedSubOptions > 0 && totalCheckedSubOptions < totalSubOptions;
       $(this).prop('indeterminate', shouldFullAccessBeIndeterminate);
     });
-  });
+  }
 
-  function toggleContent() {
+  function toggleApiNamespaceContent() {
     $("input[data-group='api-sub-settings']").on('change', function() {
       const specificAccessCheckboxes = $(this).siblings('ul').first().find("> li > input.full-access-option[type='checkbox'], > li + ul.sub-options input[type='checkbox']");
       const categoryCheckboxes = $(this).siblings('ul').first().find("> li > div > input[type='checkbox']");
@@ -241,7 +267,7 @@
     })
   }
 
-  function toggleCheckboxes() {
+  function toggleApiNamespaceCheckboxes() {
     $("input[data-type='toggle-checkboxes']").on('click', function() {
       if (this.checked) {
         const currentElement = this;
@@ -256,7 +282,7 @@
     })
   }
 
-  function toggleFullAccessAndSubOptions() {
+  function toggleApiNamespaceFullAccessAndSubOptions() {
     $('input.full-access-option').on('change', function() {
       const subOptionCheckboxes = $(this).parent().siblings('ul.sub-options').find("input[type='checkbox']");
 
@@ -292,4 +318,53 @@
         });
       }
     })
+  }
+
+  function toggleApiKeyFullAccessAndSubOptions() {
+    const apiKeyFullAccessCheckbox = $('input.api-keys-full-access-option');
+    const apiKeySubOptionCheckboxes = $("li.api-keys-sub-option input[type='checkbox']");
+
+    apiKeyFullAccessCheckbox.on('change', function() {
+      if (this.checked) {
+        apiKeySubOptionCheckboxes.prop('checked', true);
+      } else {
+        apiKeySubOptionCheckboxes.prop('checked', false);
+      }
+      apiKeySubOptionCheckboxes.trigger('change');
+    });
+
+    apiKeySubOptionCheckboxes.on('change', function() {
+      const totalSubOptions = apiKeySubOptionCheckboxes.length;
+      const totalCheckedSubOptions = $("li.api-keys-sub-option input[type='checkbox']:checked").length;
+
+      const shouldCheckFullAccess = totalCheckedSubOptions > 0 && totalCheckedSubOptions == totalSubOptions;
+      const shouldFullAccessBeIndeterminate = totalCheckedSubOptions > 0 && totalCheckedSubOptions < totalSubOptions;
+
+      apiKeyFullAccessCheckbox.prop('checked', shouldCheckFullAccess);
+      apiKeyFullAccessCheckbox.prop('indeterminate', shouldFullAccessBeIndeterminate);
+
+      if (shouldCheckFullAccess) {
+        apiKeySubOptionCheckboxes.each(function() {
+          $(this).removeAttr('name');
+        });
+      } else {
+        apiKeySubOptionCheckboxes.each(function() {
+          const nameAttrValue = $(this).attr('data-name');
+          $(this).attr('name', nameAttrValue);
+        });
+      }
+    });
+  }
+
+  function initializeApiKeyIndeterminateState() {
+    // initialize indeterminate state for ApiKey full access checkbox
+    const apiKeyFullAccessCheckbox = $('input.api-keys-full-access-option');
+    const apiKeySubOptionCheckboxes = $("li.api-keys-sub-option input[type='checkbox']");
+
+    const totalSubOptions = apiKeySubOptionCheckboxes.length;
+    const totalCheckedSubOptions = $("li.api-keys-sub-option input[type='checkbox']:checked").length;
+
+    const shouldFullAccessBeIndeterminate = totalCheckedSubOptions > 0 && totalCheckedSubOptions < totalSubOptions;
+
+    apiKeyFullAccessCheckbox.prop('indeterminate', shouldFullAccessBeIndeterminate);
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,9 @@ Rails.application.routes.draw do
       get 'export'
       get 'export_api_resources'
     end
-end
+  end
+
+  resources :api_keys, controller: 'comfy/admin/api_keys'
   resources :non_primitive_properties, controller: 'comfy/admin/non_primitive_properties', only: [:new]
 
   # system admin panel login
@@ -129,6 +131,7 @@ end
         post '/', to: 'resource#create', as: :create_resource
         patch '/edit/:api_resource_id', to: 'resource#update', as: :update_resource
         delete '/destroy/:api_resource_id', to: 'resource#destroy', as: :destroy_resource
+        post '/:external_api_client/webhook', to: 'external_api_clients#webhook', as: :external_api_client_webhook
       end
     end
   end

--- a/db/migrate/20220922060021_create_api_keys.rb
+++ b/db/migrate/20220922060021_create_api_keys.rb
@@ -1,0 +1,14 @@
+class CreateApiKeys < ActiveRecord::Migration[6.1]
+  def change
+    create_table :api_keys do |t|
+      t.string :slug, null: false, unique: true
+      t.string :label, null: false, default: 'customer_identifier_here'
+      t.string :authentication_strategy, null: false, default: 'bearer_token'
+      t.string :encrypted_token, unique: true
+      t.binary :salt
+
+      t.timestamps
+    end
+    add_index :api_keys, :encrypted_token
+  end
+end

--- a/db/migrate/20220922061014_create_api_namespace_keys.rb
+++ b/db/migrate/20220922061014_create_api_namespace_keys.rb
@@ -1,0 +1,10 @@
+class CreateApiNamespaceKeys < ActiveRecord::Migration[6.1]
+  def change
+    create_table :api_namespace_keys do |t|
+      t.belongs_to :api_namespace, null: false, foreign_key: true
+      t.belongs_to :api_key, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220922080350_migrate_api_clients_to_api_keys.rb
+++ b/db/migrate/20220922080350_migrate_api_clients_to_api_keys.rb
@@ -1,0 +1,13 @@
+class MigrateApiClientsToApiKeys < ActiveRecord::Migration[6.1]
+  def change
+    files = Dir[Rails.root + 'app/models/*.rb']
+    models = files.map{ |m| File.basename(m, '.rb').camelize }
+
+    if models.include?("ApiClient")
+      ApiClient.all.each do |api_client|
+        api_key = ApiKey.create!(slug: api_client.slug, label: api_client.label, token: api_client.bearer_token, authentication_strategy: api_client.authentication_strategy)
+        ApiNamespaceKey.create(api_namespace_id: api_client.api_namespace_id, api_key_id: api_key.id)
+      end
+    end
+  end
+end

--- a/db/migrate/20221018082555_create_webhook_verification_methods.rb
+++ b/db/migrate/20221018082555_create_webhook_verification_methods.rb
@@ -1,0 +1,13 @@
+class CreateWebhookVerificationMethods < ActiveRecord::Migration[6.1]
+  def change
+    create_table :webhook_verification_methods do |t|
+      t.references :external_api_client, null: false, foreign_key: true
+      t.string :webhook_type
+      t.text :encrypted_webhook_secret
+      t.text :custom_method_definition, default: "[false, 'Verification failed']"
+      t.binary :salt
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221221073259_sanitize_user_accessibility_in_users.rb
+++ b/db/migrate/20221221073259_sanitize_user_accessibility_in_users.rb
@@ -1,0 +1,21 @@
+class SanitizeUserAccessibilityInUsers < ActiveRecord::Migration[6.1]
+  def up
+    User.all.each do |user|
+      unless user.api_accessibility['api_namespaces'].present?
+        old_api_accessibility = user.api_accessibility
+        new_api_accessibility = {'api_namespaces' => old_api_accessibility}
+        new_api_accessibility['api_keys'] = {'full_access' => 'true'} if old_api_accessibility.dig('all_namespaces', 'full_access') == 'true'
+
+        user.update!(api_accessibility: new_api_accessibility)
+      end
+    end
+  end
+
+  def down
+    User.all.each do |user|
+      if user.api_accessibility['api_namespaces'].present?
+        user.update!(api_accessibility: user.api_accessibility['api_namespaces'])
+      end
+    end
+  end
+end

--- a/db/migrate/20230109150520_change_default_for_model_definition.rb
+++ b/db/migrate/20230109150520_change_default_for_model_definition.rb
@@ -1,0 +1,7 @@
+class ChangeDefaultForModelDefinition < ActiveRecord::Migration[6.1]
+  OLD_MODEL_DEFINITION = "raise StandardError"
+
+  def change
+    change_column_default :external_api_clients, :model_definition, from: OLD_MODEL_DEFINITION, to: ExternalApiClient::DEFAULT_MODEL_DEFINITION
+  end
+end

--- a/test/controllers/admin/comfy/api_actions_controller_test.rb
+++ b/test/controllers/admin/comfy/api_actions_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:public)
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @api_namespace = api_namespaces(:one)
     @api_action = api_actions(:one)
   end
@@ -47,7 +47,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   # SHOW
   # API access for all_namespaces
   test 'should get show if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -56,7 +56,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has full_read_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -65,7 +65,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has full_access_for_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_actions_only: 'true'}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -74,7 +74,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has read_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_actions_only: 'true'}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -83,7 +83,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get show if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -98,7 +98,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -109,7 +109,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_read_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -120,7 +120,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_access_for_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -131,7 +131,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has read_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -140,7 +140,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has read_api_actions_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {read_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -151,7 +151,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get show if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     api_action = api_actions(:two)
@@ -165,7 +165,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   # INDEX
   # API access for all_namespaces
   test 'should get index if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -173,7 +173,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index if user has full_read_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -181,7 +181,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index if user has full_access_for_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_actions_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -189,7 +189,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index if user has read_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_actions_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -197,7 +197,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get index if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -211,7 +211,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get index if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -221,7 +221,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get index if user has full_read_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -231,7 +231,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get index if user has full_access_for_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -241,7 +241,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get index if user has read_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -249,7 +249,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index if user has read_api_actions_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {read_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -259,7 +259,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get index if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -272,7 +272,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   # NEW
   # API access for all_namespaces
   test 'should get new if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -280,7 +280,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get new if user has full_access_for_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_actions_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -288,7 +288,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get new if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespace: {all_namespaces: {read_api_actions_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id)
@@ -302,7 +302,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get new if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -312,7 +312,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get new if user has full_access_for_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -320,7 +320,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get new if user has read_api_actions_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -330,7 +330,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get new if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -343,7 +343,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   # EDIT
   # API access for all_namespaces
   test 'should get edit if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -351,7 +351,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit if user has full_access_for_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_actions_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -359,7 +359,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get edit if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_actions_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id)
@@ -373,7 +373,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -383,7 +383,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit if user has full_access_for_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -391,7 +391,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit if user has read_api_actions_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -401,7 +401,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get edit if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_action_url(api_namespace_id: @api_action.api_namespace_id, index: 1, type: 'new_api_actions'), xhr: true
@@ -414,7 +414,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   # ACTION_WORKFLOW
   # API access for all_namespaces
   test 'should get action_workflow if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -426,7 +426,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get action_workflow if user has full_access_for_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_actions_only: 'true'}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -438,7 +438,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get action_workflow if user has read_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_actions_only: 'true'}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -450,7 +450,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get action_workflow if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_resources_only: 'true'}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -461,7 +461,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update action_workflow if user has full_access_for_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_actions_only: 'true'}}})
 
     payload = {
       api_namespace: {
@@ -517,7 +517,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not update action_workflow if user has read_api_actions_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_actions_only: 'true'}}})
 
     payload = {
       api_namespace: {
@@ -576,7 +576,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get action_workflow if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -590,7 +590,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get action_workflow if user has full_access_for_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -602,7 +602,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get action_workflow if user has full_access_for_api_actions_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -616,7 +616,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should get action_workflow if user has read_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -630,7 +630,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get action_workflow if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get action_workflow_api_namespace_api_actions_url(api_namespace_id: @api_action.api_namespace_id)
@@ -643,7 +643,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should update action_workflow if user has category-specific full_access_for_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}}})
 
     payload = {
       api_namespace: {
@@ -701,7 +701,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   test 'should not update action_workflow if user has category-specific read_api_actions_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_actions_only: 'true'}}}})
 
     payload = {
       api_namespace: {
@@ -757,7 +757,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update action_workflow if user has uncategorized full_access_for_api_actions_only for the namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_actions_only: 'true'}}}})
 
     payload = {
       api_namespace: {
@@ -813,7 +813,7 @@ class Comfy::Admin::ApiActionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not update action_workflow if user has uncategorized read_api_actions_only for the namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {read_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {read_api_actions_only: 'true'}}}})
 
     payload = {
       api_namespace: {

--- a/test/controllers/admin/comfy/api_clients_controller_test.rb
+++ b/test/controllers/admin/comfy/api_clients_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:public)
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @api_client = api_clients(:one)
     @api_namespace = api_namespaces(:one)
   end
@@ -97,7 +97,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   # SHOW
   # API access for all namespaces
   test 'should get show if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -106,7 +106,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has full_read_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -115,7 +115,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has full_access_for_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_clients_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -124,7 +124,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has read_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_clients_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -133,7 +133,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get show if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -147,7 +147,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -158,7 +158,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_read_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -169,7 +169,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_access_for_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -180,7 +180,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has read_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -189,7 +189,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has read_api_clients_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -200,7 +200,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get show if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -213,7 +213,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   # INDEX
   # API access for all namespaces
   test 'should get index if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -221,7 +221,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index if user has full_read_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -229,7 +229,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index if user has full_access_for_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_clients_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -237,7 +237,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index if user has read_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_clients_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -245,7 +245,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get index if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -259,7 +259,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get index if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -269,7 +269,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get index if user has full_read_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -279,7 +279,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get index if user has full_access_for_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -289,7 +289,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get index if user has read_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -297,7 +297,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get index if user has read_api_clients_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -307,7 +307,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get index if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_api_clients_url(api_namespace_id: @api_namespace.id)
@@ -320,7 +320,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   # NEW
   # API access for all_namespaces
   test 'should get new if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_client_url(api_namespace_id: @api_namespace.id)
@@ -328,7 +328,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get new if user has full_access_for_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_clients_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_client_url(api_namespace_id: @api_namespace.id)
@@ -336,7 +336,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get new if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_clients_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_api_client_url(api_namespace_id: @api_namespace.id)
@@ -350,7 +350,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get new if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_client_url(api_namespace_id: @api_namespace.id)
@@ -360,7 +360,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get new if user has full_access_for_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_client_url(api_namespace_id: @api_namespace.id)
@@ -368,7 +368,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get new if user has read_api_clients_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_client_url(api_namespace_id: @api_namespace.id)
@@ -378,7 +378,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get new if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_api_client_url(api_namespace_id: @api_namespace.id)
@@ -391,7 +391,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   # EDIT
   # API access for all_namespaces
   test 'should get edit if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_api_client_path(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -400,7 +400,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit if user has full_access_for_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_clients_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_api_client_path(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -409,7 +409,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get edit if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_clients_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_api_client_path(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -423,7 +423,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_api_client_path(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -434,7 +434,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit if user has full_access_for_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_api_client_path(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -443,7 +443,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit if user has read_api_clients_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_api_client_path(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -454,7 +454,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get edit if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_api_client_path(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id)
@@ -467,7 +467,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   # CREATE
   # API access for all_namespaces
   test 'should get create if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count') do
@@ -478,7 +478,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get create if user has full_access_for_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_clients_only: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count') do
@@ -489,7 +489,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get create if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_clients_only: 'true'}}})
 
     sign_in(@user)
     assert_no_difference('ApiClient.count') do
@@ -506,7 +506,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get create if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count') do
@@ -519,7 +519,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get create if user has full_access_for_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count') do
@@ -530,7 +530,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get create if user has read_api_clients_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count') do
@@ -543,7 +543,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get create if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     assert_no_difference('ApiClient.count') do
@@ -558,7 +558,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   # UPDATE
   # API access for all_namespaces
   test 'should get update if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id), params: { api_client: { authentication_strategy: @api_client.authentication_strategy, bearer_token: @api_client.bearer_token, label: @api_client.label } }
@@ -566,7 +566,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get update if user has full_access_for_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_clients_only: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id), params: { api_client: { authentication_strategy: @api_client.authentication_strategy, bearer_token: @api_client.bearer_token, label: @api_client.label } }
@@ -574,7 +574,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get update if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_clients_only: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id), params: { api_client: { authentication_strategy: @api_client.authentication_strategy, bearer_token: @api_client.bearer_token, label: @api_client.label } }
@@ -588,7 +588,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get update if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id), params: { api_client: { authentication_strategy: @api_client.authentication_strategy, bearer_token: @api_client.bearer_token, label: @api_client.label } }
@@ -598,7 +598,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should get update if user has full_access_for_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id), params: { api_client: { authentication_strategy: @api_client.authentication_strategy, bearer_token: @api_client.bearer_token, label: @api_client.label } }
@@ -606,7 +606,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get update if user has read_api_clients_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id), params: { api_client: { authentication_strategy: @api_client.authentication_strategy, bearer_token: @api_client.bearer_token, label: @api_client.label } }
@@ -616,7 +616,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get update if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_api_client_url(api_namespace_id: @api_client.api_namespace.id, id: @api_client.id), params: { api_client: { authentication_strategy: @api_client.authentication_strategy, bearer_token: @api_client.bearer_token, label: @api_client.label } }
@@ -629,7 +629,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   # DESTROY
   # API access for all_namespaces
   test 'should destroy if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count', -1) do
@@ -640,7 +640,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy if user has full_access_for_api_clients_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_clients_only: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count', -1) do
@@ -651,7 +651,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not destroy if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_clients_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_clients_only: 'true'}}})
 
     sign_in(@user)
     assert_no_difference('ApiClient.count') do
@@ -668,7 +668,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should destroy if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count', -1) do
@@ -681,7 +681,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should destroy if user has full_access_for_api_clients_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count', -1) do
@@ -692,7 +692,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy if user has read_api_clients_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiClient.count', -1) do
@@ -705,7 +705,7 @@ class Comfy::Admin::ApiClientsControllerTest < ActionDispatch::IntegrationTest
   test 'should not destroy if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_clients_only: 'true'}}}})
 
     sign_in(@user)
     assert_no_difference('ApiClient.count') do

--- a/test/controllers/admin/comfy/api_forms_controller_test.rb
+++ b/test/controllers/admin/comfy/api_forms_controller_test.rb
@@ -9,19 +9,19 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
 
 
   test "should get edit if permissioned" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     sign_in(@user)
 
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
     assert_response :success
 
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_form_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_form_only: 'true'}}})
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
     assert_response :success
   end
 
   test "deny edit if not permissioned" do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
     sign_in(@user)
 
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
@@ -30,19 +30,19 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update api_form if permissioned" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     sign_in(@user)
 
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
     assert_redirected_to api_namespace_url(@api_form.api_namespace.slug)
 
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_form_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_form_only: 'true'}}})
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
     assert_redirected_to api_namespace_url(@api_form.api_namespace.slug)
   end
 
   test "deny update api_form if not permissioned" do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
     sign_in(@user)
 
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
@@ -53,7 +53,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   # EDIT
   # API access for all_namespaces
   test 'should get edit if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
@@ -61,7 +61,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit if user has full_access_for_api_form_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_form_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_form_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
@@ -69,7 +69,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get edit if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
@@ -83,7 +83,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
@@ -93,7 +93,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit if user has full_access_for_api_form_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_form_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_form_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
@@ -101,7 +101,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit if user has full_access_for_api_form_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_form_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_form_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
@@ -111,7 +111,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get edit if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_api_form_url(api_namespace_id: @api_namespace.id, id: ApiForm.last.id)
@@ -124,7 +124,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   # UPDATE
   # API access for all_namespaces
   test 'should get update if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
@@ -132,7 +132,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get update if user has full_access_for_api_form_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_form_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_form_only: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
@@ -140,7 +140,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get update if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
@@ -154,7 +154,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   test 'should get update if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
@@ -164,7 +164,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   test 'should get update if user has full_access_for_api_form_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_form_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_form_only: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
@@ -172,7 +172,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get update if user has full_access_for_api_form_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_form_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_form_only: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }
@@ -182,7 +182,7 @@ class Comfy::Admin::ApiFormsControllerTest < ActionDispatch::IntegrationTest
   test 'should not get update if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_api_form_url(@api_form, api_namespace_id: @api_form.api_namespace_id), params: { api_form: { properties: @api_form.properties } }

--- a/test/controllers/admin/comfy/api_keys_controller_test.rb
+++ b/test/controllers/admin/comfy/api_keys_controller_test.rb
@@ -1,0 +1,183 @@
+require "test_helper"
+
+class Comfy::Admin::ApiKeysControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:public)
+    @user.update(api_accessibility: {api_keys: {full_access: 'true'}})
+    @api_key = api_keys(:one)
+    @api_namespace = api_namespaces(:one)
+  end
+
+  test "should not get index if not authenticated" do
+    get api_keys_url
+    assert_redirected_to new_user_session_url
+  end
+
+  test "should not get #index, #new if signed in but does not have proper api-keys access" do
+    sign_in(@user)
+    @user.update(api_accessibility: {})
+    get api_keys_url
+    assert_response :redirect
+    assert_equal "You do not have the permission to do that. Only users with full_access or read_access or delete_acess for ApiKeys are allowed to perform that action.", flash[:alert]
+
+    get new_api_key_url
+    assert_response :redirect
+    assert_equal "You do not have the permission to do that. Only users with full_access for ApiKeys are allowed to perform that action.", flash[:alert]
+  end
+
+  test "should get index when user has proper api-key access" do
+    ['full_access', 'delete_access', 'read_access'].each do |access_name|
+      api_hash = {api_keys: {}}
+      api_hash[:api_keys][access_name] = 'true'
+      @user.update(api_accessibility: api_hash)
+
+      sign_in(@user)
+      get api_keys_url
+      assert_response :success
+    end
+  end
+
+  test "should get new when user has only full_access for api-key" do
+    @user.update(api_accessibility: {api_keys: {full_access: 'true'}})
+    sign_in(@user)
+    get new_api_key_url
+    assert_response :success
+  end
+
+  test "should deny new when user has only other accesses for api-key" do
+    ['delete_access', 'read_access'].each do |access_name|
+      api_hash = {api_keys: {}}
+      api_hash[:api_keys][access_name] = 'true'
+      @user.update(api_accessibility: api_hash)
+
+      sign_in(@user)
+      get new_api_key_url
+      assert_response :redirect
+      assert_equal "You do not have the permission to do that. Only users with full_access for ApiKeys are allowed to perform that action.", flash[:alert]
+    end
+  end
+
+  test "should create api_key when user has full_access for api-keys" do
+    @user.update(api_accessibility: {api_keys: {full_access: 'true'}})
+    sign_in(@user)
+    assert_difference('ApiKey.count', +1) do
+      post api_keys_url, params: { api_key: {  authentication_strategy: @api_key.authentication_strategy, label: "foobar" } }
+    end
+    api_key = ApiKey.last
+    assert_redirected_to api_key_path(id: api_key.id)
+  end
+
+  test "should deny create api_key when user has other accesses for api-key" do
+    ['delete_access', 'read_access'].each do |access_name|
+      api_hash = {api_keys: {}}
+      api_hash[:api_keys][access_name] = 'true'
+      @user.update(api_accessibility: api_hash)
+
+      sign_in(@user)
+      assert_no_difference('ApiKey.count') do
+        post api_keys_url, params: { api_key: {  authentication_strategy: @api_key.authentication_strategy, label: "foobar" } }
+      end
+      
+      assert_response :redirect
+      assert_equal "You do not have the permission to do that. Only users with full_access for ApiKeys are allowed to perform that action.", flash[:alert]
+    end
+  end
+
+  test "should show api_key when user has proper access for api-keys" do
+    ['full_access', 'read_access'].each do |access_name|
+      api_hash = {api_keys: {}}
+      api_hash[:api_keys][access_name] = 'true'
+      @user.update(api_accessibility: api_hash)
+
+      sign_in(@user)
+      get api_key_url(id: @api_key.id)
+      assert_response :success
+      assert_template :show
+    end
+  end
+
+  test "should deny show api_key when user has delete_access for api-keys" do
+    api_hash = {api_keys: {delete_access: 'true'}}
+    @user.update(api_accessibility: api_hash)
+
+    sign_in(@user)
+    get api_key_url(id: @api_key.id)
+    assert_response :redirect
+    assert_equal "You do not have the permission to do that. Only users with full_access or read_access for ApiKeys are allowed to perform that action.", flash[:alert]
+  end
+
+  test "should get edit only when the user has full_access for api-key" do
+    @user.update(api_accessibility: {api_keys: {full_access: 'true'}})
+    sign_in(@user)
+    get edit_api_key_path(id: @api_key.id)
+    assert_response :success
+    assert_template :edit
+  end
+
+  test "should deny edit when the user has other accesses for api-key" do
+    ['delete_access', 'read_access'].each do |access_name|
+      api_hash = {api_keys: {}}
+      api_hash[:api_keys][access_name] = 'true'
+      @user.update(api_accessibility: api_hash)
+
+      sign_in(@user)
+      get edit_api_key_path(id: @api_key.id)
+      assert_response :redirect
+      assert_equal "You do not have the permission to do that. Only users with full_access for ApiKeys are allowed to perform that action.", flash[:alert]
+    end
+  end
+
+  test "should update api_key when the user has full_access for api-keys" do
+    @user.update(api_accessibility: {api_keys: {full_access: 'true'}})
+    sign_in(@user)
+    patch api_key_url(id: @api_key.id), params: { api_key: { authentication_strategy: @api_key.authentication_strategy, label: @api_key.label } }
+    assert_redirected_to api_key_url(id: @api_key.id)
+  end
+
+  test "should deny update api_key when the user has other accesses for api-keys" do
+    ['delete_access', 'read_access'].each do |access_name|
+      api_hash = {api_keys: {}}
+      api_hash[:api_keys][access_name] = 'true'
+      @user.update(api_accessibility: api_hash)
+
+      sign_in(@user)
+      patch api_key_url(id: @api_key.id), params: { api_key: { authentication_strategy: @api_key.authentication_strategy, label: @api_key.label } }
+      assert_response :redirect
+      assert_equal "You do not have the permission to do that. Only users with full_access for ApiKeys are allowed to perform that action.", flash[:alert]
+    end
+  end
+
+  test "should destroy api_key when user has full_access for api-keys" do
+    @user.update(api_accessibility: {api_keys: {full_access: 'true'}})
+
+    sign_in(@user)
+    assert_difference('ApiKey.count', -1) do
+      delete api_key_url(id: @api_key.id)
+    end
+
+    assert_redirected_to api_keys_url
+  end
+
+  test "should destroy api_key when user has delete_access for api-keys" do
+    @user.update(api_accessibility: {api_keys: {delete_access: 'true'}})
+
+    sign_in(@user)
+    assert_difference('ApiKey.count', -1) do
+      delete api_key_url(id: @api_key.id)
+    end
+
+    assert_redirected_to api_keys_url
+  end
+
+  test "should deny destroy api_key when user has read_access for api-keys" do
+    @user.update(api_accessibility: {api_keys: {read_access: 'true'}})
+
+    sign_in(@user)
+    assert_no_difference('ApiKey.count') do
+      delete api_key_url(id: @api_key.id)
+    end
+
+    assert_response :redirect
+    assert_equal "You do not have the permission to do that. Only users with full_access or delete_access for ApiKeys are allowed to perform that action.", flash[:alert]
+  end
+end

--- a/test/controllers/admin/comfy/api_namespaces_controller_test.rb
+++ b/test/controllers/admin/comfy/api_namespaces_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:public)
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @api_namespace = api_namespaces(:one)
   end
 
@@ -158,7 +158,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_no_difference('ApiNamespace.count') do
       assert_no_difference('ApiResource.count') do
         assert_no_difference('ApiAction.count') do
-          assert_no_difference('ApiClient.count') do
+          assert_no_difference('ApiNamespaceKey.count') do
             assert_no_difference('ExternalApiClient.count') do
               assert_no_difference('NonPrimitiveProperty.count') do
                 post duplicate_without_associations_api_namespace_url(id: @api_namespace.id)
@@ -181,7 +181,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_difference('ApiNamespace.count', +1) do
       assert_no_difference('ApiResource.count') do
         assert_no_difference('ApiAction.count') do
-          assert_no_difference('ApiClient.count') do
+          assert_no_difference('ApiNamespaceKey.count') do
             assert_no_difference('ExternalApiClient.count') do
               assert_no_difference('NonPrimitiveProperty.count') do
                 post duplicate_without_associations_api_namespace_url(id: @api_namespace.id)
@@ -213,7 +213,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should allow duplicate_with_associations" do
     api_resources_count = @api_namespace.api_resources.count
     api_actions_count = @api_namespace.api_actions.count + @api_namespace.api_resources.map(&:api_actions).flatten.count
-    api_clients_count = @api_namespace.api_clients.count
+    api_namespace_keys_count = @api_namespace.api_namespace_keys.count
     external_api_clients_count = @api_namespace.external_api_clients.count
     non_primitive_properties_count = @api_namespace.non_primitive_properties.count
 
@@ -221,7 +221,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_difference('ApiNamespace.count', +1) do
       assert_difference('ApiResource.count', +api_resources_count) do
         assert_difference('ApiAction.count', +api_actions_count) do
-          assert_difference('ApiClient.count', +api_clients_count) do
+          assert_difference('ApiNamespaceKey.count', +api_namespace_keys_count) do
             assert_difference('ExternalApiClient.count', +external_api_clients_count) do
               assert_difference('NonPrimitiveProperty.count', +non_primitive_properties_count) do
                 post duplicate_with_associations_api_namespace_url(id: @api_namespace.id)
@@ -406,7 +406,6 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
       root: 'api_namespace',
       include: [
         :api_form,
-        :api_clients,
         :external_api_clients,
         :non_primitive_properties,
         {
@@ -425,6 +424,12 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
                 }
               }
             ]
+          }
+        },
+        {
+          api_keys: {
+            except: [:salt, :encrypted_token],
+            methods: [:token]
           }
         }
       ]
@@ -447,7 +452,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_no_difference('ApiNamespace.count') do
       assert_no_difference('ApiResource.count') do
         assert_no_difference('ApiAction.count') do
-          assert_no_difference('ApiClient.count') do
+          assert_no_difference('ApiNamespaceKey.count') do
             assert_no_difference('ExternalApiClient.count') do
               assert_no_difference('NonPrimitiveProperty.count') do
                 post import_as_json_api_namespaces_url, params: payload
@@ -474,7 +479,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_no_difference('ApiNamespace.count') do
       assert_no_difference('ApiResource.count') do
         assert_no_difference('ApiAction.count') do
-          assert_no_difference('ApiClient.count') do
+          assert_no_difference('ApiNamespaceKey.count') do
             assert_no_difference('ExternalApiClient.count') do
               assert_no_difference('NonPrimitiveProperty.count') do
                 post import_as_json_api_namespaces_url, params: payload
@@ -503,7 +508,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_difference('ApiNamespace.count', +1) do
       assert_no_difference('ApiResource.count') do
         assert_no_difference('ApiAction.count') do
-          assert_no_difference('ApiClient.count') do
+          assert_no_difference('ApiNamespaceKey.count') do
             assert_no_difference('ExternalApiClient.count') do
               assert_no_difference('NonPrimitiveProperty.count') do
                 post import_as_json_api_namespaces_url, params: payload
@@ -524,7 +529,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should allow import api_namespace provided as json with its asscociations and the newly created api_namespace should be followed by secure-random if api_namespace with such name exists" do
     api_resources_count = @api_namespace.api_resources.count
     api_actions_count = @api_namespace.api_actions.count + @api_namespace.api_resources.map(&:api_actions).flatten.count
-    api_clients_count = @api_namespace.api_clients.count
+    api_namespace_keys_count = @api_namespace.api_namespace_keys.count
     external_api_clients_count = @api_namespace.external_api_clients.count
     non_primitive_properties_count = @api_namespace.non_primitive_properties.count
 
@@ -540,7 +545,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_difference('ApiNamespace.count', +1) do
       assert_difference('ApiResource.count', +api_resources_count) do
         assert_difference('ApiAction.count', +api_actions_count) do
-          assert_difference('ApiClient.count', +api_clients_count) do
+          assert_difference('ApiNamespaceKey.count', +api_namespace_keys_count) do
             assert_difference('ExternalApiClient.count', +external_api_clients_count) do
               assert_difference('NonPrimitiveProperty.count', +non_primitive_properties_count) do
                 post import_as_json_api_namespaces_url, params: payload
@@ -561,7 +566,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should allow import api_namespace provided as json with its asscociations and the newly created api_namespace's name should be as provided if api_namespace with such name does not exist" do
     api_resources_count = @api_namespace.api_resources.count
     api_actions_count = @api_namespace.api_actions.count + @api_namespace.api_resources.map(&:api_actions).flatten.count
-    api_clients_count = @api_namespace.api_clients.count
+    api_namespace_keys_count = @api_namespace.api_namespace_keys.count
     external_api_clients_count = @api_namespace.external_api_clients.count
     non_primitive_properties_count = @api_namespace.non_primitive_properties.count
 
@@ -580,7 +585,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_difference('ApiNamespace.count', +1) do
       assert_difference('ApiResource.count', +api_resources_count) do
         assert_difference('ApiAction.count', +api_actions_count) do
-          assert_difference('ApiClient.count', +api_clients_count) do
+          assert_difference('ApiNamespaceKey.count', +api_namespace_keys_count) do
             assert_difference('ExternalApiClient.count', +external_api_clients_count) do
               assert_difference('NonPrimitiveProperty.count', +non_primitive_properties_count) do
                 post import_as_json_api_namespaces_url, params: payload
@@ -607,7 +612,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     get api_namespace_url(@api_namespace)
     assert_response :success
 
-    assert_select "table", 1, "This page must contain a api-resources table"
+    assert_select "table", 2, "This page must contain a api-resources table and external api webhook table"
     properties.keys.each do |heading|
       assert_select "thead th", {count: 1, text: heading.capitalize.gsub('_', ' ')}, "Api-resources table must contain '#{heading}' column"
     end
@@ -790,43 +795,56 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # API access for all_namespaces
   test "should get index if user has full_access for all namespaces" do
     sign_in(@user)
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     get api_namespaces_url
     assert_response :success
   end
 
   test "should get index if user has full_read_access for all namespaces" do
     sign_in(@user)
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
     get api_namespaces_url
     assert_response :success
   end
 
   test "should get index if user has full_access_api_namespace_only for all namespaces" do
     sign_in(@user)
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
     get api_namespaces_url
     assert_response :success
   end
 
   test "should get index if user has other access for all namespaces" do
     sign_in(@user)
-    @user.update(api_accessibility: {all_namespaces: {allow_exports: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_exports: 'true'}}})
     get api_namespaces_url
     assert_response :success
   end
 
   test "should get index if user has allow_social_share_metadata access for all namespaces" do
     sign_in(@user)
-    @user.update(api_accessibility: {all_namespaces: {allow_social_share_metadata: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_social_share_metadata: 'true'}}})
     get api_namespaces_url
     assert_response :success
   end
 
   test "should get index if user has other access related to api-actions/api-resources/api-clients/api-form/external-api-connection for all namespaces" do
     ['read_api_resources_only', 'full_access_for_api_resources_only', 'delete_access_for_api_resources_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {all_namespaces: {}}
-      access[:all_namespaces][access_name] = 'true'
+      access = {api_namespaces: {all_namespaces: {}}}
+      access[:api_namespaces][:all_namespaces][access_name] = 'true'
+
+      @user.update(api_accessibility: access)
+
+      sign_in(@user)
+      get api_namespaces_url
+      assert_response :success
+    end
+  end
+
+  test "should get index if user has access only related to api-keys" do
+    ['full_access', 'delete_access', 'read_access'].each do |access_name|
+      access = {api_keys: {}}
+      access[:api_keys][access_name] = 'true'
 
       @user.update(api_accessibility: access)
 
@@ -838,7 +856,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should get index with all namespaces if user has access for all_namespaces" do
     sign_in(@user)
-    @user.update(api_accessibility: {all_namespaces: {allow_exports: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_exports: 'true'}}})
     get api_namespaces_url
     assert_response :success
 
@@ -853,7 +871,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should get index if user has category specific full_access for one of the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespaces_url
@@ -863,7 +881,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should get index if user has category specific full_read_access for one of the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespaces_url
@@ -873,7 +891,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should get index if user has category specific full_access_api_namespace_only for one of the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespaces_url
@@ -883,7 +901,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should get index if user has category specific other access for one of the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     sign_in(@user)
     get api_namespaces_url
@@ -893,7 +911,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should get index if user has category-specific allow_social_share_metadata access for one of the namespaces" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_social_share_metadata: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_social_share_metadata: 'true'}}}})
 
     sign_in(@user)
     get api_namespaces_url
@@ -901,7 +919,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should get index if user has uncategorized allow_social_share_metadata access for one of the namespaces" do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {allow_social_share_metadata: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {allow_social_share_metadata: 'true'}}}})
 
     sign_in(@user)
     get api_namespaces_url
@@ -913,9 +931,9 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     ['read_api_resources_only', 'full_access_for_api_resources_only', 'delete_access_for_api_resources_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {namespaces_by_category: {}}
-      access[:namespaces_by_category][category.label] = {}
-      access[:namespaces_by_category][category.label][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {}}}
+      access[:api_namespaces][:namespaces_by_category][category.label] = {}
+      access[:api_namespaces][:namespaces_by_category][category.label][access_name] = 'true'
 
       @user.update(api_accessibility: access)
 
@@ -935,7 +953,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     end
     
     sign_in(@user)
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {allow_exports: 'true'}}}})
     get api_namespaces_url
     assert_response :success
 
@@ -972,7 +990,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     end
     
     sign_in(@user)
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {allow_exports: 'true'}, "#{category_one.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {allow_exports: 'true'}, "#{category_one.label}": {allow_exports: 'true'}}}})
     get api_namespaces_url
     assert_response :success
 
@@ -1009,7 +1027,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     expected_namespaces = [@api_namespace, api_namespace_two, api_namespace_three, api_namespace_four, api_namespace_five, api_namespace_six]
 
     sign_in(@user)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_two.label}": {allow_exports: 'true'}, "#{category_one.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_two.label}": {allow_exports: 'true'}, "#{category_one.label}": {allow_exports: 'true'}}}})
     get api_namespaces_url
     assert_response :success
 
@@ -1026,8 +1044,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should get index if user has other uncategorized access related to api-actions/api-resources/api-clients/api-form/external-api-connection for namespaces" do
     ['read_api_resources_only', 'full_access_for_api_resources_only', 'delete_access_for_api_resources_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {namespaces_by_category: {uncategorized: {}}}
-      access[:namespaces_by_category][:uncategorized][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {uncategorized: {}}}}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized][access_name] = 'true'
 
       @user.update(api_accessibility: access)
 
@@ -1040,7 +1058,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # NEW
   # API access for all_namespace
   test "should get new if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_url
@@ -1048,7 +1066,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should get new if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_url
@@ -1056,7 +1074,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "#new: should show categories when user has proper access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_url
@@ -1070,7 +1088,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not get new if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_url
@@ -1084,7 +1102,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not get new if user has access by category wise" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_url
@@ -1095,7 +1113,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should get new if user has full_access for uncategorized api-namespaces" do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_url
@@ -1103,7 +1121,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should get new if user has full_access_api_namespace_only for uncategorized api-namespaces" do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_url
@@ -1114,7 +1132,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace_1 = comfy_cms_categories(:api_namespace_1)
     api_namespace_2 = comfy_cms_categories(:api_namespace_2)
     api_namespace_3 = comfy_cms_categories(:api_namespace_3)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{api_namespace_1.label}": {full_access: 'true'}, "#{api_namespace_2.label}": {full_access: 'true'}, uncategorized: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{api_namespace_1.label}": {full_access: 'true'}, "#{api_namespace_2.label}": {full_access: 'true'}, uncategorized: {full_access: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_url
@@ -1130,7 +1148,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # CREATE
   # API access for all_namespace
   test "should create if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count') do
@@ -1142,7 +1160,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should create if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count') do
@@ -1154,7 +1172,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not create if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     assert_no_difference('ApiNamespace.count') do
@@ -1172,7 +1190,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not create if user has access by category wise" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     assert_no_difference('ApiNamespace.count') do
@@ -1187,7 +1205,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should create if user has full_access for uncategorized api-namespaces" do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count') do
@@ -1199,7 +1217,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should create if user has full_access_api_namespace_only for uncategorized api-namespaces" do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count') do
@@ -1213,7 +1231,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # IMPORT_AS_JSON
   # API access for all_namespace
   test "should import_as_json if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     json_file = Tempfile.new(['api_namespace.json', '.json'])
     json_file.write(@api_namespace.export_as_json(include_associations: false))
@@ -1236,7 +1254,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should import_as_json if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     json_file = Tempfile.new(['api_namespace.json', '.json'])
     json_file.write(@api_namespace.export_as_json(include_associations: false))
@@ -1259,7 +1277,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not import_as_json if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     json_file = Tempfile.new(['api_namespace.json', '.json'])
     json_file.write(@api_namespace.export_as_json(include_associations: false))
@@ -1283,7 +1301,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not import_as_json if user has access by category wise" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     json_file = Tempfile.new(['api_namespace.json', '.json'])
     json_file.write(@api_namespace.export_as_json(include_associations: false))
@@ -1304,7 +1322,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should import_as_json if user has full_access for uncategorized api-namespaces" do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access: 'true'}}}})
 
     json_file = Tempfile.new(['api_namespace.json', '.json'])
     json_file.write(@api_namespace.export_as_json(include_associations: false))
@@ -1327,7 +1345,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should import_as_json if user has full_access_api_namespace_only for uncategorized api-namespaces" do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_api_namespace_only: 'true'}}}})
 
     json_file = Tempfile.new(['api_namespace.json', '.json'])
     json_file.write(@api_namespace.export_as_json(include_associations: false))
@@ -1352,7 +1370,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # SHOW
   # API access for all_namespace
   test "should show if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1360,7 +1378,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should show if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1368,7 +1386,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should show if user has full_read_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1377,8 +1395,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should show api-resources section if user has full_access or access related to api-resource for all_namespaces" do
     ['full_access', 'full_read_access', 'full_access_for_api_resources_only', 'read_api_resources_only', 'delete_access_for_api_resources_only'].each do |access_name|
-      access = {all_namespaces: {}}
-      access[:all_namespaces][access_name] = 'true'
+      access = {api_namespaces: {all_namespaces: {}}}
+      access[:api_namespaces][:all_namespaces][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1390,8 +1408,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should not show if user has other access for all_namespaces" do
     ['delete_access_api_namespace_only', 'allow_exports', 'allow_duplication', 'allow_social_share_metadata', 'full_access_api_namespace_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {all_namespaces: {}}
-      access[:all_namespaces][access_name] = 'true'
+      access = {api_namespaces: {all_namespaces: {}}}
+      access[:api_namespaces][:all_namespaces][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1403,8 +1421,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should show if user has other access related to namespace for all_namespaces" do
     ['allow_exports', 'allow_duplication', 'allow_social_share_metadata'].each do |access_name|
-      access = {all_namespaces: {}}
-      access[:all_namespaces][access_name] = 'true'
+      access = {api_namespaces: {all_namespaces: {}}}
+      access[:api_namespaces][:all_namespaces][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1415,8 +1433,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should show if user has other access related to api-actions/api-resources/api-clients/api-form/external-api-connection for all_namespaces" do
     ['read_api_resources_only', 'full_access_for_api_resources_only', 'delete_access_for_api_resources_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {all_namespaces: {}}
-      access[:all_namespaces][access_name] = 'true'
+      access = {api_namespaces: {all_namespaces: {}}}
+      access[:api_namespaces][:all_namespaces][access_name] = 'true'
 
       @user.update(api_accessibility: access)
 
@@ -1430,7 +1448,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should show if user has category specific full_access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1440,7 +1458,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should show if user has category specific full_read_access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1452,9 +1470,9 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     ['read_api_resources_only', 'full_access_for_api_resources_only', 'delete_access_for_api_resources_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {namespaces_by_category: {}}
-      access[:namespaces_by_category][category.label]= {}
-      access[:namespaces_by_category][category.label][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {}}}
+      access[:api_namespaces][:namespaces_by_category][category.label]= {}
+      access[:api_namespaces][:namespaces_by_category][category.label][access_name] = 'true'
 
       @user.update(api_accessibility: access)
 
@@ -1469,9 +1487,9 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     ['allow_exports', 'allow_duplication', 'allow_social_share_metadata'].each do |access_name|
-      access = {namespaces_by_category: {}}
-      access[:namespaces_by_category][category.label]= {}
-      access[:namespaces_by_category][category.label][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {}}}
+      access[:api_namespaces][:namespaces_by_category][category.label]= {}
+      access[:api_namespaces][:namespaces_by_category][category.label][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1481,7 +1499,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should show if user has uncategorized access for the namespace with no category" do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1490,8 +1508,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should show if user has uncategorized access related to api-actions/api-resources/api-clients/api-form/external-api-connection for the namespace" do
     ['read_api_resources_only', 'full_access_for_api_resources_only', 'delete_access_for_api_resources_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {namespaces_by_category: {uncategorized: {}}}
-      access[:namespaces_by_category][:uncategorized][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {uncategorized: {}}}}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized][access_name] = 'true'
 
       @user.update(api_accessibility: access)
 
@@ -1503,9 +1521,9 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should show if user has uncategorized other access related to namespace for the namespace" do
     ['allow_exports', 'allow_duplication', 'allow_social_share_metadata'].each do |access_name|
-      access = {namespaces_by_category: {}}
-      access[:namespaces_by_category][:uncategorized]= {}
-      access[:namespaces_by_category][:uncategorized][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {}}}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized]= {}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1517,7 +1535,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should show if user has category specific full_access_api_namespace_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1527,7 +1545,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should show if user has category specific other access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1539,7 +1557,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_url(@api_namespace)
@@ -1554,9 +1572,9 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     ['full_access', 'full_read_access', 'full_access_for_api_resources_only', 'read_api_resources_only', 'delete_access_for_api_resources_only'].each do |access_name|
-      access = {namespaces_by_category: {}}
-      access[:namespaces_by_category][:"#{category.label}"]= {}
-      access[:namespaces_by_category][:"#{category.label}"][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {}}}
+      access[:api_namespaces][:namespaces_by_category][:"#{category.label}"]= {}
+      access[:api_namespaces][:namespaces_by_category][:"#{category.label}"][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1571,9 +1589,9 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     ['delete_access_api_namespace_only', 'allow_exports', 'allow_duplication', 'allow_social_share_metadata', 'full_access_api_namespace_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {namespaces_by_category: {}}
-      access[:namespaces_by_category][:"#{category.label}"]= {}
-      access[:namespaces_by_category][:"#{category.label}"][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {}}}
+      access[:api_namespaces][:namespaces_by_category][:"#{category.label}"]= {}
+      access[:api_namespaces][:namespaces_by_category][:"#{category.label}"][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1585,9 +1603,9 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should show api-resources section if user has uncategorized full_access or access related to api-resource for the namespace" do
     ['full_access', 'full_read_access', 'full_access_for_api_resources_only', 'read_api_resources_only', 'delete_access_for_api_resources_only'].each do |access_name|
-      access = {namespaces_by_category: {}}
-      access[:namespaces_by_category][:uncategorized]= {}
-      access[:namespaces_by_category][:uncategorized][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {}}}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized]= {}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1599,9 +1617,9 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should not show if user has other uncategorized access for the namespace" do
     ['delete_access_api_namespace_only', 'allow_exports', 'allow_duplication', 'allow_social_share_metadata', 'full_access_api_namespace_only', 'read_api_actions_only', 'full_access_for_api_actions_only', 'read_external_api_connections_only', 'full_access_for_external_api_connections_only', 'read_api_clients_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {namespaces_by_category: {}}
-      access[:namespaces_by_category][:uncategorized]= {}
-      access[:namespaces_by_category][:uncategorized][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {}}}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized]= {}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized][access_name] = 'true'
       @user.update(api_accessibility: access)
   
       sign_in(@user)
@@ -1614,7 +1632,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # EDIT
   # API access for all_namespace
   test "should edit if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1622,7 +1640,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should edit if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1630,7 +1648,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not edit if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1641,7 +1659,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "#edit: should show all categories when user has proper access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1658,7 +1676,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should edit if user has category specific full_access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1668,7 +1686,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should edit if user has category specific full_access_api_namespace_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1678,7 +1696,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not edit if user has category specific other access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1693,7 +1711,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1707,7 +1725,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace_1 = comfy_cms_categories(:api_namespace_1)
     api_namespace_2 = comfy_cms_categories(:api_namespace_2)
     api_namespace_3 = comfy_cms_categories(:api_namespace_3)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{api_namespace_1.label}": {full_access: 'true'}, "#{api_namespace_2.label}": {full_access: 'true'}, uncategorized: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{api_namespace_1.label}": {full_access: 'true'}, "#{api_namespace_2.label}": {full_access: 'true'}, uncategorized: {full_access: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_url(@api_namespace)
@@ -1723,7 +1741,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # UPDATE
   # API access for all_namespace
   test "should update if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
@@ -1731,7 +1749,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should update if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
@@ -1739,7 +1757,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not update if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
@@ -1753,7 +1771,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should update if user has category specific full_access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
@@ -1763,7 +1781,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should update if user has category specific full_access_api_namespace_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
@@ -1773,7 +1791,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not update if user has category specific other access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
@@ -1788,7 +1806,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
@@ -1801,7 +1819,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # DESTROY
   # API access for all_namespace
   test "should destroy if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count', -1) do
@@ -1812,7 +1830,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should destroy if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count', -1) do
@@ -1823,7 +1841,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should destroy if user has delete_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {delete_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {delete_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count', -1) do
@@ -1834,7 +1852,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not destroy if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     assert_no_difference('ApiNamespace.count') do
@@ -1851,7 +1869,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should destroy if user has category specific full_access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count', -1) do
@@ -1864,7 +1882,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should destroy if user has category specific full_access_api_namespace_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count', -1) do
@@ -1877,7 +1895,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should destroy if user has category specific delete_access_api_namespace_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {delete_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {delete_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiNamespace.count', -1) do
@@ -1890,7 +1908,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not destroy if user has category specific other access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     sign_in(@user)
     assert_no_difference('ApiNamespace.count') do
@@ -1908,7 +1926,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     assert_no_difference('ApiNamespace.count') do
@@ -1924,7 +1942,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # DISCARD_FAILED_API_ACTIONS
   # API access for all_namespace
   test "should discard_failed_api_actions if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -1939,7 +1957,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should discard_failed_api_actions if user has full_access_for_api_actions_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_actions_only: 'true'}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -1954,7 +1972,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not discard_failed_api_actions if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -1974,7 +1992,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not discard_failed_api_actions if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -1997,7 +2015,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should discard_failed_api_actions if user has category specific full_access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2014,7 +2032,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should discard_failed_api_actions if user has category specific full_access_for_api_actions_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2031,7 +2049,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not discard_failed_api_actions if user has category specific full_access_api_namespace_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2053,7 +2071,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not discard_failed_api_actions if user has category specific other access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2077,7 +2095,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2099,7 +2117,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # RERUN_FAILED_API_ACTIONS
   # API access for all_namespace
   test "should rerun_failed_api_actions if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2113,7 +2131,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should rerun_failed_api_actions if user has full_access_for_api_actions_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_actions_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_actions_only: 'true'}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2127,7 +2145,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not rerun_failed_api_actions if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2145,7 +2163,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not rerun_failed_api_actions if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2166,7 +2184,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should rerun_failed_api_actions if user has category specific full_access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2182,7 +2200,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should rerun_failed_api_actions if user has category specific full_access_for_api_actions_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_actions_only: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2198,7 +2216,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not rerun_failed_api_actions if user has category specific full_access_api_namespace_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2218,7 +2236,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not rerun_failed_api_actions if user has category specific other access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2240,7 +2258,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     failed_action = api_actions(:two)
     failed_action.update(lifecycle_stage: 'failed')
@@ -2260,7 +2278,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # EXPORT
   # API access for all_namespace
   test "should export if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     api_namespace = api_namespaces(:namespace_with_all_types)
@@ -2274,7 +2292,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should export if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     api_namespace = api_namespaces(:namespace_with_all_types)
@@ -2288,7 +2306,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should export if user has allow_exports for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {allow_exports: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_exports: 'true'}}})
 
     sign_in(@user)
     api_namespace = api_namespaces(:namespace_with_all_types)
@@ -2302,7 +2320,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not export if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     api_namespace = api_namespaces(:namespace_with_all_types)
@@ -2320,7 +2338,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace = api_namespaces(:namespace_with_all_types)
     category = comfy_cms_categories(:api_namespace_1)
     api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     stubbed_date = DateTime.new(2022, 1, 1)
@@ -2336,7 +2354,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace = api_namespaces(:namespace_with_all_types)
     category = comfy_cms_categories(:api_namespace_1)
     api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     stubbed_date = DateTime.new(2022, 1, 1)
@@ -2352,7 +2370,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace = api_namespaces(:namespace_with_all_types)
     category = comfy_cms_categories(:api_namespace_1)
     api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     sign_in(@user)
     stubbed_date = DateTime.new(2022, 1, 1)
@@ -2366,7 +2384,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should export if user has uncategorized access for the namespace with no category" do
     api_namespace = api_namespaces(:namespace_with_all_types)
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {allow_exports: 'true'}}}})
 
     sign_in(@user)
     stubbed_date = DateTime.new(2022, 1, 1)
@@ -2382,7 +2400,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace = api_namespaces(:namespace_with_all_types)
     category = comfy_cms_categories(:api_namespace_1)
     api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     stubbed_date = DateTime.new(2022, 1, 1)
@@ -2400,7 +2418,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     stubbed_date = DateTime.new(2022, 1, 1)
@@ -2415,7 +2433,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # EXPORT_API_RESOURCES
   # API access for all_namespace
   test "should export_api_resources if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     api_namespace = api_namespaces(:namespace_with_all_types)
@@ -2436,7 +2454,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should export_api_resources if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
 
     sign_in(@user)
     api_namespace = api_namespaces(:namespace_with_all_types)
@@ -2457,7 +2475,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should export_api_resources if user has allow_exports for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {allow_exports: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_exports: 'true'}}})
 
     sign_in(@user)
     api_namespace = api_namespaces(:namespace_with_all_types)
@@ -2478,7 +2496,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not export_api_resources if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     api_namespace = api_namespaces(:namespace_with_all_types)
@@ -2500,7 +2518,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace = api_namespaces(:namespace_with_all_types)
     category = comfy_cms_categories(:api_namespace_1)
     api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     resource_one = api_resources(:resource_with_all_types_one)
@@ -2523,7 +2541,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace = api_namespaces(:namespace_with_all_types)
     category = comfy_cms_categories(:api_namespace_1)
     api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     sign_in(@user)
     resource_one = api_resources(:resource_with_all_types_one)
@@ -2546,7 +2564,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace = api_namespaces(:namespace_with_all_types)
     category = comfy_cms_categories(:api_namespace_1)
     api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_exports: 'true'}}}})
 
     sign_in(@user)
     resource_one = api_resources(:resource_with_all_types_one)
@@ -2567,7 +2585,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should export_api_resources if user has uncategorized access for the namespace with no category" do
     api_namespace = api_namespaces(:namespace_with_all_types)
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {allow_exports: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {allow_exports: 'true'}}}})
 
     sign_in(@user)
     resource_one = api_resources(:resource_with_all_types_one)
@@ -2590,7 +2608,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace = api_namespaces(:namespace_with_all_types)
     category = comfy_cms_categories(:api_namespace_1)
     api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     resource_one = api_resources(:resource_with_all_types_one)
@@ -2612,7 +2630,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     resource_one = api_resources(:resource_with_all_types_one)
@@ -2631,7 +2649,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # DUPLICATE_WITHOUT_ASSOCIATIONS
   # API access for all_namespace
   test "should duplicate_without_associations if user has full_access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @api_namespace.api_form.destroy
 
     sign_in(@user)
@@ -2655,7 +2673,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should duplicate_without_associations if user has full_access_api_namespace_only for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_api_namespace_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_api_namespace_only: 'true'}}})
     @api_namespace.api_form.destroy
 
     sign_in(@user)
@@ -2679,7 +2697,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should duplicate_without_associations if user has allow_exports for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
     @api_namespace.api_form.destroy
 
     sign_in(@user)
@@ -2703,7 +2721,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "should not duplicate_without_associations if user has other access for all_namespaces" do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
     @api_namespace.api_form.destroy
 
     sign_in(@user)
@@ -2730,7 +2748,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should duplicate_without_associations if user has category specific full_access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     @api_namespace.api_form.destroy
 
@@ -2757,7 +2775,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should duplicate_without_associations if user has category specific full_access_api_namespace_only for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_api_namespace_only: 'true'}}}})
 
     @api_namespace.api_form.destroy
 
@@ -2784,7 +2802,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should duplicate_without_associations if user has category specific allow_exports for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     @api_namespace.api_form.destroy
 
@@ -2810,7 +2828,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "should duplicate_without_associations if user has uncategorized access for the namespace with no category" do
     api_namespace = api_namespaces(:namespace_with_all_types)
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {allow_duplication: 'true'}}}})
 
     @api_namespace.api_form.destroy
 
@@ -2837,7 +2855,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   test "should not duplicate_without_associations if user has category specific other access for the namespace" do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     @api_namespace.api_form.destroy
 
@@ -2866,7 +2884,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     category_2 = comfy_cms_categories(:api_namespace_2)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category_2.label}": {full_access: 'true'}}}})
 
     @api_namespace.api_form.destroy
 
@@ -2894,8 +2912,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
   # API access for all_namespaces
   test 'social_share_metadata# should return success when the user has full_access/full_access_for_api_namespace_only/allow_social_share_metadata for all_namespaces' do
     ['full_access', 'full_access_api_namespace_only', 'allow_social_share_metadata'].each do |access_name|
-      access = {all_namespaces: {}}
-      access[:all_namespaces][access_name] = 'true'
+      access = {api_namespaces: {all_namespaces: {}}}
+      access[:api_namespaces][:all_namespaces][access_name] = 'true'
       @user.update!(api_accessibility: access)
 
       payload = {api_namespace: {"social_share_metadata"=>{"title"=>"Array", "description"=>"String", "image"=>"picto"}}}
@@ -2912,8 +2930,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test 'social_share_metadata# should deny when the user has other access like full_read_access/delete_access_api_namespace_only/allow_exports/allow_duplication/full_access_for_api_resources_only/full_access_for_api_actions_only/full_access_for_external_api_connections_only/full_access_for_api_clients_only/full_access_for_api_form_only for all_namespaces' do
     ['full_read_access', 'delete_access_api_namespace_only', 'allow_exports', 'allow_duplication', 'full_access_for_api_resources_only', 'full_access_for_api_actions_only', 'full_access_for_external_api_connections_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {all_namespaces: {}}
-      access[:all_namespaces][access_name] = 'true'
+      access = {api_namespaces: {all_namespaces: {}}}
+      access[:api_namespaces][:all_namespaces][access_name] = 'true'
       @user.update!(api_accessibility: access)
 
       payload = {api_namespace: {"social_share_metadata"=>{"title"=>"Array", "description"=>"String", "image"=>"picto"}}}
@@ -2934,8 +2952,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     ['full_access', 'full_access_api_namespace_only', 'allow_social_share_metadata'].each do |access_name|
-      access = {namespaces_by_category: {"#{category.label}": {}}}
-      access[:namespaces_by_category][:"#{category.label}"][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {"#{category.label}": {}}}}
+      access[:api_namespaces][:namespaces_by_category][:"#{category.label}"][access_name] = 'true'
       @user.update!(api_accessibility: access)
 
       payload = {api_namespace: {"social_share_metadata"=>{"title"=>"Array", "description"=>"String", "image"=>"picto"}}}
@@ -2955,8 +2973,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     ['full_read_access', 'delete_access_api_namespace_only', 'allow_exports', 'allow_duplication', 'full_access_for_api_resources_only', 'full_access_for_api_actions_only', 'full_access_for_external_api_connections_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {namespaces_by_category: {"#{category.label}": {}}}
-      access[:namespaces_by_category][:"#{category.label}"][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {"#{category.label}": {}}}}
+      access[:api_namespaces][:namespaces_by_category][:"#{category.label}"][access_name] = 'true'
       @user.update!(api_accessibility: access)
 
       payload = {api_namespace: {"social_share_metadata"=>{"title"=>"Array", "description"=>"String", "image"=>"picto"}}}
@@ -2973,8 +2991,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test 'social_share_metadata# should return success when the user has uncategorized full_access/full_access_for_api_namespace_only/allow_social_share_metadata for a namespace' do
     ['full_access', 'full_access_api_namespace_only', 'allow_social_share_metadata'].each do |access_name|
-      access = {namespaces_by_category: {uncategorized: {}}}
-      access[:namespaces_by_category][:uncategorized][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {uncategorized: {}}}}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized][access_name] = 'true'
       @user.update!(api_accessibility: access)
 
       payload = {api_namespace: {"social_share_metadata"=>{"title"=>"Array", "description"=>"String", "image"=>"picto"}}}
@@ -2994,8 +3012,8 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     @api_namespace.update(category_ids: [category.id])
 
     ['full_read_access', 'delete_access_api_namespace_only', 'allow_exports', 'allow_duplication', 'full_access_for_api_resources_only', 'full_access_for_api_actions_only', 'full_access_for_external_api_connections_only', 'full_access_for_api_clients_only', 'full_access_for_api_form_only'].each do |access_name|
-      access = {namespaces_by_category: {uncategorized: {}}}
-      access[:namespaces_by_category][:uncategorized][access_name] = 'true'
+      access = {api_namespaces: {namespaces_by_category: {uncategorized: {}}}}
+      access[:api_namespaces][:namespaces_by_category][:uncategorized][access_name] = 'true'
       @user.update!(api_accessibility: access)
 
       payload = {api_namespace: {"social_share_metadata"=>{"title"=>"Array", "description"=>"String", "image"=>"picto"}}}

--- a/test/controllers/admin/comfy/api_resources_controller_test.rb
+++ b/test/controllers/admin/comfy/api_resources_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:public)
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @api_namespace = api_namespaces(:one)
     @api_resource = api_resources(:one)
 
@@ -17,7 +17,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "deny new if not permissioned" do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
     sign_in(@user)
     get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
     assert_response :redirect
@@ -114,7 +114,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   # SHOW
   # API access for all namespaces
   test 'should get show if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -122,7 +122,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has full_read_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -130,7 +130,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has full_access_for_api_resources_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -138,7 +138,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has read_api_resources_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_resources_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -146,7 +146,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get show if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -160,7 +160,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -170,7 +170,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_read_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -180,7 +180,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has full_access_for_api_resources_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -190,7 +190,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get show if user has read_api_resources_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -198,7 +198,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get show if user has read_api_resources_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {read_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {read_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -208,7 +208,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should not get show if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -221,7 +221,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   # NEW
   # API access for all_namespaces
   test 'should get new if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
@@ -229,7 +229,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get new if user has full_access_for_api_resources_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
@@ -237,7 +237,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get new if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_resources_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
@@ -251,7 +251,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get new if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
@@ -261,7 +261,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get new if user has full_access_for_api_resources_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
@@ -269,7 +269,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get new if user has read_api_resources_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
@@ -279,7 +279,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should not get new if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
@@ -292,7 +292,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   # EDIT
   # API access for all_namespaces
   test 'should get edit if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -300,7 +300,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit if user has full_access_for_api_resources_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -308,7 +308,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get edit if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_resources_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -322,7 +322,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -332,7 +332,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get edit if user has full_access_for_api_resources_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -340,7 +340,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit if user has read_api_resources_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -350,7 +350,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should not get edit if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_resource_url(api_namespace_id: @api_namespace.id, id: @api_namespace.api_resources.sample.id)
@@ -363,7 +363,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   # UPDATE
   # API access for all_namespaces
   test 'should get update if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     perform_enqueued_jobs do
@@ -374,7 +374,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get update if user has full_access_for_api_resources_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     perform_enqueued_jobs do
@@ -385,7 +385,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not get update if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_resources_only: 'true'}}})
 
     sign_in(@user)
     perform_enqueued_jobs do
@@ -402,7 +402,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get update if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     perform_enqueued_jobs do
@@ -415,7 +415,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should get update if user has full_access_for_api_resources_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     perform_enqueued_jobs do
@@ -426,7 +426,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get update if user has read_api_resources_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     perform_enqueued_jobs do
@@ -439,7 +439,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should not get update if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     perform_enqueued_jobs do
@@ -455,7 +455,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   # DESTROY
   # API access for all_namespaces
   test 'should destroy if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiResource.count', -1) do
@@ -465,7 +465,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy if user has full_access_for_api_resources_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiResource.count', -1) do
@@ -475,7 +475,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy if user has delete_access_for_api_resources_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {delete_access_for_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {delete_access_for_api_resources_only: 'true'}}})
 
     sign_in(@user)
     assert_difference('ApiResource.count', -1) do
@@ -485,7 +485,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not destroy if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_api_resources_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_api_resources_only: 'true'}}})
 
     sign_in(@user)
     assert_no_difference('ApiResource.count') do
@@ -502,7 +502,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should destroy if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiResource.count', -1) do
@@ -514,7 +514,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should destroy if user has full_access_for_api_resources_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiResource.count', -1) do
@@ -524,7 +524,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy if user has delete_access_for_api_resources_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {delete_access_for_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {delete_access_for_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     assert_difference('ApiResource.count', -1) do
@@ -536,7 +536,7 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
   test 'should not destroy if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_api_resources_only: 'true'}}}})
 
     sign_in(@user)
     assert_no_difference('ApiResource.count') do

--- a/test/controllers/admin/comfy/external_api_clients_controller_test.rb
+++ b/test/controllers/admin/comfy/external_api_clients_controller_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:public)
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @api_client = api_clients(:one)
     @api_namespace = api_namespaces(:one)
     @external_api_client = external_api_clients(:test)
@@ -588,7 +588,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # SHOW
   # API access for all namespaces
   test 'should get show if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -597,7 +597,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get show if user has full_read_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -606,7 +606,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get show if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -615,7 +615,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get show if user has read_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -624,7 +624,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not get show if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -639,7 +639,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get show if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -650,7 +650,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get show if user has full_read_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -661,7 +661,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get show if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -672,7 +672,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get show if user has read_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -681,7 +681,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get show if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {read_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -692,7 +692,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not get show if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -706,7 +706,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # INDEX
   # API access for all namespaces
   test 'should get index if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -714,7 +714,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get index if user has full_read_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_read_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_read_access: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -722,7 +722,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get index if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -730,7 +730,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get index if user has read_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -738,7 +738,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not get index if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {allow_duplication: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {allow_duplication: 'true'}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -752,7 +752,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get index if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -762,7 +762,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get index if user has full_read_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_read_access: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -772,7 +772,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get index if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -782,7 +782,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get index if user has read_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -790,7 +790,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get index if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {read_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -800,7 +800,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not get index if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {allow_duplication: 'true'}}}})
 
     sign_in(@user)
     get api_namespace_external_api_clients_path(api_namespace_id: @api_namespace.id)
@@ -813,7 +813,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # NEW
   # API access for all_namespaces
   test 'should get new if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id)
@@ -821,7 +821,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get new if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id)
@@ -829,7 +829,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not get new if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     get new_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id)
@@ -843,7 +843,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get new if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id)
@@ -853,7 +853,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get new if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id)
@@ -861,7 +861,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get new if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id)
@@ -871,7 +871,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not get new if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get new_api_namespace_external_api_client_path(api_namespace_id: @api_namespace.id)
@@ -884,7 +884,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # EDIT
   # API access for all_namespaces
   test 'should get edit if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -892,7 +892,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get edit if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -900,7 +900,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not get edit if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     get edit_api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -914,7 +914,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get edit if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -924,7 +924,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get edit if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -932,7 +932,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get edit if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -942,7 +942,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not get edit if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     get edit_api_namespace_external_api_client_url(api_namespace_id: @api_namespace.id, id: @external_api_client.id)
@@ -955,7 +955,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # CREATE
   # API access for all_namespaces
   test 'should get create if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     payload = {
       external_api_client: {
@@ -993,7 +993,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get create if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
 
     payload = {
       external_api_client: {
@@ -1031,7 +1031,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not get create if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
 
     payload = {
       external_api_client: {
@@ -1073,7 +1073,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get create if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     payload = {
       external_api_client: {
@@ -1113,7 +1113,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get create if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
 
     payload = {
       external_api_client: {
@@ -1151,7 +1151,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get create if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
 
     payload = {
       external_api_client: {
@@ -1191,7 +1191,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not get create if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
 
     payload = {
       external_api_client: {
@@ -1231,7 +1231,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # UPDATE
   # API access for all_namespaces
   test 'should get update if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     payload = {
       external_api_client: {
@@ -1267,7 +1267,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get update if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
 
     payload = {
       external_api_client: {
@@ -1303,7 +1303,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not get update if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
 
     payload = {
       external_api_client: {
@@ -1343,7 +1343,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get update if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     payload = {
       external_api_client: {
@@ -1381,7 +1381,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should get update if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
 
     payload = {
       external_api_client: {
@@ -1417,7 +1417,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should get update if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
 
     payload = {
       external_api_client: {
@@ -1455,7 +1455,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not get update if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
 
     payload = {
       external_api_client: {
@@ -1494,7 +1494,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # DESTROY
   # API access for all_namespaces
   test 'should destroy if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
 
@@ -1509,7 +1509,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should destroy if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
 
@@ -1524,7 +1524,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not destroy if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
 
@@ -1541,7 +1541,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should destroy if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
 
@@ -1558,7 +1558,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should destroy if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
 
@@ -1573,7 +1573,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should destroy if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
 
@@ -1590,7 +1590,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not destroy if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
 
@@ -1606,7 +1606,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # START
   # API access for all_namespaces
   test 'should start if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
@@ -1617,7 +1617,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should start if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
@@ -1628,7 +1628,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not start if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
 
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
@@ -1645,7 +1645,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should start if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
 
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
@@ -1658,7 +1658,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should start if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
@@ -1669,7 +1669,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should start if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
@@ -1682,7 +1682,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not start if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
 
     sign_in(@user)
     @external_api_client.update(status: ExternalApiClient::STATUSES[:stopped], enabled: true)
@@ -1698,7 +1698,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # STOP
   # API access for all_namespaces
   test 'should stop if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:running])
 
     sign_in(@user)
@@ -1708,7 +1708,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should stop if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:running])
 
     sign_in(@user)
@@ -1718,7 +1718,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not stop if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:running])
 
     sign_in(@user)
@@ -1734,7 +1734,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should stop if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:running])
 
     sign_in(@user)
@@ -1746,7 +1746,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should stop if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:running])
 
     sign_in(@user)
@@ -1756,7 +1756,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should stop if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:running])
 
     sign_in(@user)
@@ -1768,7 +1768,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not stop if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:running])
 
     sign_in(@user)
@@ -1783,7 +1783,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # CLEAR_ERRORS
   # API access for all_namespaces
   test 'should clear_errors if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:error], error_message: 'test error message', retries: 3, error_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1798,7 +1798,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should clear_errors if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:error], error_message: 'test error message', retries: 3, error_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1813,7 +1813,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not clear_errors if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:error], error_message: 'test error message', retries: 3, error_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1834,7 +1834,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should clear_errors if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:error], error_message: 'test error message', retries: 3, error_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1851,7 +1851,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should clear_errors if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:error], error_message: 'test error message', retries: 3, error_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1866,7 +1866,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should clear_errors if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:error], error_message: 'test error message', retries: 3, error_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1883,7 +1883,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not clear_errors if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
     @external_api_client.update(status: ExternalApiClient::STATUSES[:error], error_message: 'test error message', retries: 3, error_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1903,7 +1903,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   # CLEAR_STATE
   # API access for all_namespaces
   test 'should clear_state if user has full_access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     @external_api_client.update(state_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1915,7 +1915,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should clear_state if user has full_access_for_external_api_connections_only for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access_for_external_api_connections_only: 'true'}}})
     @external_api_client.update(state_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1927,7 +1927,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should not clear_state if user has other access for all namespace' do
-    @user.update(api_accessibility: {all_namespaces: {read_external_api_connections_only: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {read_external_api_connections_only: 'true'}}})
     @external_api_client.update(state_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1945,7 +1945,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should clear_state if user has full_access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access: 'true'}}}})
     @external_api_client.update(state_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1959,7 +1959,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should clear_state if user has full_access_for_external_api_connections_only for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {full_access_for_external_api_connections_only: 'true'}}}})
     @external_api_client.update(state_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1971,7 +1971,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   end
 
   test 'should clear_state if user has read_external_api_connections_only for the uncategorized namespace' do
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access_for_external_api_connections_only: 'true'}}}})
     @external_api_client.update(state_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)
@@ -1985,7 +1985,7 @@ class Comfy::Admin::ExternalApiClientsControllerTest < ActionDispatch::Integrati
   test 'should not clear_state if user has other access for the namespace' do
     category = comfy_cms_categories(:api_namespace_1)
     @api_namespace.update(category_ids: [category.id])
-    @user.update(api_accessibility: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{category.label}": {read_external_api_connections_only: 'true'}}}})
     @external_api_client.update(state_metadata: { 'testKey': 'testMessage'})
 
     sign_in(@user)

--- a/test/controllers/api/external_api_clients_controller_test.rb
+++ b/test/controllers/api/external_api_clients_controller_test.rb
@@ -1,0 +1,168 @@
+require "test_helper"
+
+class Api::ExternalApiClientsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @external_api_client = external_api_clients(:webhook_drive_strategy)
+    @api_namespace = @external_api_client.api_namespace
+  end
+
+  test '#webhook: should return success response if webhook verification not required' do
+    post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {},  as: :json
+    assert_response :success
+  end
+
+  test '#webhook: should unload class after webhook request' do
+    post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {},  as: :json
+    assert_response :success
+
+    refute Object.const_defined?('ExternalApiClient::ExternalApiModelExample')
+  end
+
+  test '#webhook: should be able to render custom response' do
+    model_definition = "
+      class ExternalApiModelExample
+        def initialize(parameters)
+          @external_api_client = parameters[:external_api_client]
+        end
+
+        def start
+          render json: { a: 'b' }
+        end
+      end
+
+      ExternalApiModelExample
+    "
+
+    @external_api_client.update(model_definition: model_definition)
+    post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {},  as: :json
+    
+    assert_response :success
+    assert_equal({"a"=>"b"} , response.parsed_body)
+  end
+
+  test '#webhook: should be able to render custom status code' do
+    model_definition = "
+      class ExternalApiModelExample
+        def initialize(parameters)
+          @external_api_client = parameters[:external_api_client]
+        end
+
+        def start
+          render json: { a: 'b' }, status: 400 
+        end
+      end
+
+      ExternalApiModelExample
+    "
+
+    @external_api_client.update(model_definition: model_definition)
+    post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {},  as: :json
+    
+    assert_response 400
+    assert_equal({"a" =>"b"}, response.parsed_body)
+  end
+
+  test '#webhook: should return 204 if render method not called' do
+    model_definition = "
+      class ExternalApiModelExample
+        def initialize(parameters)
+          @external_api_client = parameters[:external_api_client]
+        end
+
+        def start
+          { a: 'b' }
+        end
+      end
+
+      ExternalApiModelExample
+    "
+
+    @external_api_client.update(model_definition: model_definition)
+    post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {},  as: :json
+    
+    assert_response 204
+  end
+
+  test '#webhook: route should not exist if drive strategy id not webhook' do
+    @external_api_client.update(drive_strategy: 'on_demand')
+    assert_raises ActionController::RoutingError do
+      post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {},  as: :json
+    end
+  end
+
+  test '#webhook: should return error unless api client is enabled' do
+    @external_api_client.update(enabled: false)
+    post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {},  as: :json
+    assert_response 400
+    assert_equal({ 'message' => 'Webhook not enabled', 'success' => false }, JSON.parse(response.body))
+  end
+
+  test '#webhook - stripe: should return success response if webhook verification required and webhook verfied' do
+    WebhookVerificationMethod.create(webhook_type: 'stripe', external_api_client_id: @external_api_client.id, webhook_secret: 'secret')
+    Webhook::Verification.any_instance.stubs(:call).returns([true, 'success'])
+
+    assert_difference "@api_namespace.api_resources.reload.count", +1 do
+      post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: { type: 'customer.created' },  as: :json
+    end
+    assert_response :success
+
+    assert_no_difference "@api_namespace.api_resources.reload.count" do
+      post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: { type: 'customer.removed' },  as: :json
+    end
+    assert_response :success
+  end
+
+  test '#webhook - stripe: should return error response if webhook verification required and webhook verfication failed' do
+    WebhookVerificationMethod.create(webhook_type: 'stripe', external_api_client_id: @external_api_client.id, webhook_secret: 'secret')
+    Webhook::Verification.any_instance.stubs(:call).returns([false, 'error message'])
+
+    post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {},  as: :json
+
+    assert_response 401
+    assert_equal({ 'message' => 'error message', 'success' => false }, JSON.parse(response.body))
+  end
+
+  test '#webhook - custom: should return success response if webhook verification required and webhook verified' do
+    WebhookVerificationMethod.create(
+      webhook_type: 'custom',
+      external_api_client_id: @external_api_client.id,
+      webhook_secret: 'secret',
+      custom_method_definition: "
+      if request.headers['Authorization'] == verification_method.webhook_secret
+        [true, 'Verification Success']
+      else
+        [false, 'Invalid Authorization Token']
+      end"
+    )
+
+    assert_difference "@api_namespace.api_resources.reload.count", +1 do
+      post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: { type: 'customer.created' }, headers: { 'Authorization': 'secret' }, as: :json
+    end
+    assert_response :success
+
+    assert_no_difference "@api_namespace.api_resources.reload.count" do
+      post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: { type: 'customer.removed' }, headers: { 'Authorization': 'secret' }, as: :json
+    end
+    assert_response :success
+  end
+
+
+  test '#webhook - custom: should return error response if webhook verification required and webhook verfication failed' do
+    WebhookVerificationMethod.create(
+      webhook_type: 'custom',
+      external_api_client_id: @external_api_client.id,
+      webhook_secret: 'secret',
+      custom_method_definition: "
+      if request.headers['Authorization'] == verification_method.webhook_secret
+        [true, 'Verification Success']
+      else
+        [false, 'Invalid Authorization Token']
+      end"
+    )
+
+    post api_external_api_client_webhook_url(version: @api_namespace.version, api_namespace: @api_namespace.slug, external_api_client: @external_api_client.slug), params: {}, headers: { 'Authorization': 'not secret' }, as: :json
+
+    assert_response 401
+    assert_equal({ 'message' => 'Invalid Authorization Token', 'success' => false }, JSON.parse(response.body))
+  end
+end

--- a/test/controllers/api/resource_controller_test.rb
+++ b/test/controllers/api/resource_controller_test.rb
@@ -145,7 +145,7 @@ class Api::ResourceControllerTest < ActionDispatch::IntegrationTest
 
   test '#create access is allowed if bearer authentication is provided' do
     @users_namespace.update(requires_authentication: true)
-    api_client = api_clients(:for_users)
+    api_key = api_keys(:for_users)
     payload = {
       data: {
         first_name: 'Don',
@@ -153,13 +153,13 @@ class Api::ResourceControllerTest < ActionDispatch::IntegrationTest
       }
     }
     assert_difference "@users_namespace.api_resources.count", +1 do
-      post api_create_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug), params: payload, headers: { 'Authorization': "Bearer #{api_client.bearer_token}" }
+      post api_create_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug), params: payload, headers: { 'Authorization': "Bearer #{api_key.token}" }
     end
     assert_equal [:status, :code, :object].sort, response.parsed_body.symbolize_keys.keys.sort
     assert_equal payload[:data].keys.sort, response.parsed_body["object"]["data"]["attributes"]["properties"].symbolize_keys.keys.sort
 
     assert_no_difference "@users_namespace.api_resources.count", +1 do
-      post api_create_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug), headers: { 'Authorization': "Bearer #{api_client.bearer_token}" }
+      post api_create_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug), headers: { 'Authorization': "Bearer #{api_key.token}" }
     end
     assert_equal [:status, :code].sort, response.parsed_body.symbolize_keys.keys.sort
     assert_equal response.parsed_body["status"], "Please make sure that your parameters are provided under a data: {} top-level key"
@@ -167,7 +167,7 @@ class Api::ResourceControllerTest < ActionDispatch::IntegrationTest
 
   test 'doesnot create allow #create if required property is missing' do
     @users_namespace.update(requires_authentication: true)
-    api_client = api_clients(:for_users)
+    api_key = api_keys(:for_users)
     ApiForm.create(api_namespace_id: @users_namespace.id, properties: { 'name': {'label': 'Test', 'placeholder': 'Test', 'field_type': 'input', 'required': '1' }})
     payload = {
       data: {
@@ -175,7 +175,7 @@ class Api::ResourceControllerTest < ActionDispatch::IntegrationTest
       }
     }
     assert_no_difference "@users_namespace.api_resources.count" do
-      post api_create_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug), params: payload, headers: { 'Authorization': "Bearer #{api_client.bearer_token}" }
+      post api_create_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug), params: payload, headers: { 'Authorization': "Bearer #{api_key.token}" }
     end
 
     assert_equal response.parsed_body["code"], 400
@@ -184,7 +184,7 @@ class Api::ResourceControllerTest < ActionDispatch::IntegrationTest
 
   test '#update access is allowed if bearer authentication is provided' do
     @users_namespace.update(requires_authentication: true)
-    api_client = api_clients(:for_users)
+    api_key = api_keys(:for_users)
     payload = {
       data: {
         first_name: 'Don!',
@@ -194,25 +194,25 @@ class Api::ResourceControllerTest < ActionDispatch::IntegrationTest
     api_resource = @users_namespace.api_resources.first
     assert_not_equal api_resource.properties["first_name"], payload[:data][:first_name]
     cloned_before_state = api_resource.dup
-    patch api_update_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug, api_resource_id: api_resource.id), params: payload, headers: { 'Authorization': "Bearer #{api_client.bearer_token}" }
+    patch api_update_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug, api_resource_id: api_resource.id), params: payload, headers: { 'Authorization': "Bearer #{api_key.token}" }
     assert_equal [:status, :code, :object, :before].sort, response.parsed_body.symbolize_keys.keys.sort
     assert_equal api_resource.reload.properties["first_name"], response.parsed_body["object"]["data"]["attributes"]["properties"]["first_name"]
     assert_equal cloned_before_state.properties["first_name"], response.parsed_body["before"]["data"]["attributes"]["properties"]["first_name"]
     assert_equal payload[:data].keys.sort, response.parsed_body["object"]["data"]["attributes"]["properties"].symbolize_keys.keys.sort
 
-    patch api_update_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug, api_resource_id: api_resource.id), headers: { 'Authorization': "Bearer #{api_client.bearer_token}" }
+    patch api_update_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug, api_resource_id: api_resource.id), headers: { 'Authorization': "Bearer #{api_key.token}" }
     assert_equal response.parsed_body["status"], "Please make sure that your parameters are provided under a data: {} top-level key"
   end
 
   test '#destroy access is allowed if bearer authentication is provided' do
     @users_namespace.update(requires_authentication: true)
-    api_client = api_clients(:for_users)
+    api_key = api_keys(:for_users)
     assert_difference "@users_namespace.api_resources.count", -1 do
-      delete api_destroy_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug, api_resource_id: @users_namespace.api_resources.first.id), headers: { 'Authorization': "Bearer #{api_client.bearer_token}" }
+      delete api_destroy_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug, api_resource_id: @users_namespace.api_resources.first.id), headers: { 'Authorization': "Bearer #{api_key.token}" }
     end
     assert_equal [:status, :code, :object].sort, response.parsed_body.symbolize_keys.keys.sort
 
-    delete api_destroy_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug, api_resource_id: 42), headers: { 'Authorization': "Bearer #{api_client.bearer_token}" }
+    delete api_destroy_resource_url(version: @users_namespace.version, api_namespace: @users_namespace.slug, api_resource_id: 42), headers: { 'Authorization': "Bearer #{api_key.token}" }
     assert_equal response.parsed_body["code"], 404
   end
 

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -219,7 +219,7 @@ class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
       assert_redirected_to api_namespace_url(subdomain: @restarone_subdomain.name, id: api_namespace.id)
 
       # The response will be success if the user is properly permissioned
-      @restarone_user.update!(api_accessibility: {all_namespaces: {full_access: 'true'}})
+      @restarone_user.update!(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
       sign_in(@restarone_user)
       get api_namespace_url(subdomain: @restarone_subdomain.name, id: api_namespace.id)
       assert_response :success

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -1,0 +1,16 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  slug: MyString
+  label: MyString
+  authentication_strategy: 'bearer_token'
+
+two:
+  slug: MyString
+  label: MyString
+  authentication_strategy: bearer_token
+
+for_users:
+  slug: MyString
+  label: MyString
+  authentication_strategy: bearer_token

--- a/test/fixtures/api_namespace_keys.yml
+++ b/test/fixtures/api_namespace_keys.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  api_namespace: one
+  api_key: one
+
+two:
+  api_namespace: two
+  api_key: two
+
+for_users:
+  api_namespace: users
+  api_key: for_users

--- a/test/fixtures/external_api_clients.yml
+++ b/test/fixtures/external_api_clients.yml
@@ -592,3 +592,35 @@ transcript_parser_plugin:
     end
     # at the end of the file we have to implicitly return the class
     TranscriptParser
+
+webhook_drive_strategy:
+  api_namespace: two
+  slug: test-webhook-drive-strategy
+  label: Test Webhook Drive Strategy
+  enabled: true
+  metadata: {}
+  drive_strategy: 'webhook'
+  model_definition: |
+    class ExternalApiModelExample
+      def initialize(parameters)
+        @external_api_client = parameters[:external_api_client]
+        @payload = parameters[:request]&.request_parameters
+      end
+  
+      def start
+        if @payload['type'] == 'customer.created'
+          @external_api_client.api_namespace.api_resources.create(
+            properties: {
+              request_body: @payload
+            }
+          )
+          render json: { success: true }
+        end
+      end
+
+      def log
+        return true
+      end
+    end
+    
+    ExternalApiModelExample

--- a/test/fixtures/webhook_verification_methods.yml
+++ b/test/fixtures/webhook_verification_methods.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  external_api_client: one
+  webhook_type: MyString
+
+two:
+  external_api_client: two
+  webhook_type: MyString

--- a/test/helpers/api_accessibility_helper_test.rb
+++ b/test/helpers/api_accessibility_helper_test.rb
@@ -6,49 +6,49 @@ class ApiAccessibilityHelperTest < ActionView::TestCase
   end
 
   test 'should return true/false accordingly if the user has/has not some access in the provided category' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     assert has_access_to_main_category?(@user.api_accessibility, 'all_namespaces')
     refute has_access_to_main_category?(@user.api_accessibility, 'namespaces_by_category')
   end
 
   test 'should return true/false accordingly if the user has/has not some access in the specific category' do
-    @user.update(api_accessibility: {namespaces_by_category: {test_1: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {test_1: {full_access: 'true'}}}})
 
     assert has_access_to_specific_category?(@user.api_accessibility, 'test_1')
     refute has_access_to_specific_category?(@user.api_accessibility, 'test_2')
   end
 
   test 'should return true/false accordingly if the user has/has not some sub-access in the specific category' do
-    @user.update(api_accessibility: {namespaces_by_category: {test_1: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {test_1: {full_access: 'true'}}}})
 
     assert has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'test_1')
     refute has_sub_access_to_specific_category?(@user.api_accessibility, 'full_access', 'namespaces_by_category', 'test_2')
   end
 
   test 'should return true/false accordingly if the user has no any sub-access in the specific category' do
-    @user.update(api_accessibility: {namespaces_by_category: {test_1: {full_access: 'true'}, test_2: {}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {test_1: {full_access: 'true'}, test_2: {}}}})
 
     assert has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'test_1')
     refute has_no_sub_access_to_specific_category?(@user.api_accessibility, 'namespaces_by_category', 'test_2')
   end
 
   test 'should return true/false accordingly if the user has only uncategorized access or not' do
-    @user.update(api_accessibility: {namespaces_by_category: {test_1: {full_access: 'true'}, test_2: {}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {test_1: {full_access: 'true'}, test_2: {}}}})
     refute has_only_uncategorized_access?(@user.api_accessibility)
 
-    @user.update(api_accessibility: {namespaces_by_category: {test_1: {full_access: 'true'}, uncategorized: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {test_1: {full_access: 'true'}, uncategorized: {full_access: 'true'}}}})
     refute has_only_uncategorized_access?(@user.api_accessibility)
 
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     refute has_only_uncategorized_access?(@user.api_accessibility)
 
-    @user.update(api_accessibility: {namespaces_by_category: {uncategorized: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {uncategorized: {full_access: 'true'}}}})
     assert has_only_uncategorized_access?(@user.api_accessibility)
   end
 
   test 'should return all categories if the user has access all_namespaces' do
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
 
     api_namespace_1 = comfy_cms_categories(:api_namespace_1)
     api_namespace_2 = comfy_cms_categories(:api_namespace_2)
@@ -65,7 +65,7 @@ class ApiAccessibilityHelperTest < ActionView::TestCase
     api_namespace_1 = comfy_cms_categories(:api_namespace_1)
     api_namespace_2 = comfy_cms_categories(:api_namespace_2)
     api_namespace_3 = comfy_cms_categories(:api_namespace_3)
-    @user.update(api_accessibility: {namespaces_by_category: {"#{api_namespace_1.label}": {full_access: 'true'}, "#{api_namespace_2.label}": {full_access: 'true'}, uncategorized: {full_access: 'true'}}})
+    @user.update(api_accessibility: {api_namespaces: {namespaces_by_category: {"#{api_namespace_1.label}": {full_access: 'true'}, "#{api_namespace_2.label}": {full_access: 'true'}, uncategorized: {full_access: 'true'}}}})
 
 
     filtered_categories = filter_categories_by_api_accessibility(@user.api_accessibility, Comfy::Cms::Category.of_type('ApiNamespace'))

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class ApiKeyTest < ActiveSupport::TestCase
+  test "should create token before save" do
+    api_key = ApiKey.new(authentication_strategy: 'bearer_token', label: 'test')
+    refute api_key.token
+
+    api_key.save!
+    assert api_key.token
+  end
+
+  test "should not update token if token already exist" do
+    api_key = ApiKey.new(authentication_strategy: 'bearer_token', label: 'test', token: 'test')
+    assert_equal 'test', api_key.token
+
+    api_key.save!
+    assert_equal 'test', api_key.token
+  end
+end

--- a/test/models/api_namespace_key_test.rb
+++ b/test/models/api_namespace_key_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ApiNamespaceKeyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/webhook_verification_method_test.rb
+++ b/test/models/webhook_verification_method_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class WebhookVerificationMethodTest < ActiveSupport::TestCase
+  setup do
+    @external_api_client = external_api_clients(:webhook_drive_strategy)
+  end
+
+  test 'should be invalid if users private attributes are accessed' do
+    User::PRIVATE_ATTRIBUTES.each do |private_attr|
+      webhook_verification_method = WebhookVerificationMethod.new(webhook_type: 'custom', external_api_client_id: @external_api_client.id, webhook_secret: 'secret', custom_method_definition: "User.last.#{private_attr}")
+      refute webhook_verification_method.valid?
+      assert_includes webhook_verification_method.errors.messages[:custom_method_definition].to_s, 'contains disallowed keyword'
+    end
+  end
+
+  test 'should be invalid if users permissions are referenced' do
+    User::FULL_PERMISSIONS.keys.each do |permission_attr|
+      webhook_verification_method = WebhookVerificationMethod.new(webhook_type: 'custom', external_api_client_id: @external_api_client.id, webhook_secret: 'secret', custom_method_definition: "User.last.update(#{permission_attr} => false)")
+      refute webhook_verification_method.valid?
+      assert_includes webhook_verification_method.errors.messages[:custom_method_definition].to_s, 'contains disallowed keyword'
+    end
+  end
+
+  test 'should be invalid if blacklisted keywords are present' do
+    invalid_model_definations = [
+      'Subdomain.destroy_all',
+      'exit()',
+      'subdomain.constantize.last.update(id: 1)',
+      'eval("1 + 1")',
+      'User.last.update(can_manage_users: true)',
+      'User.send(:new)',
+      '#{User.destroy_all}'
+    ]
+
+    invalid_model_definations.each do |invalid_executable|
+      webhook_verification_method = WebhookVerificationMethod.new(webhook_type: 'custom', external_api_client_id: @external_api_client.id, webhook_secret: 'secret', custom_method_definition: invalid_executable)
+      refute webhook_verification_method.valid?
+      assert_includes webhook_verification_method.errors.messages[:custom_method_definition].to_s, 'contains disallowed keyword'
+    end
+  end
+end

--- a/test/plugins/bishop_monitoring_plugin_test.rb
+++ b/test/plugins/bishop_monitoring_plugin_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class BishopMonitoringPluginTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:public)
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
   end
 
   test "#BishopMonitoring: sends HTTP request and does not log incident (resource creation + email) if HTTP endpoint error does not occur" do

--- a/test/plugins/bishop_tls_monitoring_plugin_test.rb
+++ b/test/plugins/bishop_tls_monitoring_plugin_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class BishopTlsMonitoringPluginTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:public)
-    @user.update(api_accessibility: {all_namespaces: {full_access: 'true'}})
+    @user.update(api_accessibility: {api_namespaces: {all_namespaces: {full_access: 'true'}}})
     WebMock.allow_net_connect!(net_http_connect_on_start: true)
   end
 

--- a/test/services/webhook/verification_method/custom_test.rb
+++ b/test/services/webhook/verification_method/custom_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Webhook::VerificationMethod::StripeTest < ActiveSupport::TestCase
+  setup do
+    @external_api_client = external_api_clients(:webhook_drive_strategy)
+    @request = ActionDispatch::Request.new({ "REQUEST_METHOD" => "POST", "HTTP_STRIPE_SIGNATURE" => "dummy_signature", "RAW_POST_DATA" => "{}" }) 
+    @webhook_verification_method = WebhookVerificationMethod.create(
+      webhook_type: 'custom',
+      external_api_client_id: @external_api_client.id,
+      webhook_secret: 'secret',
+      custom_method_definition: "
+      if request.headers['Authorization'] == verification_method.webhook_secret
+        [true, 'Verification Success']
+      else
+        [false, 'Invalid Authorization Token']
+      end"
+    ) 
+  end
+
+  test '#call: should return success' do
+    @request.headers["Authorization"] = 'secret'
+
+    response = Webhook::VerificationMethod::Custom.new(@request, @webhook_verification_method).call
+
+    assert_equal([true, 'Verification Success'], response)
+  end
+
+  test '#call: should return error message' do
+    @request.headers["Authorization"] = 'not secret'
+
+    response = Webhook::VerificationMethod::Custom.new(@request, @webhook_verification_method).call
+
+    assert_equal([false, 'Invalid Authorization Token'], response)
+  end
+end

--- a/test/services/webhook/verification_method/stripe_test.rb
+++ b/test/services/webhook/verification_method/stripe_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class Webhook::VerificationMethod::StripeTest < ActiveSupport::TestCase
+  setup do
+    @request = ActionDispatch::Request.new({ "REQUEST_METHOD" => "POST", "HTTP_STRIPE_SIGNATURE" => "dummy_signature", "RAW_POST_DATA" => "{}" })  
+  end
+
+  test '#call: should return success message if stripe verifies signature' do
+    ::Stripe::Webhook.expects(:construct_event).returns({})
+
+    response = Webhook::VerificationMethod::Stripe.new(@request, 'dummy_signing_secret').call
+
+    assert_equal([true, 'Signature Verified'], response)
+  end
+
+  test '#call: should return json parse error message if stripe raise JSON::ParserError' do
+    ::Stripe::Webhook.expects(:construct_event).raises(JSON::ParserError)
+
+    response = Webhook::VerificationMethod::Stripe.new(@request, 'dummy_signing_secret').call
+
+    assert_equal([false, "Invalid json payload"], response)
+  end
+
+  test '#call: should return signature verification error message if stripe raises Stripe::SignatureVerificationError' do
+    Stripe::Webhook.expects(:construct_event).raises(::Stripe::SignatureVerificationError.new('msg', 'sig_header'))
+
+    response = Webhook::VerificationMethod::Stripe.new(@request, 'dummy_signing_secret').call
+
+    assert_equal([false, 'Signature verification failed'], response)
+  end
+end

--- a/test/services/webhook/verification_test.rb
+++ b/test/services/webhook/verification_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Webhook::VerificationTest  < ActiveSupport::TestCase
+  setup do
+    @external_api_client = external_api_clients(:webhook_drive_strategy)
+    @request = ActionDispatch::Request.new({ "REQUEST_METHOD" => "POST", "HTTP_STRIPE_SIGNATURE" => "dummy_signature", "RAW_POST_DATA" => "{}" }) 
+  end
+
+  test "stripe webhook type" do
+    Webhook::VerificationMethod::Stripe.any_instance.stubs(:call).returns([true, 'success'])
+    webhook_verification_method = WebhookVerificationMethod.create(webhook_type: 'stripe', external_api_client_id: @external_api_client.id, webhook_secret: 'secret') 
+
+    verification_service = Webhook::Verification.new(@request, webhook_verification_method)
+
+    assert_equal webhook_verification_method, verification_service.verification_method
+    assert_equal @request, verification_service.request
+
+    assert_equal [true, 'success'], verification_service.call
+  end
+
+  test "custom webhook type" do
+    Webhook::VerificationMethod::Custom.any_instance.stubs(:call).returns([true, 'success'])
+    webhook_verification_method = WebhookVerificationMethod.create(webhook_type: 'custom', external_api_client_id: @external_api_client.id, webhook_secret: 'secret') 
+
+    verification_service = Webhook::Verification.new(@request, webhook_verification_method)
+
+    assert_equal webhook_verification_method, verification_service.verification_method
+    assert_equal @request, verification_service.request
+
+    assert_equal [true, 'success'], verification_service.call
+  end
+end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/682

Api Keys:

https://user-images.githubusercontent.com/50227291/196992417-ab91ed2e-1514-4abf-9954-d44123542583.mov

Webhook:

https://user-images.githubusercontent.com/50227291/196992487-4c3c9593-4cb6-4b8c-8f7b-c6e22d9385a2.mov

**The webhook's payload can be accessed as `parameters[:request]['body']` in external api client.**

Eg: https://github.com/restarone/violet_rails/pull/1167/files#diff-1aa9cadc4b4c76bf7ec3d7c0cf8d0da66be3ba87336bad4d32241c99d53aa6beR603-R623

```
    class ExternalApiModelExample
      def initialize(parameters)
        @external_api_client = parameters[:external_api_client]
        @request = parameters[:request]
      end
  
      def start
        if @request['body']['type'] == 'customer.created'
          resource = @external_api_client.api_namespace.api_resources.create(
            properties: {
              request_body: @request["body"]	
            }
          )
          render json: { result: resource } 
        end
      end
```

Custom webhook verification method:

https://user-images.githubusercontent.com/50227291/197921958-a06b85a8-7c7a-4e3b-afb9-889fe5c6e110.mov
Co-authored-by: Pralish Kayastha <50227291+Pralish@users.noreply.github.com>
Co-authored-by: Pralish Kayastha <pralishkayastha@gmail.com>
Co-authored-by: Prashant Khadka <25191509+alis-khadka@users.noreply.github.com>