### PR TITLE
[bug fix] non renderable API Namespace unable to create Resources

### DIFF
--- a/app/helpers/api_forms_helper.rb
+++ b/app/helpers/api_forms_helper.rb
@@ -45,11 +45,11 @@ module ApiFormsHelper
     key = form.object.label.to_sym
     case type
     when 'file'
-      options = { required:  form_properties.dig(key, 'required') == '1', class: 'form-control', type: 'file', direct_upload: true, onchange: "previewFile(event, '#{key.to_s.parameterize.underscore}_preview')" }
+      options = { required:  form_properties&.dig(key, 'required') == '1', class: 'form-control', type: 'file', direct_upload: true, onchange: "previewFile(event, '#{key.to_s.parameterize.underscore}_preview')" }
       form.file_field :attachment, options
     when 'richtext'
-      options = { placeholder: form_properties.dig(key, 'placeholder'), required: form_properties.dig(key, 'required') == '1' }
-      options[:value] = form_properties.dig(key, 'prepopulate') == '1' || is_edit ? form.object.content : ''
+      options = { placeholder:  form_properties&.dig(key, 'placeholder'), required:  form_properties&.dig(key, 'required') == '1' }
+      options[:value] =  form_properties&.dig(key, 'prepopulate') == '1' || is_edit ? form.object.content : ''
       form.rich_text_area :content, options
     end
   end

--- a/app/views/comfy/admin/api_namespaces/_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_form.html.haml
@@ -29,7 +29,7 @@
     = f.label :requires_authentication
     = f.check_box :requires_authentication
   .field
-    = f.label :has_form
+    = f.label "Renderable (Form, and representation)"
     = f.check_box :has_form, checked: @api_namespace.api_form.present?
 
   - unless has_only_uncategorized_access?(current_user.api_accessibility) 

--- a/test/controllers/admin/comfy/api_resources_controller_test.rb
+++ b/test/controllers/admin/comfy/api_resources_controller_test.rb
@@ -548,4 +548,17 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
     expected_message = "You do not have the permission to do that. Only users with full_access or full_access_for_api_resources_only or delete_access_for_api_resources_only are allowed to perform that action."
     assert_equal expected_message, flash[:alert]
   end
+
+  test "should able to create api_resource if has_form params is set false" do
+    @api_namespace.has_form = '0';
+    @api_namespace.save;
+    payload_as_stringified_json = "{\"age\":26,\"alive\":true,\"last_name\":\"Teng\",\"first_name\":\"Jennifer\"}"
+
+    sign_in(@user)
+    get new_api_namespace_resource_url(api_namespace_id: @api_namespace.id)
+    assert_response :success
+    assert_difference('ApiResource.count') do
+      post api_namespace_resources_url(api_namespace_id: @api_namespace.id), params: { api_resource: { properties: payload_as_stringified_json } }
+    end
+  end
 end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/1111

If has_form is unchecked, 

<img width="1727" alt="Screen Shot 2023-01-12 at 8 42 02 PM" src="https://user-images.githubusercontent.com/35935196/212217659-5c5f1f92-8629-4943-8570-ee79e4ea4eee.png">

then the form is not rendered

<img width="1728" alt="Screen Shot 2023-01-13 at 2 43 15 PM" src="https://user-images.githubusercontent.com/35935196/212405547-83913614-8f44-405d-adb3-924df1375bae.png">