### PR TITLE
[feature] enable profiling in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 gem 'rack-mini-profiler', '~> 3.0', require: false
 gem 'flamegraph'
 gem 'stackprof'
+gem 'memory_profiler'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,12 @@ gem 'net-ssh', '>= 6.0.2'
 gem 'ed25519', '>= 1.2', '< 2.0'
 gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 
+# Display performance information such as SQL time and flame graphs for each request in your browser.
+# Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
+gem 'rack-mini-profiler', '~> 3.0', require: false
+gem 'flamegraph'
+gem 'stackprof'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -69,9 +75,6 @@ group :development, :test do
 end
 
 group :development do
-  # Display performance information such as SQL time and flame graphs for each request in your browser.
-  # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'rack-mini-profiler', '~> 2.0'
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -571,7 +571,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 3.0.0p0
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
     mailgun-ruby (1.2.4)
       rest-client (>= 2.0.2)
     marcel (1.0.2)
+    memory_profiler (1.0.1)
     meta-tags (2.14.0)
       actionpack (>= 3.2.0, < 6.2)
     method_source (1.0.0)
@@ -534,6 +535,7 @@ DEPENDENCIES
   listen (~> 3.3)
   local_time
   mailgun-ruby
+  memory_profiler
   meta-tags
   mocha
   net-ssh (>= 6.0.2)
@@ -571,7 +573,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 3.0.0p0
+   ruby 2.6.6p146
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
     faker (2.21.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
+    flamegraph (0.9.5)
     font-awesome-sass (5.15.1)
       sassc (>= 1.11)
     friendly_id (5.4.2)
@@ -317,7 +318,7 @@ GEM
       rack (>= 0.4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-mini-profiler (2.3.1)
+    rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
     rack-protection (2.2.0)
       rack
@@ -439,6 +440,7 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stackprof (0.2.23)
     stripe (7.1.0)
     stripe-rails (2.3.5)
       rails (>= 5.1)
@@ -519,6 +521,7 @@ DEPENDENCIES
   ember-cli-rails (= 0.10.0)
   exception_notification (~> 4.5)
   faker
+  flamegraph
   friendly_id
   graphiql-rails
   graphql (~> 2.0)
@@ -538,7 +541,7 @@ DEPENDENCIES
   pry
   puma (~> 5.6)
   rack-cors
-  rack-mini-profiler (~> 2.0)
+  rack-mini-profiler (~> 3.0)
   rack-timeout (~> 0.6)
   rails (~> 6.1.5)
   rails-controller-testing
@@ -554,6 +557,7 @@ DEPENDENCIES
   sinatra
   sitemap_generator
   spring
+  stackprof
   stripe-rails
   turbo-rails (~> 1.1)
   turnout (~> 2.5)
@@ -567,7 +571,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 3.0.0p0
+   ruby 2.6.6p146
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -573,7 +573,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 3.0.0p0
 
 BUNDLED WITH
    2.1.4

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,8 @@
 class ApplicationController < ActionController::Base
   include ActiveStorage::SetCurrent
 
-  before_action :prepare_exception_notifier
   before_action :store_user_location!, if: :storable_location?
-  before_action :set_current_user
+  before_action :prepare_profiler,:prepare_exception_notifier , :set_current_user
 
   def after_sign_in_path_for(resource)
     if session[:user_return_to] then return session[:user_return_to] end
@@ -39,6 +38,12 @@ class ApplicationController < ActionController::Base
       current_user: current_user,
       current_visit: current_visit
     }
+  end
+
+  def prepare_profiler
+    if current_user && current_user.can_access_admin? & current_user.show_profiler?
+      Rack::MiniProfiler.authorize_request
+    end
   end
 
   # Reference: https://github.com/heartcombo/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update#storelocation-to-the-rescue

--- a/app/controllers/comfy/admin/users_controller.rb
+++ b/app/controllers/comfy/admin/users_controller.rb
@@ -88,6 +88,7 @@ class Comfy::Admin::UsersController < Comfy::Admin::Cms::BaseController
       :can_manage_subdomain_settings,
       :can_access_admin,
       :deliver_error_notifications,
+      :show_profiler,
       category_ids: [],
       api_accessibility: {}
     )

--- a/app/views/comfy/admin/users/_form.haml
+++ b/app/views/comfy/admin/users/_form.haml
@@ -56,7 +56,11 @@
               .form-group
                 = f.check_box :deliver_error_notifications
                 %label 
-                  Deliver error notifications                  
+                  Deliver error notifications   
+              .form-group
+                = f.check_box :show_profiler
+                %label 
+                  Show Profiler                  
               .form-group
                 = f.check_box :can_manage_users
                 %label 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,6 +84,4 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-
-  Rack::MiniProfiler.config.position = 'bottom-right'
 end

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require "rack-mini-profiler"
+
+# initialization is skipped so trigger it
+Rack::MiniProfilerRails.initialize!(Rails.application)
+Rack::MiniProfiler.config.position = 'bottom-right'
+Rack::MiniProfiler.config.authorization_mode = :allow_authorized
+Rack::MiniProfiler.config.enable_hotwire_turbo_drive_support = true

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -6,3 +6,4 @@ Rack::MiniProfilerRails.initialize!(Rails.application)
 Rack::MiniProfiler.config.position = 'bottom-right'
 Rack::MiniProfiler.config.authorization_mode = :allow_authorized
 Rack::MiniProfiler.config.enable_hotwire_turbo_drive_support = true
+Rack::MiniProfiler.config.enable_advanced_debugging_tools = true

--- a/db/migrate/20230310222034_add_show_profiler_to_users.rb
+++ b/db/migrate/20230310222034_add_show_profiler_to_users.rb
@@ -1,0 +1,5 @@
+class AddShowProfilerToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :show_profiler, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_24_014921) do
+ActiveRecord::Schema.define(version: 2023_03_10_222034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -561,6 +561,7 @@ ActiveRecord::Schema.define(version: 2023_01_24_014921) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login", default: false
     t.boolean "can_access_forum", default: false
+    t.boolean "show_profiler", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true


### PR DESCRIPTION
## Shows application profiling
When enabled, shows profiling information to admin users
<img width="1728" alt="Screen Shot 2023-03-10 at 6 27 18 PM" src="https://user-images.githubusercontent.com/35935196/224448480-6cf1f7ec-e48d-4c9b-8a88-df1de8b5571a.png">

## Permissions
Ensure user has `show profiler` permission
<img width="1728" alt="Screen Shot 2023-03-10 at 6 28 13 PM" src="https://user-images.githubusercontent.com/35935196/224448545-ea9afe62-e68d-4681-a332-7c98fc5d251c.png">

## Profiling configuration
Append `?pp=help` to access the profiling help page
<img width="1728" alt="Screen Shot 2023-03-10 at 6 27 41 PM" src="https://user-images.githubusercontent.com/35935196/224448618-c8eebc9f-b845-43c8-931f-0d9f25218a76.png">

## Improve app performance!
Use instrumentation to track down performance bottlenecks and improve app performance 
<img width="1728" alt="Screen Shot 2023-03-10 at 6 29 32 PM" src="https://user-images.githubusercontent.com/35935196/224448636-d6d0bb5e-3597-4b9e-8b6d-f7487eb88d04.png">
