### PR TITLE
[fix] optimize analytics V2 further + lockdown profiler 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,8 @@ class ApplicationController < ActionController::Base
   end
 
   def prepare_profiler
-    if current_user && current_user.can_access_admin? & current_user.show_profiler?
+    if current_user && current_user.can_access_admin? && current_user.show_profiler?
+      return if params[:pp].present? && params[:pp] == 'env' && !current_user.global_admin?
       Rack::MiniProfiler.authorize_request
     end
   end

--- a/app/controllers/comfy/admin/v2/dashboard_controller.rb
+++ b/app/controllers/comfy/admin/v2/dashboard_controller.rb
@@ -1,58 +1,79 @@
 class Comfy::Admin::V2::DashboardController < Comfy::Admin::Cms::BaseController
-  include AhoyEventsHelper
+  include DashboardHelper
 
   before_action :ensure_authority_to_manage_analytics
 
   def dashboard
     @start_date = params[:start_date]&.to_date || Date.today.beginning_of_month
     @end_date = params[:end_date]&.to_date || Date.today.end_of_month
-    date_range = @start_date.beginning_of_day..@end_date.end_of_day
 
-    @visits = Ahoy::Visit.where(started_at: date_range)
-
-    filtered_events = Ahoy::Event.joins(:visit)
-    filtered_events = filtered_events.jsonb_search(:properties, { page_id: params[:page] }) if params[:page].present?
-
-    Ahoy::Event::EVENT_CATEGORIES.values.each do |event_category|
-      if event_category == Ahoy::Event::EVENT_CATEGORIES[:page_visit]
-        events = filtered_events.where(name: 'comfy-cms-page-visit')
-      else
-        events = filtered_events.jsonb_search(:properties, { category: event_category })
-      end
-
-      events = events.filter_records_with_video_details_missing if event_category == Ahoy::Event::EVENT_CATEGORIES[:video_view]
-
-      instance_variable_set("@previous_period_#{event_category}_events", events.where(time: previous_period(params[:interval], @start_date, @end_date)))
-      instance_variable_set("@#{event_category}_events", events.where(time: date_range))
-    end
-
-    # legacy and system events does not have category 
-    # separating out 'comfy-cms-page-visit' event since we have a seprate section
-    @legacy_and_system_events = filtered_events.where.not('properties::jsonb ? :key', key: 'category').where.not(name: 'comfy-cms-page-visit')
-    @previous_period_legacy_and_system_events = @legacy_and_system_events.where(time: previous_period(params[:interval], @start_date, @end_date))
-    @legacy_and_system_events = @legacy_and_system_events.where(time: date_range)
+    set_event_category_specific_analytics_data
   end
 
 
   private
+  def set_event_category_specific_analytics_data
+    Ahoy::Event::EVENT_CATEGORIES.values.each do |event_category|
+      if event_category == Ahoy::Event::EVENT_CATEGORIES[:page_visit]
+        current_events_sql = params[:page].present? ? Ahoy::Event.joins(:visit).jsonb_search(:properties, { page_id: params[:page] }).where(name: 'comfy-cms-page-visit').where(time: @start_date.beginning_of_day..@end_date.end_of_day).to_sql : Ahoy::Event.joins(:visit).where(name: 'comfy-cms-page-visit').where(time: @start_date.beginning_of_day..@end_date.end_of_day).to_sql
+        previous_events_sql = params[:page].present? ? Ahoy::Event.joins(:visit).jsonb_search(:properties, { page_id: params[:page] }).where(name: 'comfy-cms-page-visit').where(time: previous_time_interval_range(params[:interval], @start_date, @end_date)).to_sql : Ahoy::Event.joins(:visit).where(name: 'comfy-cms-page-visit').where(time: previous_time_interval_range(params[:interval], @start_date, @end_date)).to_sql
+      elsif event_category == Ahoy::Event::EVENT_CATEGORIES[:video_view]
+        current_events_sql = params[:page].present? ? Ahoy::Event.joins(:visit).jsonb_search(:properties, { page_id: params[:page] }).jsonb_search(:properties, { category: event_category }).filter_records_with_video_details_missing.where(time: @start_date.beginning_of_day..@end_date.end_of_day).to_sql : Ahoy::Event.joins(:visit).jsonb_search(:properties, { category: event_category }).filter_records_with_video_details_missing.where(time: @start_date.beginning_of_day..@end_date.end_of_day).to_sql
+        previous_events_sql = params[:page].present? ? Ahoy::Event.joins(:visit).jsonb_search(:properties, { page_id: params[:page] }).jsonb_search(:properties, { category: event_category }).filter_records_with_video_details_missing.where(time: previous_time_interval_range(params[:interval], @start_date, @end_date)).to_sql : Ahoy::Event.joins(:visit).jsonb_search(:properties, { category: event_category }).filter_records_with_video_details_missing.where(time: previous_time_interval_range(params[:interval], @start_date, @end_date)).to_sql
+      else
+        current_events_sql = params[:page].present? ? Ahoy::Event.joins(:visit).jsonb_search(:properties, { page_id: params[:page] }).jsonb_search(:properties, { category: event_category }).where(time: @start_date.beginning_of_day..@end_date.end_of_day).to_sql : Ahoy::Event.joins(:visit).jsonb_search(:properties, { category: event_category }).where(time: @start_date.beginning_of_day..@end_date.end_of_day).to_sql
+        previous_events_sql = params[:page].present? ? Ahoy::Event.joins(:visit).jsonb_search(:properties, { page_id: params[:page] }).jsonb_search(:properties, { category: event_category }).where(time: previous_time_interval_range(params[:interval], @start_date, @end_date)).to_sql : Ahoy::Event.joins(:visit).jsonb_search(:properties, { category: event_category }).where(time: previous_time_interval_range(params[:interval], @start_date, @end_date)).to_sql
+      end
 
-  def previous_period(interval, start_date, end_date)
-    today = Date.current
-    interval = interval || today.strftime('%B %Y')
+      if event_category == Ahoy::Event::EVENT_CATEGORIES[:page_visit]
+        instance_variable_set("@#{event_category}_events", {
+          events_exists: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").size > 0,
+          events_count: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").size,
+          previous_period_events_count: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").size,
+          column_chart_data: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").page_visit_chart_data_for_page_visit_events(@start_date..@end_date, split_into(@start_date, @end_date)),
+          pie_chart_data: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").visitors_chart_data_for_page_visit_events
+        })
+      elsif event_category == Ahoy::Event::EVENT_CATEGORIES[:video_view]
+        current_top_videos_hash = Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").top_three_videos_details
+        previous_top_videos_hash = Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").total_views_and_watch_time_detals_for_previous_video_events(current_top_videos_hash.map { |video| video[:resource_id] })
 
-    case interval
-    when "#{today.strftime('%B %Y')}"
-      today.prev_month.beginning_of_month.beginning_of_day..today.prev_month.end_of_month.end_of_day
-    when "3 months"
-      (start_date - 3.months).beginning_of_month.beginning_of_day..(start_date - 1.month).end_of_month.end_of_day
-    when "6 months"
-      (today - 6.months).beginning_of_month.beginning_of_day..(start_date - 1.month).end_of_month.end_of_day
-    when "1 year"
-      (today - 12.months).beginning_of_month.beginning_of_day..(start_date - 1.month).end_of_month.end_of_day
-    else
+        instance_variable_set("@#{event_category}_events", {
+          events_exists: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").size > 0,
+          events_count: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").size,
+          previous_period_events_count: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").size,
+          watch_time: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").total_watch_time_for_video_events,
+          previous_watch_time: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").total_watch_time_for_video_events,
+          avg_view_duration: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").avg_view_duration_for_video_events,
+          previous_avg_view_duration: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").avg_view_duration_for_video_events,
+          avg_view_percent: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").avg_view_percentage_for_video_events,
+          previous_avg_view_percent: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").avg_view_percentage_for_video_events,
+          top_videos: top_three_videos_details(current_top_videos_hash, previous_top_videos_hash)
+        })
+      else
+        instance_variable_set("@#{event_category}_events", {
+          events_exists: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").size > 0,
+          events_count: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").size,
+          label_grouped_events: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").with_label_grouped_data,
+          previous_period_events_count: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").size,
+          previous_label_grouped_events: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").with_label_grouped_data
+        })
+      end
 
-      days_diff = (end_date - start_date).to_i
-      (start_date - (days_diff + 1).days).beginning_of_day..(start_date - 1.day).end_of_day
     end
+
+    # legacy and system events does not have category 
+    # separating out 'comfy-cms-page-visit' event since we have a seprate section
+    current_events_sql = Ahoy::Event.joins(:visit).where.not('properties::jsonb ? :key', key: 'category').where.not(name: 'comfy-cms-page-visit').where(time: @start_date.beginning_of_day..@end_date.end_of_day).to_sql
+    previous_events_sql = Ahoy::Event.joins(:visit).where.not('properties::jsonb ? :key', key: 'category').where.not(name: 'comfy-cms-page-visit').where(time: previous_time_interval_range(params[:interval], @start_date, @end_date)).to_sql
+
+    @legacy_and_system_events = {
+      events_exists: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").size > 0,
+      events_count: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").size,
+      label_grouped_events: Ahoy::Event.from("(#{current_events_sql}) as ahoy_events").with_label_grouped_data,
+      previous_period_events_count: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").size,
+      previous_label_grouped_events: Ahoy::Event.from("(#{previous_events_sql}) as ahoy_events").with_label_grouped_data
+    }
+
+    GC.start
   end
 end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -21,23 +21,6 @@ module DashboardHelper
     user_visit_count = Ahoy::Visit.where(user_id: params[:id]).where('started_at <= ?', @visit.started_at).size
     "Visit (#{user_visit_count})"
   end
-
-  def page_visit_chart_data(page_visit_events, start_date, end_date)
-    period, format = split_into(start_date, end_date)
-
-    page_visit_events
-      .where.not(visit: {device_type: nil})
-      .group("visit.device_type")
-      .group_by_period(period, :time, range: start_date..end_date, format: format)
-      .size
-      .group_by {|k, v| k.first}
-      .map do |k,  v| 
-        {
-          name: k,
-          data: v.map {|item| [item.first.last, item.last]}.to_h
-        }
-      end 
-  end 
     
   def page_name(page_id)
     return 'Website' if page_id.blank?
@@ -45,15 +28,8 @@ module DashboardHelper
     Comfy::Cms::Page.find_by(id: page_id)&.label
   end
 
-  def visitors_chart_data(visits)
-    visitors_by_token = visits.group(:visitor_token).size
-    recurring_visitors = visitors_by_token.values.count { |v| v > 1 }
-    single_time_visitors = visitors_by_token.keys.count - recurring_visitors
-    {"Single time visitor": single_time_visitors, "Recurring visitors" => recurring_visitors  }
-  end
-
   def display_percent_change(current_count, prev_count)
-    return if prev_count == 0
+    return if prev_count.to_i == 0
 
     percent_change = percent_change(current_count, prev_count)
 
@@ -70,76 +46,79 @@ module DashboardHelper
     "This is a #{percent_change.round(2).abs} % #{percent_change > 0 ? 'increase': 'decrease'} compared to the previous #{prev_interval}"
   end
 
-  def total_watch_time(video_view_events)
-    video_view_events.pluck(Arel.sql("SUM((#{Ahoy::Event.table_name}.properties ->> 'watch_time')::bigint)")).sum
-  end
-
   def to_minutes(time_in_milisecond)
     "#{number_with_delimiter((time_in_milisecond.to_f / (1000 * 60)).round(2) , :delimiter => ',')} min"
   end
 
-  def total_views(video_view_events)
-    video_view_events.pluck(Arel.sql("SUM(CASE WHEN (#{Ahoy::Event.table_name}.properties ->> 'video_start')::boolean THEN 1 ELSE 0 END)")).sum
+  def top_three_videos_details(current_top_videos_details, previous_top_videos_details)
+    current_top_videos_details.each do |video_detail|
+      video_detail.merge(previous_top_videos_details.find { |previous_video_detail| previous_video_detail[:resource_id] == video_detail[:resource_id] } || {})
+    end
   end
 
-  def avg_view_duration(video_view_events)
-    total_watch_time(video_view_events).to_f / (total_views(video_view_events).nonzero? || 1)
+  def event_title(event_category)
+    case event_category
+    when Ahoy::Event::EVENT_CATEGORIES[:click]
+      'Clicks'
+    when Ahoy::Event::EVENT_CATEGORIES[:form_submit]
+      'Form Submissions'
+    when Ahoy::Event::EVENT_CATEGORIES[:section_view]
+      'Section Views'
+    when 'system_events'
+      'Events'
+    end
   end
 
-  def avg_view_percentage(video_view_events)
-    video_view_events.pluck(Arel.sql("((properties ->> 'watch_time')::float / (properties ->> 'total_duration')::float) * 100")).sum / (total_views(video_view_events).nonzero? || 1)
+  def event_types(event_category)
+    case event_category
+    when Ahoy::Event::EVENT_CATEGORIES[:click]
+      'clickables'
+    when Ahoy::Event::EVENT_CATEGORIES[:form_submit]
+      'submitables'
+    when Ahoy::Event::EVENT_CATEGORIES[:section_view]
+      'viewables'
+    when 'system_events'
+      'events'
+    end
   end
 
-  def top_three_videos(video_view_events, previous_video_view_events)
-    video_view_events
-      .with_api_resource
-      .group(:resource_id)
-      .reorder("SUM(is_viewed) DESC", "total_watch_time DESC")
-      .select(:resource_id,
-        "SUM(watch_time)::INT AS total_watch_time",
-        "SUM(is_viewed) AS total_views",
-        "MAX(total_duration)::float AS duration",
-        "json_agg(ahoy_events.name) AS names",
-        "json_agg(namespace_id) AS namespace_ids")
-      .limit(3)
-      .as_json
-      .map(&:with_indifferent_access)
-      .each do |video_event|
-        previous_period_event = previous_video_view_events.jsonb_search(:properties, { resource_id: video_event[:resource_id] })
-        api_resource = ApiResource.find_by(id: video_event[:resource_id])
-
-        video_event[:name] = video_event[:names].uniq.first
-        video_event[:duration] = video_event[:duration] || 0
-        video_event[:namespace_id] = video_event[:namespace_ids].uniq.first
-        video_event[:previous_period_total_views] = total_views(previous_period_event)
-        video_event[:previous_period_total_watch_time] = total_watch_time(previous_period_event)
-        video_event[:resource_title] = api_resource&.properties.dig(api_resource&.api_namespace.analytics_metadata&.dig("title")) || "Resource Id: #{video_event[:resource_id]}"
-        video_event[:resource_author] = api_resource&.properties.dig(api_resource&.api_namespace.analytics_metadata&.dig("author"))
-        video_event[:resource_image] = api_resource&.non_primitive_properties.find_by(field_type: "file", label: api_resource&.api_namespace.analytics_metadata&.dig("thumbnail"))&.file_url
-
-        video_event.delete(:names)
-        video_event.delete(:namespace_ids)
-        video_event.delete(:id)
-      end
-  end
-
-  private
   def split_into(start_date, end_date)
     time_in_days = (end_date - start_date).to_i
 
     if time_in_days <= 1
-      [:hour_of_day, '%I %P']
+      {period: :hour_of_day, format: '%I %P'}
     elsif time_in_days <= 7
-      [:day, '%-d %^b %Y']
+      {period: :day, format: '%-d %^b %Y'}
     elsif time_in_days <= 30
-      [:week, '%V']
+      {period: :week, format: '%V'}
     elsif time_in_days <= 365
-      [:month, '%^b %Y']
+      {period: :month, format: '%^b %Y'}
     else
-      [:year, '%Y']
+      {period: :year, format: '%Y'}
     end
   end
 
+  def previous_time_interval_range(interval, start_date, end_date)
+    today = Date.current
+    interval = interval || today.strftime('%B %Y')
+
+    case interval
+    when "#{today.strftime('%B %Y')}"
+      today.prev_month.beginning_of_month.beginning_of_day..today.prev_month.end_of_month.end_of_day
+    when "3 months"
+      (start_date - 3.months).beginning_of_month.beginning_of_day..(start_date - 1.month).end_of_month.end_of_day
+    when "6 months"
+      (today - 6.months).beginning_of_month.beginning_of_day..(start_date - 1.month).end_of_month.end_of_day
+    when "1 year"
+      (today - 12.months).beginning_of_month.beginning_of_day..(start_date - 1.month).end_of_month.end_of_day
+    else
+
+      days_diff = (end_date - start_date).to_i
+      (start_date - (days_diff + 1).days).beginning_of_day..(start_date - 1.day).end_of_day
+    end
+  end
+
+  private
   def previous_interval(interval, start_date, end_date)
     today = Date.current
     interval = interval || today.strftime('%B %Y')

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -27,12 +27,20 @@ class Ahoy::Event < ApplicationRecord
   belongs_to :visit
   belongs_to :user, optional: true
 
-  scope :with_label , -> {
+  scope :with_label_grouped_data , -> {
     # Build a subquery SQL
     subquery = self.unscoped.select("(case when #{table_name}.properties->>'label' is not NULL then #{table_name}.properties->>'label' else #{table_name}.name end) as label, #{table_name}.id").to_sql
 
-    # join the subquery to base model
-    joins("INNER JOIN (#{subquery}) as labelled_events ON labelled_events.id = #{table_name}.id")
+    # join the subquery to base model and returns the grouped data as Hash
+    self
+      .joins("INNER JOIN (#{subquery}) as labelled_events ON labelled_events.id = #{table_name}.id")
+      .group(:label)
+      .pluck(
+        :label,
+        Arel.sql("jsonb_build_object('count', COUNT(#{table_name}.id), 'name', jsonb_array_element(jsonb_agg(#{table_name}.name), 0))")
+      )
+      .to_h
+      .with_indifferent_access
   }
 
   scope :with_api_resource , -> {
@@ -103,4 +111,97 @@ class Ahoy::Event < ApplicationRecord
       { success: false, message: e.message }
     end
   end
+
+  # Methods for Video related events analytics - START
+  def self.total_watch_time_for_video_events
+    self.pluck(Arel.sql("SUM((#{Ahoy::Event.table_name}.properties ->> 'watch_time')::bigint)")).sum
+  end
+
+  def self.total_views_for_video_events
+    self.pluck(Arel.sql("SUM(CASE WHEN (#{Ahoy::Event.table_name}.properties ->> 'video_start')::boolean THEN 1 ELSE 0 END)")).sum
+  end
+
+  def self.avg_view_duration_for_video_events
+    self.total_watch_time_for_video_events.to_f / (self.total_views_for_video_events.nonzero? || 1)
+  end
+
+  def self.avg_view_percentage_for_video_events
+    self.pluck(Arel.sql("((properties ->> 'watch_time')::float / (properties ->> 'total_duration')::float) * 100")).sum / (self.total_views_for_video_events.nonzero? || 1)
+  end
+
+  def self.top_three_videos_details
+    self
+      .with_api_resource
+      .group(:resource_id)
+      .reorder("SUM(is_viewed) DESC", "total_watch_time DESC")
+      .select(:resource_id,
+        "SUM(watch_time)::INT AS total_watch_time",
+        "SUM(is_viewed) AS total_views",
+        "MAX(total_duration)::float AS duration",
+        "json_agg(ahoy_events.name) AS names",
+        "json_agg(namespace_id) AS namespace_ids")
+      .limit(3)
+      .as_json
+      .map(&:with_indifferent_access)
+      .each do |video_event|
+        api_resource = ApiResource.find_by(id: video_event[:resource_id])
+
+        video_event[:name] = video_event[:names].uniq.first
+        video_event[:duration] = video_event[:duration] || 0
+        video_event[:namespace_id] = video_event[:namespace_ids].uniq.first
+        video_event[:resource_title] = api_resource&.properties.dig(api_resource&.api_namespace.analytics_metadata&.dig("title")) || "Resource Id: #{video_event[:resource_id]}"
+        video_event[:resource_author] = api_resource&.properties.dig(api_resource&.api_namespace.analytics_metadata&.dig("author"))
+        video_event[:resource_image] = api_resource&.non_primitive_properties.find_by(field_type: "file", label: api_resource&.api_namespace.analytics_metadata&.dig("thumbnail"))&.file_url
+
+        video_event.delete(:names)
+        video_event.delete(:namespace_ids)
+        video_event.delete(:id)
+      end
+  end
+
+  # Argument resource_ids are derived from the above top_three_videos_details methods.
+  # Thus, the array of resource_ids will be a maximum size of 3.
+  def self.total_views_and_watch_time_detals_for_previous_video_events(resource_ids)
+    self
+      .with_api_resource
+      .where('api_resourced_events.resource_id': resource_ids)
+      .group(:resource_id)
+      .select(:resource_id,
+        "SUM(watch_time)::INT AS previous_period_total_watch_time",
+        "SUM(is_viewed) AS previous_period_total_views",
+        "MAX(total_duration)::float AS duration")
+      .as_json
+      .map(&:with_indifferent_access)
+  end
+  # Methods for Video related events analytics - END
+
+  # Methods for Page View related events analytics - START
+  def self.page_visit_chart_data_for_page_visit_events(date_range, grouping_data)
+    chart_data = []
+
+    self
+      .joins(:visit)
+      .where.not(visit: {device_type: nil})
+      .group("visit.device_type")
+      .group_by_period(grouping_data[:period], :time, range: date_range, format: grouping_data[:format])
+      .size
+      .group_by {|k, v| k.first}
+      .each do |k, v|
+        chart_data << {
+          name: k,
+          data: v.map {|item| [item.first.last, item.last]}.to_h
+        }
+      end
+
+    chart_data
+  end 
+
+  def self.visitors_chart_data_for_page_visit_events
+    visitors_by_token = self.joins(:visit).group(:visitor_token).size
+    recurring_visitors = visitors_by_token.values.count { |v| v > 1 }
+    single_time_visitors = visitors_by_token.keys.count - recurring_visitors
+
+    {"Single time visitor" => single_time_visitors, "Recurring visitors" => recurring_visitors  }
+  end
+  # Methods for Page View related events analytics - END
 end

--- a/app/views/comfy/admin/v2/dashboard/_events.html.haml
+++ b/app/views/comfy/admin/v2/dashboard/_events.html.haml
@@ -1,13 +1,13 @@
-%section.vr-analytics-section.vr-analytics-events
+%section{class: ['vr-analytics-section', 'vr-analytics-events', "#{event_category}-section"]}
   .vr-analytics-section-header
     .d-md-flex.align-items-center
       .vr-analytics-sub-title
-        = title
+        = event_title(event_category)
       - if events_exists
         .d-flex.align-items-center.mt-2.mt-md-0
           .vr-analytics-count
             = events_count 
-            = "total #{type}"
+            = "total #{event_types(event_category)}"
           .vr-analytics-percent-change
             = display_percent_change(events_count, previous_period_events_count)
           .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(events_count, previous_period_events_count, params[:interval], @start_date, @end_date) }
@@ -16,14 +16,14 @@
   - if events_exists
     .vr-analytics-section-body.d-flex.align-items-center
       .vr-analytics-events-grid.row.w-100
-        - label_grouped_event.each do |key, value|
+        - label_grouped_events.each do |label, data|
           .vr-analytics-events-grid-item.col.col-12.col-sm-6.col-md-4.col-lg-3.mb-4
             .d-flex.mr-4.align-items-center.mb-2
               .vr-analytics-count-lg
-                = value.size 
+                = data[:count]
               .vr-analytics-percent-change
-                = display_percent_change(value.size, previous_grouped_events[key].to_i)
-              - if previous_grouped_events[key].to_i == 0
-                .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(value.size, 0, params[:interval], @start_date, @end_date) }
+                = display_percent_change(data[:count], previous_label_grouped_events.dig(label, :count).to_i)
+              - if previous_label_grouped_events.dig(label, :count).to_i == 0
+                .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(data[:count], 0, params[:interval], @start_date, @end_date) }
                   ?
-            = link_to key, dashboard_events_path(ahoy_event_type: value.first), class: 'vr-analytics-event-label'  
+            = link_to label, dashboard_events_path(ahoy_event_type: data[:name]), class: 'vr-analytics-event-label'  

--- a/app/views/comfy/admin/v2/dashboard/dashboard.html.haml
+++ b/app/views/comfy/admin/v2/dashboard/dashboard.html.haml
@@ -22,23 +22,23 @@
 
   %main{class: 'my-5'}
     %section.row.vr-analytics-section.vr-analytics-page-visit-events
-      .col{ class: @page_visit_events.load.any? ? "col-lg-9 mb-4" : "col-12" }
+      .col{ class: @page_visit_events.present? ? "col-lg-9 mb-4" : "col-12" }
         .d-flex.justify-content-between
           .vr-analytics-section-header.d-md-flex.justify-content-between.align-items-center
             .vr-analytics-sub-title
               = "#{page_name(params[:page])} visits"
-            - if @page_visit_events.load.any?
+            - if @page_visit_events.present?
               .d-flex.justify-content-between.align-items-center.mt-2.mt-md-0
                 .vr-analytics-count
-                  = @page_visit_events.size 
+                  = @page_visit_events[:events_count]
                   total visits
                 .vr-analytics-percent-change
-                  = display_percent_change(@page_visit_events.size, @previous_period_page_visit_events.size)
-                .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(@page_visit_events.size, @previous_period_page_visit_events.size, params[:interval], @start_date, @end_date) }
+                  = display_percent_change(@page_visit_events[:events_count], @page_visit_events[:previous_period_events_count])
+                .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(@page_visit_events[:events_count], @page_visit_events[:previous_period_events_count], params[:interval], @start_date, @end_date) }
                   ?
         .vr-analytics-section-body
-          - if @page_visit_events.load.any?
-            = column_chart page_visit_chart_data(@page_visit_events, @start_date, @end_date), colors: ["#88DAE3FF", "#D785E3FF", "#F7C85CFF"], library: { plugins: { legend: { position: "top", align: "end", labels: { padding: 24, boxWidth: 8, usePointStyle: true, font: { size: 16 } } } }  }
+          - if @page_visit_events.present?
+            = column_chart @page_visit_events[:column_chart_data], colors: ["#88DAE3FF", "#D785E3FF", "#F7C85CFF"], library: { plugins: { legend: { position: "top", align: "end", labels: { padding: 24, boxWidth: 8, usePointStyle: true, font: { size: 16 } } } }  }
           - else
             .vr-analytics-blank-states
               There are no page visit events within the selected date range. 
@@ -58,16 +58,16 @@
                 %br
                 :escaped
                   </main>
-      - if @page_visit_events.load.any?
+      - if @page_visit_events.present?
         .col.col-lg-3
           .vr-analytics-card.vr-analytics-page-visit-events-donut-chart
             %h5 Website visitors
-            = pie_chart visitors_chart_data(@page_visit_events), colors: ['#F7A47B', '#B5E69A'], donut: true, library: { cutout: 85, plugins: { legend: { position: "bottom",  align: 'start', labels: {boxWidth: 8, usePointStyle: true, font: { size: 16 } } } } }
+            = pie_chart @page_visit_events[:pie_chart_data], colors: ['#F7A47B', '#B5E69A'], donut: true, library: { cutout: 85, plugins: { legend: { position: "bottom",  align: 'start', labels: {boxWidth: 8, usePointStyle: true, font: { size: 16 } } } } }
 
   
     %hr.m-0
-    = render partial: 'events', locals: { events_exists: @click_events.load.any?, events_count: @click_events.size, label_grouped_event: @click_events.with_label.group(:label).pluck(:label, Arel.sql('json_agg(ahoy_events.name)')), previous_period_events_count: @previous_period_click_events.size, previous_grouped_events: @previous_period_click_events.with_label.group(:label).size, title: 'Clicks', type: 'clickables' }
-    - unless @click_events.load.any?
+    = render partial: 'events', locals: (@click_events.present? ? @click_events : { events_exists: false }).merge({ event_category: Ahoy::Event::EVENT_CATEGORIES[:click] })
+    - unless @click_events.present?
       .vr-analytics-blank-states
         There are no click events within the selected date range. 
         %br
@@ -86,49 +86,42 @@
           .vr-analytics-sub-title.col.col-12.col-md-2
             Watch time
 
-          - if @video_view_events.load.any? 
+          - if @video_view_events.present? 
             .col.col-md-10
               .row
-                - watch_time = total_watch_time(@video_view_events)
-                - previous_watch_time = total_watch_time(@previous_period_video_view_events)
                 .col.col-12.col-sm-4.d-flex.align-items-center.my-3.my-sm-0
                   .vr-analytics-count.ml-0
                     Total watch time
-                    = to_minutes(watch_time)
+                    = to_minutes(@video_view_events[:watch_time])
                   .vr-analytics-percent-change
-                    = display_percent_change(watch_time, previous_watch_time)
-                  .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(watch_time, previous_watch_time, params[:interval], @start_date, @end_date) }
+                    = display_percent_change(@video_view_events[:watch_time], @video_view_events[:previous_watch_time])
+                  .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(@video_view_events[:watch_time], @video_view_events[:previous_watch_time], params[:interval], @start_date, @end_date) }
                     ?
             
                 .col.col-12.col-sm-4.d-flex.align-items-center.mb-3.mb-sm-0
                   .vr-analytics-count.ml-0
                     Avg. view duration
-                    - view_duration = avg_view_duration(@video_view_events)
-                    - previous_view_duration = avg_view_duration(@previous_period_video_view_events)
-                    = to_minutes(view_duration)
+                    = to_minutes(@video_view_events[:avg_view_duration])
                   .vr-analytics-percent-change
-                    = display_percent_change(view_duration, previous_view_duration)
-                  .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(view_duration, previous_view_duration, params[:interval], @start_date, @end_date) }
+                    = display_percent_change(@video_view_events[:avg_view_duration], @video_view_events[:previous_avg_view_duration])
+                  .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(@video_view_events[:avg_view_duration], @video_view_events[:previous_avg_view_duration], params[:interval], @start_date, @end_date) }
                     ?
 
                 .col.col-12.col-sm-4.d-flex.align-items-center.mb-3.mb-sm-0
                   .vr-analytics-count.ml-0
                     Avg. view percentage
-                    - view_percent = avg_view_percentage(@video_view_events)
-                    - previous_view_percent = avg_view_percentage(@previous_period_video_view_events)
-                    = "#{view_percent.round(2)}%"
+                    = "#{@video_view_events[:avg_view_percent].round(2)}%"
                   .vr-analytics-percent-change
-                    = display_percent_change(view_percent, previous_view_percent)
-                  .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(view_percent, previous_view_percent, params[:interval], @start_date, @end_date) }
+                    = display_percent_change(@video_view_events[:avg_view_percent], @video_view_events[:previous_avg_view_percent])
+                  .vr-analytics-tooltips{ data: { toggle: "tooltip", placement: "right" }, title: tooltip_content(@video_view_events[:avg_view_percent], @video_view_events[:previous_avg_view_percent], params[:interval], @start_date, @end_date) }
                     ?
-      - if @video_view_events.load.any? 
+      - if @video_view_events.present? 
         .vr-analytics-section-body
           .vr-analytics-event-label 
-            - top_videos = top_three_videos(@video_view_events, @previous_period_video_view_events)
-            = "Top #{top_videos.size} videos"
+            = "Top #{@video_view_events[:top_videos].size} videos"
 
           .row.mt-4
-            - top_videos.each do |event|
+            - @video_view_events[:top_videos].each do |event|
               .col.col-12.col-lg-5.mb-4
                 .vr-analytics-card
                   = link_to '', dashboard_events_path(ahoy_event_type: event[:name])
@@ -184,8 +177,8 @@
           Please make sure 'data-violet-resource-id' is present and Analytics mapping is populated
         
     %hr.m-0
-    = render partial: 'events', locals: { events_exists: @form_submit_events.load.any?, events_count: @form_submit_events.size, label_grouped_event: @form_submit_events.with_label.group(:label).pluck(:label, Arel.sql('json_agg(ahoy_events.name)')), previous_period_events_count: @previous_period_form_submit_events.size, previous_grouped_events: @previous_period_form_submit_events.with_label.group(:label).size, title: 'Form Submissions', type: 'submitables' }
-    - unless @form_submit_events.load.any?
+    = render partial: 'events', locals: (@form_submit_events.present? ? @form_submit_events : { events_exists: false }).merge({ event_category: Ahoy::Event::EVENT_CATEGORIES[:form_submit] })
+    - unless @form_submit_events.present?
       .vr-analytics-blank-states
         There are no form submission events within the selected date range. 
         %br
@@ -217,8 +210,8 @@
             </form>
 
     %hr.m-0
-    = render partial: 'events', locals: { events_exists: @section_view_events.load.any?, events_count: @section_view_events.size, label_grouped_event: @section_view_events.with_label.group(:label).pluck(:label, Arel.sql('json_agg(ahoy_events.name)')), previous_period_events_count: @previous_period_section_view_events.size, previous_grouped_events: @previous_period_section_view_events.with_label.group(:label).size, title: 'Section Views', type: 'viewables' }
-    - unless @section_view_events.load.any?
+    = render partial: 'events', locals: (@section_view_events.present? ? @section_view_events : { events_exists: false }).merge({ event_category: Ahoy::Event::EVENT_CATEGORIES[:section_view] })
+    - unless @section_view_events.present?
       .vr-analytics-blank-states
         There are no section view events within the selected date range. 
         %br
@@ -252,4 +245,4 @@
         By default, the threshold value is 0.75
 
     %hr.m-0
-    = render partial: 'events', locals: { events_exists: @legacy_and_system_events.load.any?, events_count: @legacy_and_system_events.size, label_grouped_event: @legacy_and_system_events.with_label.group(:label).pluck(:label, Arel.sql('json_agg(ahoy_events.name)')), previous_period_events_count: @previous_period_legacy_and_system_events.size, previous_grouped_events: @previous_period_legacy_and_system_events.with_label.group(:label).size, title: 'Events', type: 'events' }
+    = render partial: 'events', locals: (@legacy_and_system_events.present? ? @legacy_and_system_events : { events_exists: false }).merge({ event_category: 'system_events' })

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,5 +1,5 @@
 # Mark existing migrations as safe
-StrongMigrations.start_after = 20230404085503
+StrongMigrations.start_after = 20230310222034
 
 # Set timeouts for migrations
 # If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user

--- a/db/migrate/20230321055733_add_index_to_ahoy_events_name_and_time.rb
+++ b/db/migrate/20230321055733_add_index_to_ahoy_events_name_and_time.rb
@@ -1,0 +1,8 @@
+class AddIndexToAhoyEventsNameAndTime < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :ahoy_events, :name, algorithm: :concurrently
+    add_index :ahoy_events, :time, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,7 +69,9 @@ ActiveRecord::Schema.define(version: 2023_03_24_080541) do
     t.jsonb "properties"
     t.datetime "time"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["name"], name: "index_ahoy_events_on_name"
     t.index ["properties"], name: "index_ahoy_events_on_properties", opclass: :jsonb_path_ops, using: :gin
+    t.index ["time"], name: "index_ahoy_events_on_time"
     t.index ["user_id"], name: "index_ahoy_events_on_user_id"
     t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
   end

--- a/test/controllers/admin/comfy/v2/dashboard_controller_test.rb
+++ b/test/controllers/admin/comfy/v2/dashboard_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Comfy::Admin::V2::DashboardControllerTest < ActionDispatch::IntegrationTest
+  include DashboardHelper
+
   setup do
     @user = users(:public)
     @subdomain = subdomains(:public)
@@ -60,38 +62,121 @@ class Comfy::Admin::V2::DashboardControllerTest < ActionDispatch::IntegrationTes
     assert_equal Date.today.beginning_of_month, assigns(:start_date)
     assert_equal Date.today.end_of_month, assigns(:end_date)
 
-    assert_equal [page_visit_event_1_page_2.id], assigns(:page_visit_events).pluck(:id)
-    assert_equal [click_event_1_page_2.id], assigns(:click_events).pluck(:id)
-    assert_equal [video_watch_event_1_page_2.id], assigns(:video_view_events).pluck(:id)
+    current_time_range = assigns(:start_date).beginning_of_day..assigns(:end_date).end_of_day
+    previous_time_range = previous_time_interval_range(@controller.params[:interval], assigns(:start_date), assigns(:end_date))
 
-    assert_equal [page_visit_event_1.id], assigns(:previous_period_page_visit_events).pluck(:id)
-    assert_equal [click_event_1.id], assigns(:previous_period_click_events).pluck(:id)
-    assert_equal [video_watch_event_1.id], assigns(:previous_period_video_view_events).pluck(:id)
+    # Page Visit Events
+    page_visit_data = assigns(:page_visit_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'page_visit' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'page_visit' }).where(time: previous_time_range)
+    assert_equal current_events.size, page_visit_data[:events_count]
+    assert_equal previous_events.size, page_visit_data[:previous_period_events_count]
+    assert_equal current_events.visitors_chart_data_for_page_visit_events['Single time visitor'], page_visit_data[:pie_chart_data]['Single time visitor']
+    assert_equal current_events.visitors_chart_data_for_page_visit_events['Recurring visitors'], page_visit_data[:pie_chart_data]['Recurring visitors']
+
+    # Click Events
+    click_event_data = assigns(:click_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'click' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'click' }).where(time: previous_time_range)
+    assert_equal current_events.size, click_event_data[:events_count]
+    assert_equal previous_events.size, click_event_data[:previous_period_events_count]
+    assert click_event_data[:label_grouped_events].keys.include?(click_event_1.label)
+    assert click_event_data[:previous_label_grouped_events].keys.include?(click_event_2.label)
+
+    # Video View Events
+    video_view_event_data = assigns(:video_view_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'video_view' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'video_view' }).where(time: previous_time_range)
+    assert_equal current_events.size, video_view_event_data[:events_count]
+    assert_equal previous_events.size, video_view_event_data[:previous_period_events_count]
+    assert_equal video_view_event_data[:watch_time], Ahoy::Event.where(id: video_watch_event_1_page_2.id).total_watch_time_for_video_events
+    assert_equal video_view_event_data[:previous_watch_time], Ahoy::Event.where(id: video_watch_event_1.id).total_watch_time_for_video_events
+    assert_equal video_view_event_data[:avg_view_duration], Ahoy::Event.where(id: video_watch_event_1_page_2.id).avg_view_duration_for_video_events
+    assert_equal video_view_event_data[:previous_avg_view_duration], Ahoy::Event.where(id: video_watch_event_1.id).avg_view_duration_for_video_events
+    assert_equal video_view_event_data[:avg_view_percent], Ahoy::Event.where(id: video_watch_event_1_page_2.id).avg_view_percentage_for_video_events
+    assert_equal video_view_event_data[:previous_avg_view_percent], Ahoy::Event.where(id: video_watch_event_1.id).avg_view_percentage_for_video_events
 
     # When range params is present
     get v2_dashboard_url, params: {start_date: (Time.now.beginning_of_month - 2.months).strftime('%Y-%m-%d'), end_date: Time.now.end_of_month.strftime('%Y-%m-%d'), interval: "3 months" }
 
     assert_equal (Time.now.beginning_of_month - 2.months).to_date, assigns(:start_date)
     assert_equal Time.now.end_of_month.to_date, assigns(:end_date)
-  
-    assert_equal [page_visit_event_1.id, page_visit_event_1_page_2.id].sort, assigns(:page_visit_events).pluck(:id).sort
-    assert_equal [click_event_1.id, click_event_1_page_2.id].sort, assigns(:click_events).pluck(:id).sort
-    assert_equal [video_watch_event_1.id, video_watch_event_1_page_2.id].sort, assigns(:video_view_events).pluck(:id).sort
 
-    assert_equal [page_visit_event_2.id], assigns(:previous_period_page_visit_events).pluck(:id)
-    assert_equal [click_event_2.id], assigns(:previous_period_click_events).pluck(:id)
-    assert_equal [video_watch_event_2.id], assigns(:previous_period_video_view_events).pluck(:id)
+    current_time_range = (Time.now.beginning_of_month - 2.months).to_date.beginning_of_day..Time.now.end_of_month.to_date.end_of_day
+    previous_time_range = previous_time_interval_range(@controller.params[:interval], (Time.now.beginning_of_month - 2.months).to_date, Time.now.end_of_month.to_date)
+  
+    # Page Visit Events
+    page_visit_data = assigns(:page_visit_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'page_visit' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'page_visit' }).where(time: previous_time_range)
+    assert_equal current_events.size, page_visit_data[:events_count]
+    assert_equal previous_events.size, page_visit_data[:previous_period_events_count]
+    assert_equal current_events.visitors_chart_data_for_page_visit_events['Single time visitor'], page_visit_data[:pie_chart_data]['Single time visitor']
+    assert_equal current_events.visitors_chart_data_for_page_visit_events['Recurring visitors'], page_visit_data[:pie_chart_data]['Recurring visitors']
+
+    # Click Events
+    click_event_data = assigns(:click_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'click' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'click' }).where(time: previous_time_range)
+    assert_equal current_events.size, click_event_data[:events_count]
+    assert_equal previous_events.size, click_event_data[:previous_period_events_count]
+    assert click_event_data[:label_grouped_events].keys.include?(click_event_1.label)
+    assert_equal current_events.with_label_grouped_data[click_event_1.label][:count], click_event_data[:label_grouped_events][click_event_1.label][:count]
+    assert click_event_data[:previous_label_grouped_events].keys.include?(click_event_2.label)
+    assert_equal previous_events.with_label_grouped_data[click_event_2.label][:count], click_event_data[:previous_label_grouped_events][click_event_2.label][:count]
+
+    # Video View Events
+    video_view_event_data = assigns(:video_view_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'video_view' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'video_view' }).where(time: previous_time_range)
+    assert_equal current_events.size, video_view_event_data[:events_count]
+    assert_equal previous_events.size, video_view_event_data[:previous_period_events_count]
+    assert_equal video_view_event_data[:watch_time], Ahoy::Event.where(id: [video_watch_event_1.id, video_watch_event_1_page_2.id]).total_watch_time_for_video_events
+    assert_equal video_view_event_data[:previous_watch_time], Ahoy::Event.where(id: video_watch_event_2.id).total_watch_time_for_video_events
+    assert_equal video_view_event_data[:avg_view_duration], Ahoy::Event.where(id: [video_watch_event_1.id, video_watch_event_1_page_2.id]).avg_view_duration_for_video_events
+    assert_equal video_view_event_data[:previous_avg_view_duration], Ahoy::Event.where(id: video_watch_event_2.id).avg_view_duration_for_video_events
+    assert_equal video_view_event_data[:avg_view_percent], Ahoy::Event.where(id: [video_watch_event_1.id, video_watch_event_1_page_2.id]).avg_view_percentage_for_video_events
+    assert_equal video_view_event_data[:previous_avg_view_percent], Ahoy::Event.where(id: video_watch_event_2.id).avg_view_percentage_for_video_events
 
     # When page params present, it should filter by page
     get v2_dashboard_url, params: {start_date: (Time.now.beginning_of_month - 2.months).strftime('%Y-%m-%d'), end_date: Time.now.end_of_month.strftime('%Y-%m-%d'), interval: "3 months", page: @page.id }
-  
-    assert_equal [page_visit_event_1.id], assigns(:page_visit_events).pluck(:id)
-    assert_equal [click_event_1.id], assigns(:click_events).pluck(:id)
-    assert_equal [video_watch_event_1.id], assigns(:video_view_events).pluck(:id)
 
-    assert_empty assigns(:previous_period_page_visit_events)
-    assert_equal [click_event_2.id], assigns(:previous_period_click_events).pluck(:id)
-    assert_equal [video_watch_event_2.id], assigns(:previous_period_video_view_events).pluck(:id)
+    current_time_range = assigns(:start_date).beginning_of_day..assigns(:end_date).end_of_day
+    previous_time_range = previous_time_interval_range(@controller.params[:interval], assigns(:start_date), assigns(:end_date))
+
+    # Page Visit Events
+    page_visit_data = assigns(:page_visit_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { page_id: @page.id }).jsonb_search(:properties, { category: 'page_visit' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { page_id: @page.id }).jsonb_search(:properties, { category: 'page_visit' }).where(time: previous_time_range)
+    assert_equal current_events.size, page_visit_data[:events_count]
+    assert_equal previous_events.size, page_visit_data[:previous_period_events_count]
+    assert_equal current_events.visitors_chart_data_for_page_visit_events['Single time visitor'], page_visit_data[:pie_chart_data]['Single time visitor']
+    assert_equal current_events.visitors_chart_data_for_page_visit_events['Recurring visitors'], page_visit_data[:pie_chart_data]['Recurring visitors']
+
+    # Click Events
+    click_event_data = assigns(:click_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { page_id: @page.id }).jsonb_search(:properties, { category: 'click' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { page_id: @page.id }).jsonb_search(:properties, { category: 'click' }).where(time: previous_time_range)
+    assert_equal current_events.size, click_event_data[:events_count]
+    assert_equal previous_events.size, click_event_data[:previous_period_events_count]
+    assert click_event_data[:label_grouped_events].keys.include?(click_event_1.label)
+    assert_equal current_events.with_label_grouped_data[click_event_1.label][:count], click_event_data[:label_grouped_events][click_event_1.label][:count]
+    assert click_event_data[:previous_label_grouped_events].keys.include?(click_event_2.label)
+    assert_equal previous_events.with_label_grouped_data[click_event_2.label][:count], click_event_data[:previous_label_grouped_events][click_event_2.label][:count]
+
+    # Video View Events
+    video_view_event_data = assigns(:video_view_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { page_id: @page.id }).jsonb_search(:properties, { category: 'video_view' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { page_id: @page.id }).jsonb_search(:properties, { category: 'video_view' }).where(time: previous_time_range)
+    assert_equal current_events.size, video_view_event_data[:events_count]
+    assert_equal previous_events.size, video_view_event_data[:previous_period_events_count]
+    assert_equal video_view_event_data[:previous_period_events_count], 1
+    assert_equal video_view_event_data[:watch_time], Ahoy::Event.where(id: video_watch_event_1.id).total_watch_time_for_video_events
+    assert_equal video_view_event_data[:previous_watch_time], Ahoy::Event.where(id: video_watch_event_2.id).total_watch_time_for_video_events
+    assert_equal video_view_event_data[:avg_view_duration], Ahoy::Event.where(id: video_watch_event_1.id).avg_view_duration_for_video_events
+    assert_equal video_view_event_data[:previous_avg_view_duration], Ahoy::Event.where(id: video_watch_event_2.id).avg_view_duration_for_video_events
+    assert_equal video_view_event_data[:avg_view_percent], Ahoy::Event.where(id: video_watch_event_1.id).avg_view_percentage_for_video_events
+    assert_equal video_view_event_data[:previous_avg_view_percent], Ahoy::Event.where(id: video_watch_event_2.id).avg_view_percentage_for_video_events
   end
 
   test "#dashboard: should show pie-chart data and last time-period comparision correctly" do
@@ -154,5 +239,87 @@ class Comfy::Admin::V2::DashboardControllerTest < ActionDispatch::IntegrationTes
     end
 
     assert_response :success
+  end
+
+  test "#dashboard: should set the hyperlink using event's name but not label in anchor tags of different analytics-section" do
+    @subdomain.update!(tracking_enabled: true)
+    visit = Ahoy::Visit.first
+
+    page_update_event_1 = visit.events.create(name: 'comfy-cms-page-update', user_id: @user.id, time: Time.now,  properties: {"label"=>"test_page_update", "visit_id"=>visit.id})
+    click_event_1 = visit.events.create(name: 'test-link-click', user_id: @user.id, time: Time.now, properties: {"tag"=>"BUTTON", "label"=>"test_link_page_2", "page_id"=>@page.id, "category"=>"click"})
+    form_submit_event_1 = visit.events.create(name: 'test-form-submitted', user_id: @user.id, time: Time.now,  properties: {"label"=>"form_submit_event", "page_id"=>@page.id, "category"=>"form_submit"}) 
+    section_view_event_1 = visit.events.create(name: 'test-section-view', user_id: @user.id, time: Time.now,  properties: {"label"=>"section_view_event", "page_id"=>@page.id, "category"=>"section_view"}) 
+
+    page_update_event_1_page_2 = visit.events.create(name: 'comfy-cms-page-update', user_id: @user.id, time: Time.now,  properties: {"label"=>"test_page_2_udpate", "page_id"=>@page_2.id, "visit_id"=>visit.id})
+    click_event_1_page_2 = visit.events.create(name: 'test-link-click', user_id: @user.id, time: Time.now, properties: {"tag"=>"BUTTON", "label"=>"test_link_page_2", "page_id"=>@page_2.id, "category"=>"click"})
+    form_submit_event_1_page_2 = visit.events.create(name: 'test-form-submitted', user_id: @user.id, time: Time.now,  properties: {"label"=>"form_submit_event_page_2", "page_id"=>@page_2.id, "category"=>"form_submit"}) 
+    section_view_event_1_page_2 = visit.events.create(name: 'test-section-view', user_id: @user.id, time: Time.now,  properties: {"label"=>"section_view_event_page_2", "page_id"=>@page_2.id, "category"=>"section_view"}) 
+
+    visit_1 = visit.dup
+    visit_1.save!
+
+    @user.update(can_manage_analytics: true)
+    sign_in(@user)  
+
+    get v2_dashboard_url
+
+    # default range should be current month and previous period should be last month
+    assert_equal Date.today.beginning_of_month, assigns(:start_date)
+    assert_equal Date.today.end_of_month, assigns(:end_date)
+
+    current_time_range = assigns(:start_date).beginning_of_day..assigns(:end_date).end_of_day
+    previous_time_range = previous_time_interval_range(@controller.params[:interval], assigns(:start_date), assigns(:end_date))
+
+    # Click Events
+    click_event_data = assigns(:click_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'click' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'click' }).where(time: previous_time_range)
+    assert_equal current_events.size, click_event_data[:events_count]
+    assert_equal previous_events.size, click_event_data[:previous_period_events_count]
+    assert click_event_data[:label_grouped_events].keys.include?(click_event_1.label)
+    assert click_event_data[:label_grouped_events].keys.include?(click_event_1_page_2.label)
+    assert_select "section.vr-analytics-section.vr-analytics-events.click-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: click_event_1.name), {count: 1, text: click_event_1.label}, "Uses name of click_event_1 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.click-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: click_event_1.label), {count: 0, text: click_event_1.label}, "Does not use label of click_event_1 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.click-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: click_event_1_page_2.name), {count: 1, text: click_event_1_page_2.label}, "Uses name of click_event_1_page_2 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.click-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: click_event_1_page_2.label), {count: 0, text: click_event_1_page_2.label}, "Does not use label of click_event_1_page_2 in the href attribute"
+
+    # Form Submit Events
+    form_submit_event_data = assigns(:form_submit_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'form_submit' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'form_submit' }).where(time: previous_time_range)
+    assert_equal current_events.size, form_submit_event_data[:events_count]
+    assert_equal previous_events.size, form_submit_event_data[:previous_period_events_count]
+    assert form_submit_event_data[:label_grouped_events].keys.include?(form_submit_event_1.label)
+    assert form_submit_event_data[:label_grouped_events].keys.include?(form_submit_event_1_page_2.label)
+    assert_select "section.vr-analytics-section.vr-analytics-events.form_submit-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: form_submit_event_1.name), {count: 1, text: form_submit_event_1.label}, "Uses name of form_submit_event_1 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.form_submit-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: form_submit_event_1.label), {count: 0, text: form_submit_event_1.label}, "Does not use label of form_submit_event_1 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.form_submit-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: form_submit_event_1_page_2.name), {count: 1, text: form_submit_event_1_page_2.label}, "Uses name of form_submit_event_1_page_2 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.form_submit-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: form_submit_event_1_page_2.label), {count: 0, text: form_submit_event_1_page_2.label}, "Does not use label of form_submit_event_1_page_2 in the href attribute"
+
+    # Section View Events
+    section_view_event_data = assigns(:section_view_events)
+    current_events = Ahoy::Event.jsonb_search(:properties, { category: 'section_view' }).where(time: current_time_range)
+    previous_events = Ahoy::Event.jsonb_search(:properties, { category: 'section_view' }).where(time: previous_time_range)
+    assert_equal current_events.size, section_view_event_data[:events_count]
+    assert_equal previous_events.size, section_view_event_data[:previous_period_events_count]
+    assert section_view_event_data[:label_grouped_events].keys.include?(section_view_event_1.label)
+    assert section_view_event_data[:label_grouped_events].keys.include?(section_view_event_1_page_2.label)
+    assert_select "section.vr-analytics-section.vr-analytics-events.section_view-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: section_view_event_1.name), {count: 1, text: section_view_event_1.label}, "Uses name of section_view_event_1 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.section_view-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: section_view_event_1.label), {count: 0, text: section_view_event_1.label}, "Does not use label of section_view_event_1 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.section_view-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: section_view_event_1_page_2.name), {count: 1, text: section_view_event_1_page_2.label}, "Uses name of section_view_event_1_page_2 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.section_view-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: section_view_event_1_page_2.label), {count: 0, text: section_view_event_1_page_2.label}, "Does not use label of section_view_event_1_page_2 in the href attribute"
+
+    # Legacy and System Events
+    system_events_data = assigns(:legacy_and_system_events)
+    current_events = Ahoy::Event.where.not('properties::jsonb ? :key', key: 'category').where.not(name: 'comfy-cms-page-visit').where(time: current_time_range)
+    previous_events = Ahoy::Event.where.not('properties::jsonb ? :key', key: 'category').where.not(name: 'comfy-cms-page-visit').where(time: previous_time_range)
+    assert_equal current_events.size, system_events_data[:events_count]
+    assert_equal previous_events.size, system_events_data[:previous_period_events_count]
+    assert system_events_data[:label_grouped_events].keys.include?(page_update_event_1.label)
+    assert system_events_data[:label_grouped_events].keys.include?(page_update_event_1_page_2.label)
+    assert_select "section.vr-analytics-section.vr-analytics-events.system_events-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: page_update_event_1.name), {count: 1, text: page_update_event_1.label}, "Uses name of page_update_event_1 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.system_events-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: page_update_event_1.label), {count: 0, text: page_update_event_1.label}, "Does not use label of page_update_event_1 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.system_events-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: page_update_event_1_page_2.name), {count: 1, text: page_update_event_1_page_2.label}, "Uses name of page_update_event_1_page_2 in the href attribute"
+    assert_select "section.vr-analytics-section.vr-analytics-events.system_events-section a.vr-analytics-event-label[href=?]", dashboard_events_path(ahoy_event_type: page_update_event_1_page_2.label), {count: 0, text: page_update_event_1_page_2.label}, "Does not use label of page_update_event_1_page_2 in the href attribute"
   end
 end

--- a/test/helpers/dashboard_helper_test.rb
+++ b/test/helpers/dashboard_helper_test.rb
@@ -12,54 +12,6 @@ class DashboardHelperTest < ActionView::TestCase
     assert_equal url_non_redactable , redact_private_urls(url_non_redactable)
   end
 
-  test 'page_visit_chart_data' do
-    travel_to Date.new(2023, 01, 26) do
-      visit = Ahoy::Visit.first
-      visit.update!(device_type: 'Desktop')
-      visit.events.create(name: 'test-page-view', user_id: 1, time: Time.now,  properties: {
-        label: "test_page_view",
-        page_id: 1,
-        category: "page_visit",
-      }) 
-
-      visit.events.create(name: 'test-page-view', user_id: 1, time: 1.day.ago,  properties: {
-        label: "test_page_view",
-        page_id: 1,
-        category: "page_visit",
-      }) 
-
-      visit.events.create(name: 'test-page-view', user_id: 1, time: 2.months.ago,  properties: {
-        label: "test_page_view",
-        page_id: 1,
-        category: "page_visit",
-      }) 
-
-      visit.events.create(name: 'test-page-view', user_id: 1, time: 6.months.ago,  properties: {
-        label: "test_page_view",
-        page_id: 1,
-        category: "page_visit",
-      }) 
-
-      visit.events.create(name: 'test-page-view', user_id: 1, time: 2.years.ago,  properties: {
-        label: "test_page_view",
-        page_id: 1,
-        category: "page_visit",
-      })
-      
-      # should split into days
-      assert_equal [{:name=>"Desktop", :data=>{"#{2.days.ago.strftime('%-d %^b %Y')}"=>0, "#{1.days.ago.strftime('%-d %^b %Y')}"=>1, "#{Time.now.strftime('%-d %^b %Y')}"=>1}}], page_visit_chart_data(Ahoy::Event.where(name: 'test-page-view').joins(:visit), 2.days.ago.to_date, Time.now.to_date)
-
-      # should split into weeks
-      assert_equal [{:name=>"Desktop", :data=>{"#{4.weeks.ago.strftime('%V')}"=>0, "#{3.weeks.ago.strftime('%V')}"=>0, "#{2.weeks.ago.strftime('%V')}"=>0, "#{1.weeks.ago.strftime('%V')}"=>2, "#{Time.now.strftime('%V')}"=>0}}], page_visit_chart_data(Ahoy::Event.where(name: 'test-page-view').joins(:visit), Time.now.beginning_of_month.to_date, Time.now.end_of_month.to_date)
-
-      # should split into months
-      assert_equal [{:name=>"Desktop", :data=>{"#{2.months.ago.strftime('%^b %Y')}"=>1, "#{1.months.ago.strftime('%^b %Y')}"=>0, "#{Time.now.strftime('%^b %Y')}"=>2}}], page_visit_chart_data(Ahoy::Event.where(name: 'test-page-view').joins(:visit), 2.months.ago.to_date, Time.now.to_date)
-
-      # should split into years
-      assert_equal [{:name=>"Desktop", :data=>{"#{2.years.ago.strftime('%Y')}"=>1, "#{1.years.ago.strftime('%Y')}"=>2, "#{Time.now.strftime('%Y')}"=>2}}], page_visit_chart_data(Ahoy::Event.where(name: 'test-page-view').joins(:visit), 2.years.ago.to_date, Time.now.to_date)
-    end
-  end
-
   test 'page_name' do
     assert_equal 'Website', page_name(nil)
 
@@ -89,65 +41,7 @@ class DashboardHelperTest < ActionView::TestCase
     assert_equal "This is a 100.0 % increase compared to the previous 10 days", tooltip_content(2, 1, 'Custom Range', (Time.now - 10.days).to_date, Time.now.to_date)
   end
 
-  test 'total watch time' do
-    mock_video_view_events
-    assert_equal 30000, total_watch_time(Ahoy::Event.where(id: [@video_watch_event_1, @video_watch_event_2].map(&:id)))
-  end
-
   test 'to_minutes' do
     assert_equal '10,000.0 min', to_minutes(10000*1000*60)
   end
-
-  test 'total_views' do
-    mock_video_view_events
-    assert_equal 2, total_views(Ahoy::Event.where(id: [@video_watch_event_1, @video_watch_event_2, @video_watch_event_3].map(&:id)))
-  end
-
-  test 'avg_view_duration' do
-    assert_equal 0, avg_view_duration([])
-    mock_video_view_events
-    assert_equal 25000.0, avg_view_duration(Ahoy::Event.where(id: [@video_watch_event_1, @video_watch_event_2, @video_watch_event_3].map(&:id)))
-  end
-
-  test 'avg_view_percentange' do
-    mock_video_view_events
-    assert_equal 50.0, avg_view_percentage(Ahoy::Event.where(id: [@video_watch_event_1, @video_watch_event_2, @video_watch_event_3].map(&:id)))
-  end
-
-  private 
-  
-  def mock_video_view_events
-    api_resource = api_resources(:one)
-    api_resource_2 = api_resources(:two)
-    visit = Ahoy::Visit.first
-    @video_watch_event_1 = visit.events.create(name: 'test-video-watched', user_id: 1, time: Time.now,  properties: {
-      label: "watched_this_video",
-      page_id: 1,
-      category: "video_view",
-      watch_time: 10000,
-      resource_id: api_resource.id,
-      video_start: true,
-      total_duration: 40000
-    }) 
-
-    @video_watch_event_2 = visit.events.create(name: 'test-video-watched', user_id: 1, time: Time.now,  properties: {
-      label: "watched_this_video",
-      category: "video_view",
-      page_id: 1,
-      watch_time: 20000,
-      resource_id: api_resource_2.id,
-      video_start: true,
-      total_duration: 80000
-    }) 
-
-    @video_watch_event_3 = visit.events.create(name: 'test-video-watched', user_id: 1, time: Time.now,  properties: {
-      label: "watched_this_video",
-      category: "video_view",
-      page_id: 1,
-      watch_time: 20000,
-      resource_id: api_resource.id,
-      video_start: false,
-      total_duration: 40000
-    })
-  end 
 end

--- a/test/integration/mini_profiler_test.rb
+++ b/test/integration/mini_profiler_test.rb
@@ -1,0 +1,340 @@
+require "test_helper"
+
+class Rack::MiniProfilerTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.env.stubs(:test?).returns(false)
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(true)
+
+    @restarone_subdomain = Subdomain.find_by(name: 'restarone')
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user = User.find_by(email: 'contact@restarone.com')
+      @restarone_user.update(can_manage_analytics: true)
+    end
+  end
+
+  test "should show mini-profiler badge if user is permissioned properly" do
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true)
+
+      sign_in(@restarone_user)
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name)
+
+      assert_response :success
+      assert response.headers.has_key?('X-MiniProfiler-Ids')
+      assert response.body.include?('/mini-profiler-resources/includes.js')
+    end
+  end
+
+  test "should not show mini-profiler badge if user cannot access admin or profiler" do
+    # In unhappy case, the cookies are invalid.
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(false)
+
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: false, show_profiler: true)
+
+      sign_in(@restarone_user)
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name)
+      assert_response :redirect
+
+      refute response.headers.has_key?('X-MiniProfiler-Ids')
+      refute response.body.include?('/mini-profiler-resources/includes.js')
+      
+      @restarone_user.update(can_access_admin: true, show_profiler: false)
+
+      sign_in(@restarone_user)
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name)
+      assert_response :success
+
+      refute response.headers.has_key?('X-MiniProfiler-Ids')
+      refute response.body.include?('/mini-profiler-resources/includes.js')
+    end
+  end
+
+  # pp=env - START
+  test "should show env details only if the user is properly permissioned and also a global_admin" do
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: true)
+
+      sign_in(@restarone_user)
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'env' }
+
+      assert_response :success
+      assert response.headers['Content-Type'].include?('text/plain')
+      assert_match 'QUERY_STRING', response.body
+      assert_match "Rack Environment\n---------------", response.body
+    end
+  end
+
+  test "should not show env details if the user is properly permissioned but not a global_admin" do
+    # In unhappy case, the cookies are invalid.
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(false)
+
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+
+      sign_in(@restarone_user)
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'env' }
+
+      assert_response :success
+      refute response.headers['Content-Type'].include?('text/plain')
+      refute_match 'QUERY_STRING', response.body
+      refute_match "Rack Environment\n---------------", response.body
+      refute response.headers.has_key?('X-MiniProfiler-Ids')
+      refute response.body.include?('/mini-profiler-resources/includes.js')
+    end
+  end
+
+  test "should not show env details if the user is global_admin but not properly permissioned" do
+    # In unhappy case, the cookies are invalid.
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(false)
+
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: false, global_admin: true)
+
+      sign_in(@restarone_user)
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'env' }
+
+      assert_response :success
+      refute response.headers['Content-Type'].include?('text/plain')
+      refute_match 'QUERY_STRING', response.body
+      refute_match "Rack Environment\n---------------", response.body
+      refute response.headers.has_key?('X-MiniProfiler-Ids')
+      refute response.body.include?('/mini-profiler-resources/includes.js')
+
+      @restarone_user.update(can_access_admin: false, show_profiler: true, global_admin: true)
+
+      sign_in(@restarone_user)
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'env' }
+
+      assert_response :redirect
+      refute response.headers['Content-Type'].include?('text/plain')
+      refute_match 'QUERY_STRING', response.body
+      refute_match "Rack Environment\n---------------", response.body
+      refute response.headers.has_key?('X-MiniProfiler-Ids')
+      refute response.body.include?('/mini-profiler-resources/includes.js')
+    end
+  end
+  # pp=env - END
+
+  # OTHER pp values - START
+
+  # pp=profile-memory - START
+  test "should show profile-memory details if the user is properly permissioned regardless of being global_admin" do
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'profile-memory' }
+
+      assert_response :success
+      assert response.headers['Content-Type'].include?('text/plain')
+      refute response.headers['Content-Type'].include?('text/html')
+      assert_match 'Total allocated:', response.body
+      assert_match 'Total retained:', response.body
+      assert_match 'allocated memory by gem', response.body
+      assert_match 'allocated memory by file', response.body
+      assert_match 'allocated memory by location', response.body
+      assert_match 'allocated memory by class', response.body
+      assert_match 'allocated objects by gem', response.body
+      assert_match 'allocated objects by file', response.body
+      assert_match 'allocated objects by location', response.body
+      assert_match 'allocated objects by class', response.body
+      assert_match 'retained memory by gem', response.body
+      assert_match 'retained memory by file', response.body
+      assert_match 'retained memory by location', response.body
+      assert_match 'retained memory by class', response.body
+      assert_match 'retained objects by gem', response.body
+      assert_match 'retained objects by file', response.body
+      assert_match 'retained objects by location', response.body
+      assert_match 'retained objects by class', response.body
+    end
+  end
+
+  test "should not show profile-memory details if the user is not properly permissioned" do
+    # In unhappy case, the cookies are invalid.
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(false)
+
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: false, global_admin: false)
+      sign_in(@restarone_user)
+
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'profile-memory' }
+
+      assert_response :success
+      assert response.headers['Content-Type'].include?('text/html')
+      refute response.headers['Content-Type'].include?('text/plain')
+
+      refute_match 'Total allocated:', response.body
+      refute_match 'Total retained:', response.body
+      refute_match 'allocated memory by gem', response.body
+      refute_match 'allocated memory by file', response.body
+      refute_match 'allocated memory by location', response.body
+      refute_match 'allocated memory by class', response.body
+      refute_match 'allocated objects by gem', response.body
+      refute_match 'allocated objects by file', response.body
+      refute_match 'allocated objects by location', response.body
+      refute_match 'allocated objects by class', response.body
+      refute_match 'retained memory by gem', response.body
+      refute_match 'retained memory by file', response.body
+      refute_match 'retained memory by location', response.body
+      refute_match 'retained memory by class', response.body
+      refute_match 'retained objects by gem', response.body
+      refute_match 'retained objects by file', response.body
+      refute_match 'retained objects by location', response.body
+      refute_match 'retained objects by class', response.body
+    end
+  end
+  # pp=profile-memory - END
+  
+  # pp=profile-gc - START
+  test "should show profile-gc details if the user is properly permissioned regardless of being global_admin" do
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+      
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'profile-gc' }
+      
+      assert_response :success
+      assert response.headers['Content-Type'].include?('text/plain')
+      refute response.headers['Content-Type'].include?('text/html')
+
+      assert_match 'Initial state: object count:', response.body
+      assert_match 'Memory allocated outside heap (bytes):', response.body
+      assert_match 'GC Stats:', response.body
+      assert_match 'ObjectSpace delta caused by request:', response.body
+      assert_match 'ObjectSpace stats:', response.body
+      assert_match 'String stats:', response.body
+    end
+  end
+
+  test "should not show profile-gc details if the user is not properly permissioned" do
+    # In unhappy case, the cookies are invalid.
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(false)
+
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+      
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'profile-gc' }
+      
+      assert_response :success
+      refute response.headers['Content-Type'].include?('text/plain')
+      assert response.headers['Content-Type'].include?('text/html')
+
+      refute_match 'Initial state: object count:', response.body
+      refute_match 'Memory allocated outside heap (bytes):', response.body
+      refute_match 'GC Stats:', response.body
+      refute_match 'ObjectSpace delta caused by request:', response.body
+      refute_match 'ObjectSpace stats:', response.body
+      refute_match 'String stats:', response.body
+    end
+  end
+  # pp=profile-gc - END
+  
+  # pp=analyze-memory - START
+  test "should show analyze-memory details if the user is properly permissioned regardless of being global_admin" do
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+      
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'analyze-memory' }
+      
+      assert_response :success
+      assert response.headers['Content-Type'].include?('text/plain')
+      refute response.headers['Content-Type'].include?('text/html')
+
+      assert_match 'ObjectSpace stats:', response.body
+      assert_match '1000 Largest strings:', response.body
+    end
+  end
+
+  test "should not show analyze-memory details if the user is not properly permissioned" do
+    # In unhappy case, the cookies are invalid.
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(false)
+
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+      
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'analyze-memory' }
+      
+      assert_response :success
+      refute response.headers['Content-Type'].include?('text/plain')
+      assert response.headers['Content-Type'].include?('text/html')
+
+      refute_match 'ObjectSpace stats:', response.body
+      refute_match '1000 Largest strings:', response.body
+    end
+  end
+  # pp=analyze-memory - END
+  
+  # pp=trace-exceptions - START
+  test "should show trace-exceptions details if the user is properly permissioned regardless of being global_admin" do
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+      
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'trace-exceptions' }
+      
+      assert_response :success
+      assert response.headers['Content-Type'].include?('text/plain')
+      refute response.headers['Content-Type'].include?('text/html')
+
+      assert_match 'Exceptions raised during request', response.body
+    end
+  end
+
+  test "should not show trace-exceptions details if the user is not properly permissioned" do
+    # In unhappy case, the cookies are invalid.
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(false)
+
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+      
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'trace-exceptions' }
+      
+      assert_response :success
+      refute response.headers['Content-Type'].include?('text/plain')
+      assert response.headers['Content-Type'].include?('text/html')
+
+      refute_match 'Exceptions raised during request', response.body
+    end
+  end
+  # pp=trace-exceptions - END
+  
+  # pp=help - START
+  test "should show help details if the user is properly permissioned regardless of being global_admin" do
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+      
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'help' }
+      
+      assert_response :success
+      assert response.headers['Content-Type'].include?('text/html')
+
+      assert_match "This is the help menu of the <a href='https://github.com/MiniProfiler/rack-mini-profiler'>rack-mini-profiler</a> gem, append the following to your query string for more options:", response.body
+    end
+  end
+
+  test "should not show help details if the user is not properly permissioned" do
+    # In unhappy case, the cookies are invalid.
+    Rack::MiniProfiler::ClientSettings.any_instance.stubs(:has_valid_cookie?).returns(false)
+
+    Apartment::Tenant.switch @restarone_subdomain.name do
+      @restarone_user.update(can_access_admin: true, show_profiler: true, global_admin: false)
+      sign_in(@restarone_user)
+      
+      get v2_dashboard_url(subdomain: @restarone_subdomain.name), params: { pp: 'help' }
+      
+      assert_response :success
+      assert response.headers['Content-Type'].include?('text/html')
+
+      refute_match "This is the help menu of the <a href='https://github.com/MiniProfiler/rack-mini-profiler'>rack-mini-profiler</a> gem, append the following to your query string for more options:", response.body
+    end
+  end
+  # pp=help - END
+
+  # OTHER pp values - END
+end

--- a/test/models/ahoy/event_test.rb
+++ b/test/models/ahoy/event_test.rb
@@ -1,0 +1,104 @@
+require "test_helper"
+
+class Event < ActiveSupport::TestCase
+  include DashboardHelper
+
+  setup do
+    api_resource = api_resources(:one)
+    api_resource_2 = api_resources(:two)
+    visit = Ahoy::Visit.first
+    @video_watch_event_1 = visit.events.create(name: 'test-video-watched', user_id: 1, time: Time.now,  properties: {
+      label: "watched_this_video",
+      page_id: 1,
+      category: "video_view",
+      watch_time: 10000,
+      resource_id: api_resource.id,
+      video_start: true,
+      total_duration: 40000
+    }) 
+
+    @video_watch_event_2 = visit.events.create(name: 'test-video-watched', user_id: 1, time: Time.now,  properties: {
+      label: "watched_this_video",
+      category: "video_view",
+      page_id: 1,
+      watch_time: 20000,
+      resource_id: api_resource_2.id,
+      video_start: true,
+      total_duration: 80000
+    }) 
+
+    @video_watch_event_3 = visit.events.create(name: 'test-video-watched', user_id: 1, time: Time.now,  properties: {
+      label: "watched_this_video",
+      category: "video_view",
+      page_id: 1,
+      watch_time: 20000,
+      resource_id: api_resource.id,
+      video_start: false,
+      total_duration: 40000
+    })
+  end
+  
+  test 'total watch time' do
+    assert_equal 30000, Ahoy::Event.where(id: [@video_watch_event_1, @video_watch_event_2].map(&:id)).total_watch_time_for_video_events
+  end
+
+  test 'total_views' do
+    assert_equal 2, Ahoy::Event.where(id: [@video_watch_event_1, @video_watch_event_2, @video_watch_event_3].map(&:id)).total_views_for_video_events
+  end
+
+  test 'avg_view_duration' do
+    assert_equal 25000.0, Ahoy::Event.where(id: [@video_watch_event_1, @video_watch_event_2, @video_watch_event_3].map(&:id)).avg_view_duration_for_video_events
+  end
+
+  test 'avg_view_percentange' do
+    assert_equal 50.0, Ahoy::Event.where(id: [@video_watch_event_1, @video_watch_event_2, @video_watch_event_3].map(&:id)).avg_view_percentage_for_video_events
+  end
+
+  test 'page_visit_chart_data' do
+    travel_to Date.new(2023, 01, 26) do
+      visit = Ahoy::Visit.first
+      visit.update!(device_type: 'Desktop')
+      visit.events.create(name: 'test-page-view', user_id: 1, time: Time.now,  properties: {
+        label: "test_page_view",
+        page_id: 1,
+        category: "page_visit",
+      }) 
+
+      visit.events.create(name: 'test-page-view', user_id: 1, time: 1.day.ago,  properties: {
+        label: "test_page_view",
+        page_id: 1,
+        category: "page_visit",
+      }) 
+
+      visit.events.create(name: 'test-page-view', user_id: 1, time: 2.months.ago,  properties: {
+        label: "test_page_view",
+        page_id: 1,
+        category: "page_visit",
+      }) 
+
+      visit.events.create(name: 'test-page-view', user_id: 1, time: 6.months.ago,  properties: {
+        label: "test_page_view",
+        page_id: 1,
+        category: "page_visit",
+      }) 
+
+      visit.events.create(name: 'test-page-view', user_id: 1, time: 2.years.ago,  properties: {
+        label: "test_page_view",
+        page_id: 1,
+        category: "page_visit",
+      })
+      
+      # should split into days
+      assert_equal [{:name=>"Desktop", :data=>{"#{2.days.ago.strftime('%-d %^b %Y')}"=>0, "#{1.days.ago.strftime('%-d %^b %Y')}"=>1, "#{Time.now.strftime('%-d %^b %Y')}"=>1}}], Ahoy::Event.where(name: 'test-page-view').joins(:visit).page_visit_chart_data_for_page_visit_events(2.days.ago.to_date..Time.now.to_date, split_into(2.days.ago.to_date, Time.now.to_date))
+
+      # should split into weeks
+      assert_equal [{:name=>"Desktop", :data=>{"#{4.weeks.ago.strftime('%V')}"=>0, "#{3.weeks.ago.strftime('%V')}"=>0, "#{2.weeks.ago.strftime('%V')}"=>0, "#{1.weeks.ago.strftime('%V')}"=>2, "#{Time.now.strftime('%V')}"=>0}}], Ahoy::Event.where(name: 'test-page-view').joins(:visit).page_visit_chart_data_for_page_visit_events(Time.now.beginning_of_month.to_date..Time.now.end_of_month.to_date, split_into(Time.now.beginning_of_month.to_date, Time.now.end_of_month.to_date))
+
+      # should split into months
+      assert_equal [{:name=>"Desktop", :data=>{"#{2.months.ago.strftime('%^b %Y')}"=>1, "#{1.months.ago.strftime('%^b %Y')}"=>0, "#{Time.now.strftime('%^b %Y')}"=>2}}], Ahoy::Event.where(name: 'test-page-view').joins(:visit).page_visit_chart_data_for_page_visit_events(2.months.ago.to_date..Time.now.to_date, split_into(2.months.ago.to_date, Time.now.to_date))
+
+      # should split into years
+      assert_equal [{:name=>"Desktop", :data=>{"#{2.years.ago.strftime('%Y')}"=>1, "#{1.years.ago.strftime('%Y')}"=>2, "#{Time.now.strftime('%Y')}"=>2}}], Ahoy::Event.where(name: 'test-page-view').joins(:visit).page_visit_chart_data_for_page_visit_events(2.years.ago.to_date..Time.now.to_date, split_into(2.years.ago.to_date, Time.now.to_date))
+    end
+  end
+end


### PR DESCRIPTION
Addresses: https://github.com/restarone/violet_rails/issues/1399 and https://github.com/restarone/violet_rails/issues/1452

## Profiling Results 📈 🧪 


### Slight improvements to user experience

When analysis going back 1 year is shown, there is a noticeable performance improvement:

<img width="1728" alt="Screen Shot 2023-04-08 at 11 03 31 AM" src="https://user-images.githubusercontent.com/35935196/230728720-31d5d2c0-83e0-4aa2-b3ef-fede1458ff4f.png">

### Less memory & objects used
When a 1 year analysis is shown, less memory and objects are allocated and retained: 

<img width="1728" alt="Screen Shot 2023-04-08 at 11 04 09 AM" src="https://user-images.githubusercontent.com/35935196/230728751-5302c578-4240-4f77-8ac8-166d2046be27.png">

### Garbage collector is running consistently 
on a per request basis, we observe that the garbage collector runs before the request is served. Indicating that used memory has been drained and freed to be used for other requests. 

<img width="1728" alt="Screen Shot 2023-04-08 at 11 06 48 AM" src="https://user-images.githubusercontent.com/35935196/230728822-c1f86bd8-b8fb-45ee-86fa-848c27698a6f.png">