### PR TITLE
[feature] improved API namespaces list view

### DIFF
--- a/app/assets/stylesheets/api_namespaces.scss
+++ b/app/assets/stylesheets/api_namespaces.scss
@@ -2,6 +2,20 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+#comfy.c-comfy-admin-api_namespaces.a-index #cms-main {
+  padding-bottom: 0;
+}
+
+#comfy.c-comfy-admin-api_namespaces  .read .toggle-cat-edit {
+  background-color: var(--color-primary);
+}
+
+#comfy .list-view .badge-primary {
+  background-color: #EDEBFE;
+  font-weight: 500;
+  color: #252525;
+}
+
 .api-namespace-show {
   background-color: #FCFEFF;
 
@@ -26,7 +40,7 @@
           border: 1px solid #49505714;
           box-shadow: 0px 8px 10px #0108150A;
           border-radius: 4px;
-          color: #705AFE;
+          color: var(--color-primary);
           font-weight: 600;
         }
       }
@@ -42,139 +56,162 @@
   }
 }
 
-#api-resources-list{
-  a:not(.btn) {
-    color: #6F5AFE;
+.list-view {
+  --base-line-height: 17px;
+  --base-font-size: 14px;
+  --border-radius: 6px;
+
+  .col-form-label {
+    font-weight: 500;
   }
 
   .digg_pagination {
     border-bottom: 1px solid #343A4014;;
   }
 
-  .api-resources-table-container {
-    max-height: 700px;
-    overflow: auto;
-    border-top: 1px solid #dee2e6;
-    border-bottom: 1px solid #dee2e6;
+  .view-dynamic-column {
+    white-space: nowrap;
+  }
 
-    #api-resources-table {
-      font-size: 14px;
-      line-height: 17px;
-      border-collapse: collapse;
+  a:not(.btn) {
+    color: var(--color-primary);
+  }
 
-      thead tr th {
-        position: sticky;
-        top: 0;
-        height: 57px;
-        vertical-align: middle;
-        border: 1px solid #dee2e6;
-        background: #ffffff;
-        text-align: center;
+  &--instant-search .search-box {
+    position: relative;
+    display: flex;
+    align-items: center;
 
-        a {
-          color: #495057;
-          font-weight: 500;
-        }
+    input[type='search'] {
+      height: 48px;
+      background: #B1B1B10A 0% 0% no-repeat padding-box;
+      border: 1px solid #ADB1B6;
+      border-radius: 4px;
+
+      &::-webkit-search-cancel-button{
+        height: 20px;
+        width: 20px;
+        border-radius:10px;
+        cursor: pointer;
       }
+    }
 
-      td {
-        vertical-align: middle;
+    .search-action {
+      position: absolute;
+      right: 0;
 
-        .td-content {
-          height: 80px;
-          max-height: 80px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          min-width: 80px;
-        }
-
-        .clamp-content {
-          display: -webkit-box;
-          max-width: 300px;
-          -webkit-line-clamp: 3;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
-          min-width: 180px;
-        }
-      }
-    
-      .date-col {
-        min-width: 130px;
-      }
-    
-      .view-dynamic-column {
-        white-space: nowrap;
+      .clear-text-btn {
+        border: none;
+        outline: none;
+        background-color: transparent;
       }
     }
   }
-  
-  & > form {
-  
-    .search-box {
-      position: relative;
-      display: flex;
-      align-items: center;
 
-      input[type='search'] {
-        height: 48px;
-        background: #B1B1B10A 0% 0% no-repeat padding-box;
-        border: 1px solid #E3E5E9;
-        border-radius: 4px;
+  &__table-container {
+    // Since Sass is case-sensitive and CSS isn't, the CSS version of max() will be used
+    // If max() is used instead of MAX(), Sass will throw a compilation error (Incompatible units px and vh)
+    max-height: MAX(700px, 78.8vh);
+    overflow: auto;
+    border-top: 1px solid #dee2e6;
+  }
 
-        &::-webkit-search-cancel-button{
-          height: 20px;
-          width: 20px;
-          border-radius:10px;
-          cursor: pointer;
-        }
-      }
-  
-      .search-action {
-        position: absolute;
-        right: 0;
+  &__status-text {
+    padding: 2px 10px 4px;
+    border-radius: var(--border-radius);
+    font-weight: 500;
 
-        .clear-text-btn {
-          border: none;
-          outline: none;
-          background-color: transparent;
-        }
+    &--success {
+      background-color: #DEF7EC;
+      color: #03543F;
+    }
+
+    &--failure {
+      background-color: #FEEEEB;
+      color: #C6444A;
+    }
+  }
+
+  .table {
+    margin-bottom: 0;
+    font-size: var(--base-font-size);
+    border-collapse: collapse;
+
+    thead tr th {
+      position: sticky;
+      top: 0;
+      height: 57px;
+      vertical-align: middle;
+      border: 1px solid #dee2e6;
+      background: #ffffff;
+      text-align: center;
+
+      a {
+        text-transform: uppercase;
+        font-size: 12px;
+        color: #6B7280;
+        font-weight: 600;
       }
     }
 
-    #created-at-filter,
-    #updated-at-filter {
-      cursor: pointer;
+    td {
+      vertical-align: middle;
+
+      .td-content {
+        --content-size: 80px;
+        height: var(--content-size);
+        max-height: var(--content-size);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-width: var(--content-size);
+      }
+
+      .clamp-content {
+        display: -webkit-box;
+        max-width: 300px;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        min-width: 180px;
+      }
     }
+  }
+
+  .modal-header {
+    border-bottom: none;
+  }
+
+  .modal-title {
+    text-transform: capitalize;
+    font-size: calc(var(--base-font-size) + 2px);
+    line-height: calc(var(--base-line-height) + 2px);
+    font-weight: 600;
+  }
+
+  .modal-subtitle {
+    font-size: var(--base-font-size);
+    line-height: var(--base-line-height);
   }
 
   .modal {
-    .modal-header {
-      border-bottom: none;
-
-      .modal-title {
-        text-transform: capitalize;
-        font-size: 16px;
-        line-height: 19px;
-        font-weight: 600;
-      } 
-    }
-  
-    #modal-id {
-      font-size: 14px;
-      line-height: 17px;
-    }
-  
-    pre#modal-body-content {
+    pre.modal-body-content {
       white-space: break-spaces;
       background-color: #343A400A;
-      font-size: 14px;
-      line-height: 17px;
-      border-radius: 6px;
+      font-size: var(--base-font-size);
+      border-radius: var(--border-radius);
       font-family: inherit;
     }
   }
 
+  @media (min-width: 576px) {
+    .modal-dialog-container {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
 
   @media (max-width: 576px) {
     .modal-dialog {
@@ -182,6 +219,26 @@
       bottom: 0;
       margin: 0;
       width: 100%
+    }
+  }
+}
+
+#api-namespaces-list {
+  .td-content {
+    height: auto;
+    max-height: unset;
+    min-height: var(--content-size);
+  }
+}
+
+#api-resources-list{
+  .table {
+    line-height: var(--line-height);
+  }
+  & > form {
+    #created-at-filter,
+    #updated-at-filter {
+      cursor: pointer;
     }
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,10 @@
  @import './direct_upload.scss';
  @import 'daterangepicker/daterangepicker';
 
+ :root {
+  --color-primary: #6C5BF5;
+ }
+
  .alert-file_url {
    display: none;
 }

--- a/app/assets/stylesheets/comfy/admin/cms/custom.sass
+++ b/app/assets/stylesheets/comfy/admin/cms/custom.sass
@@ -18,7 +18,7 @@ select[id=layout_app_layout]
 // customizations for violet branding
 #comfy
 	.badge-primary, .btn-primary, .btn-success
-		background-color: #6F5AFE
+		background-color: var(--color-primary)
 		border: none
 	.badge-secondary, .btn-secondary
 		background-color: #A75AFE

--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -35,6 +35,12 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
     else
       @api_namespaces = @api_namespaces_q.result.paginate(page: params[:page], per_page: 10)
     end
+
+    if turbo_frame_request?
+      render partial: 'table', locals: { api_namespaces: @api_namespaces, api_namespaces_q: @api_namespaces_q }
+    else
+      render :index
+    end
   end
 
   # GET /api_namespaces/1 or /api_namespaces/1.json
@@ -95,6 +101,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
     respond_to do |format|
       format.html { redirect_to api_namespaces_url, notice: "Api namespace was successfully destroyed." }
       format.json { head :no_content }
+      format.js
     end
   end
 

--- a/app/javascript/controllers/api_namespaces_controller.js
+++ b/app/javascript/controllers/api_namespaces_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus";
+
+/*
+ * Usage
+ * =====
+ *
+ * add data-controller="api-namespaces" to the common ancestor that contains Search form, pagination, and table
+ *
+ * Actions:
+ * Add this to "View more" link -> data-action="click->api-namespaces#showPropertiesModal"
+ * 
+ * Targets:
+ * Add this to #propertiesModal -> data-api-namespaces-target="propertiesModal"
+*/
+
+export default class extends Controller {
+	static targets = ['propertiesModal'];
+
+	showPropertiesModal(e) {
+		const dataset = e.target.dataset;
+		this.propertiesModalTarget.querySelector('#propertiesModal .modal-subtitle').innerHTML = `Namespace: <a href="/api_namespaces/${dataset.namespaceSlug}">${dataset.namespaceName}</a>`;
+		this.propertiesModalTarget.querySelector('#propertiesModal .modal-body-content').textContent = dataset.value;
+	}
+}

--- a/app/javascript/controllers/api_resources_controller.js
+++ b/app/javascript/controllers/api_resources_controller.js
@@ -2,8 +2,21 @@ import { Controller } from "@hotwired/stimulus";
 import moment from "moment";
 import 'daterangepicker';
 
+/*
+ * Usage
+ * =====
+ *
+ * add data-controller="api-resources" to the common ancestor that contains Search form, pagination, and table
+ *
+ * Actions:
+ * Add this to "View <property_name>" link -> data-action="click->api-resources#showModal"
+ *
+ * Targets:
+ * Add this to #myModal -> data-api-resources-target="modal"
+*/
+
 export default class extends Controller {
-  static targets = [ 'searchForm', 'modal' ]
+  static targets = ['modal']
 
   ranges = {
     'Last 7 days': [moment().subtract(6, 'days'), moment()],
@@ -41,45 +54,12 @@ export default class extends Controller {
       $('#q_updated_at_gteq').val(start.format('YYYY-MM-DD'));
       $('#q_updated_at_end_of_day_lteq').val(end.format('YYYY-MM-DD')).trigger("input");
     });
-
-    $(this.searchFormTarget).on("input", (_event, _params) => {
-      this.search();
-    });
-  }
-
-  search() {
-    clearTimeout(this.timeout)
-    this.timeout = setTimeout(() => {
-      this.searchFormTarget.requestSubmit();
-    }, 200)
-  }
-
-  clearText() {
-    const searchField = this.searchFormTarget.querySelector("input[type='search']");
-    searchField.value = "";
-    this.searchFormTarget.requestSubmit();
   }
 
   showModal(e) {
     const dataset = e.target.dataset;
     this.modalTarget.querySelector('#myModalLabel').textContent = dataset['column'];
-    this.modalTarget.querySelector('#modal-id').innerHTML = `ID: <a href="/api_namespaces/${dataset['namespaceId']}/resources/${dataset['id']}">${dataset['id']}</a>`;
-    this.modalTarget.querySelector('#modal-body-content').textContent = dataset['value'];
-  }
-
-  reloadTable() {
-    const params = new URLSearchParams(location.search);
-    // preserve page and sort order number while submitting form
-    if (params.get('page')) {
-      $(this.searchFormTarget).append(`<input type="hidden" name="page" value="${params.get('page')}" />`);
-    }
-
-    if (params.get('q[s]')) {
-      $(this.searchFormTarget).append(`<input type="hidden" name="q[s]" value="${params.get('q[s]')}" />`);
-    }
-    this.searchFormTarget.requestSubmit();
-
-    this.searchFormTarget.querySelector('input[name="page"]')?.remove();
-    this.searchFormTarget.querySelector('input[name="q[s]"]')?.remove();
+    this.modalTarget.querySelector('#myModal .modal-subtitle').innerHTML = `ID: <a href="/api_namespaces/${dataset['namespaceId']}/resources/${dataset['id']}">${dataset['id']}</a>`;
+    this.modalTarget.querySelector('#myModal .modal-body-content').textContent = dataset['value'];
   }
 }

--- a/app/javascript/controllers/list_view_controller.js
+++ b/app/javascript/controllers/list_view_controller.js
@@ -1,0 +1,70 @@
+import { Controller } from "@hotwired/stimulus";
+
+/*
+ * Usage
+ * =====
+ *
+ * add data-controller="list-view" to the common ancestor that contains Search form, pagination, and table
+ *
+ * Actions:
+ * Add this to the Delete icon link data-action="ajax:success->list-view#reloadTable"
+ *
+ * Targets:
+ * Add this to Search form -> data-list-view-target="searchForm"
+ *
+ * Enabling instant search
+ * Add class "list-view--instant-search" to the element having data-controller="list-view"
+ * Add data-instant-search-mode="true" to the Search form
+*/
+
+export default class extends Controller {
+  static targets = ["searchForm"];
+
+  initialize() {
+    const instantSearchMode = this.searchFormTarget.dataset.instantSearchMode;
+    if (instantSearchMode == "true") {
+      $(this.searchFormTarget).on("input", (_event, _params) => {
+        this.instantSearch();
+      });
+    } else {
+      // Submit the form when the user clicks on 'X' icon in the search input box
+      // Clear search results and show all list items when the user clicks on 'X' icon
+      $(this.searchFormTarget).on("input", (_event, _params) => {
+        if (_event.target.value == "") this.searchFormTarget.requestSubmit();
+      });
+    }
+  }
+
+  instantSearch() {
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout(() => {
+      this.searchFormTarget.requestSubmit();
+    }, 200);
+  }
+
+  reloadTable() {
+    const tableRows = document.querySelectorAll(".list-view tbody tr");
+    const params = new URLSearchParams(location.search);
+    // preserve page and sort order number while submitting form
+    if (params.get('page')) {
+      const pageNumber = getVerifiedPageNumber();
+      $(this.searchFormTarget).append(`<input type="hidden" name="page" value="${pageNumber}" />`);
+    }
+
+    if (params.get('q[s]')) {
+      $(this.searchFormTarget).append(`<input type="hidden" name="q[s]" value="${params.get('q[s]')}" />`);
+    }
+    this.searchFormTarget.requestSubmit();
+
+    this.searchFormTarget.querySelector('input[name="page"]')?.remove();
+    this.searchFormTarget.querySelector('input[name="q[s]"]')?.remove();
+
+    function getVerifiedPageNumber() {
+      const pageNumber = Number.parseFloat(params.get('page'));
+      // if the page number is greater than 1 and there is one remaining table row, then go to the previous page
+      // because after deletion, there will be no table row on this page
+      if (pageNumber > 1 && tableRows.length == 1) return (pageNumber - 1).toString();
+      return pageNumber.toString();
+    }
+  }
+}

--- a/app/views/comfy/admin/api_namespaces/_table.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_table.html.haml
@@ -1,0 +1,75 @@
+= turbo_frame_tag 'api-namespaces' do
+  .digg_pagination.d-sm-flex.justify-content-between.mb-4.pb-3
+    .page-info
+      = page_entries_info api_namespaces
+    .links
+      = will_paginate api_namespaces, container: false, renderer: TurboPaginateRenderer
+  .table-responsive.bg-white
+    .list-view__table-container
+      %table.table.table-striped.table-bordered
+        %thead
+          %tr
+            %th.px-3
+            %th.px-3
+              = sort_link api_namespaces_q, :name, {}, data: { turbo: true, turbo_action: 'advance' }
+            %th.px-3
+              = sort_link api_namespaces_q, :version, {}, data: { turbo: true, turbo_action: 'advance' }
+            %th.px-3
+              = sort_link api_namespaces_q, :properties, {}, data: { turbo: true, turbo_action: 'advance' }
+            %th.px-3
+              = sort_link api_namespaces_q, :requires_authentication, {}, data: { turbo: true, turbo_action: 'advance' }
+            %th.px-3
+              = sort_link api_namespaces_q, :namespace_type, {}, data: { turbo: true, turbo_action: 'advance' }
+            %th.px-3
+              = sort_link api_namespaces_q, 'CMS Associations', {}, data: { turbo: true, turbo_action: 'advance' }
+        
+        %tbody
+          - api_namespaces.each do |api_namespace|
+            %tr
+              %td.px-3.py-2
+                .td-content
+                  = link_to edit_api_namespace_path(api_namespace), class: 'mr-3' do
+                    %i.fas.fa-edit
+                  = link_to api_namespace, method: :delete, remote: true, data: { confirm: 'Are you sure?', page: params[:page], action: "ajax:success->list-view#reloadTable" } do
+                    %i.fas.fa-trash
+              %td.px-3.py-2
+                .td-content.justify-content-start
+                  %div
+                    = link_to api_namespace.name, api_namespace
+                    .item-categories
+                      = render "comfy/admin/cms/categories/categories", object: api_namespace
+              %td.px-3.py-2
+                .td-content
+                  = api_namespace.version
+              %td.px-3.py-2
+                .td-content.justify-content-start
+                  %div
+                    - value = api_namespace.properties.to_s
+                    - if value && value.length > 100
+                      .clamp-content
+                        = "#{truncate(value, length: 100)}..."
+                      = link_to 'View more', '#', class: 'd-block', style: 'white-space: nowrap;', data: { toggle: 'modal', target: '#propertiesModal', namespace_name: api_namespace.name, namespace_slug: api_namespace.slug, value: api_namespace.properties, action: 'click->api-namespaces#showPropertiesModal' }
+                    - else
+                      = value 
+              %td.px-3.py-2
+                .td-content
+                  %span{ class: "list-view__status-text #{api_namespace.requires_authentication.to_s == 'true' ? 'list-view__status-text--success' : 'list-view__status-text--failure'}" }
+                    = api_namespace.requires_authentication
+              %td.px-3.py-2
+                .td-content
+                  = api_namespace.namespace_type
+              %td.px-3.py-2
+                .td-content
+                  = api_namespace.cms_associations.present? ? '<i class="fa fa-solid fa-check text-success" style="width: 30px; height: 30px;"></i>'.html_safe : '<i class="fa fa-solid fa-times text-danger" style="width: 30px; height: 30px;"></i>'.html_safe
+
+  .modal.fade#propertiesModal{ tabindex: -1, role: "dialog", aria: {labelledby: "propertiesModalTitle", hidden: true}, data: { api_namespaces_target: 'propertiesModal' }}
+    .modal-dialog-container
+      .modal-dialog{role: "document"}
+        .modal-content
+          .modal-header.pb-0
+            %h5.modal-title{id: "propertiesModalTitle"} Properties
+            %button.close{type: "button", data: {dismiss: "modal"}, aria: {label: "Close"}}
+              %span{aria: {hidden: true}} &times;
+          .modal-body{style: "max-height: calc(100vh - 200px); overflow-y: auto;"}
+            %p.modal-subtitle
+            %pre.modal-body-content.p-3

--- a/app/views/comfy/admin/api_namespaces/api_resources/_index.html.haml
+++ b/app/views/comfy/admin/api_namespaces/api_resources/_index.html.haml
@@ -1,6 +1,6 @@
 - if has_access_to_api_accessibility?(ApiNamespace::API_ACCESSIBILITIES[:read_api_resources_only], current_user, @api_namespace)
-  #api-resources-list.mb-5{data: {controller: "api-resources"}}
-    = search_form_for @api_resources_q, url: api_namespace_path(@api_namespace.id), data: {api_resources_target: 'searchForm', turbo_frame: "api-resources", turbo_action: "advance"} do |f|
+  #api-resources-list.list-view.list-view--instant-search.mb-5{data: {controller: "api-resources list-view"}}
+    = search_form_for @api_resources_q, url: api_namespace_path(@api_namespace.id), data: {list_view_target: "searchForm", instant_search_mode: "true", turbo_frame: "api-resources-table", turbo_action: "advance"} do |f|
       .form-group
         = f.label "Search by properties", class: 'col-form-label pt-0'
         .search-box

--- a/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
+++ b/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
@@ -1,11 +1,11 @@
 
-= turbo_frame_tag 'api-resources' do
+= turbo_frame_tag 'api-resources-table' do
   .digg_pagination.d-sm-flex.justify-content-between.mb-4.pb-3
     .page-info= page_entries_info @api_resources
     .links= will_paginate @api_resources, container: false, renderer: TurboPaginateRenderer
   .table-responsive.bg-white
-    %div.api-resources-table-container
-      %table#api-resources-table.table.table-striped.table-bordered
+    %div.list-view__table-container
+      %table.table.table-striped.table-bordered
         %thead
           %tr
             %th.px-3= sort_link api_resources_q, :id, {}, data: { turbo: true, turbo_action: 'advance'}
@@ -25,7 +25,7 @@
                     .d-flex.mt-3
                       = link_to edit_api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), class: 'mr-3' do 
                         %i.fas.fa-edit
-                      = link_to api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), remote: true, method: :delete, data: { confirm: 'Are you sure?', page: params[:page], action: "ajax:success->api-resources#reloadTable" } do
+                      = link_to api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), remote: true, method: :delete, data: { confirm: 'Are you sure?', page: params[:page], action: "ajax:success->list-view#reloadTable" } do
                         %i.fas.fa-trash
               %td.px-3.date-col
                 .td-content
@@ -36,31 +36,37 @@
               - dynamic_columns.each_with_index do |dynamic_column|
                 %td.px-3
                   .td-content
-                    %div
-                      - if api_resource.properties[dynamic_column]&.is_a?(Array)
-                        - array = api_resource.properties[dynamic_column]
-                        - if array.length > 10
-                          .clamp-content
-                            = "[#{array.first(2).join(', ')}, ... ,#{array.last(1).join}]"
-                          = link_to "View #{dynamic_column}", '#',  class: 'd-block view-dynamic-column', data: { toggle: 'modal', target: "#myModal", namespace_id: api_resource.api_namespace_id, id: api_resource.id, column: dynamic_column , value: "[#{api_resource.properties[dynamic_column].join(', ')}]", action: "click->api-resources#showModal" }
+                    - if [true, false].include? api_resource.properties[dynamic_column]
+                      - booleanValue = api_resource.properties[dynamic_column].to_s
+                      %span{ class: "list-view__status-text #{booleanValue == 'true' ? 'list-view__status-text--success' : 'list-view__status-text--failure'}" }
+                        = booleanValue
+                    - else  
+                      %div
+                        - if api_resource.properties[dynamic_column]&.is_a?(Array)
+                          - array = api_resource.properties[dynamic_column]
+                          - if array.length > 10
+                            .clamp-content
+                              = "[#{array.first(2).join(', ')}, ... ,#{array.last(1).join}]"
+                            = link_to "View #{dynamic_column}", '#',  class: 'd-block view-dynamic-column', data: { toggle: 'modal', target: "#myModal", namespace_id: api_resource.api_namespace_id, id: api_resource.id, column: dynamic_column , value: "[#{api_resource.properties[dynamic_column].join(', ')}]", action: "click->api-resources#showModal" }
+                          - else
+                            = array
                         - else
-                          = array
-                      - else
-                        - value = api_resource.properties[dynamic_column].to_s
-                        - if value && value.length > 100
-                          .clamp-content
-                            = truncate(value, length: 100)
-                          = link_to "View #{dynamic_column}", '#' , class: 'd-block view-dynamic-column', data: { toggle: 'modal', target: "#myModal" , column: dynamic_column, namespace_id: api_resource.api_namespace_id, id: api_resource.id, value: value, action: "click->api-resources#showModal" }
-                        - else
-                          = value 
+                          - value = api_resource.properties[dynamic_column].to_s
+                          - if value && value.length > 100
+                            .clamp-content
+                              = truncate(value, length: 100)
+                            = link_to "View #{dynamic_column}", '#' , class: 'd-block view-dynamic-column', data: { toggle: 'modal', target: "#myModal" , column: dynamic_column, namespace_id: api_resource.api_namespace_id, id: api_resource.id, value: value, action: "click->api-resources#showModal" }
+                          - else
+                            = value 
    
   .modal.fade#myModal{tabindex: -1, role: "dialog", aria: {labelledby: "myModalLabel", hidden: true}, data: { api_resources_target: 'modal' }}
-    .modal-dialog{role: "document"}
-      .modal-content
-        .modal-header.pb-0
-          %h5.modal-title{id: "myModalLabel"} %p#dynamic_column_name
-          %button.close{type: "button", data: {dismiss: "modal"}, aria: {label: "Close"}}
-            %span{aria: {hidden: true}} &times;
-        .modal-body{style: "max-height: calc(100vh - 200px); overflow-y: auto;"}
-          %p#modal-id
-          %pre#modal-body-content.p-3
+    .modal-dialog-container
+      .modal-dialog{role: "document"}
+        .modal-content
+          .modal-header.pb-0
+            %h5.modal-title{id: "myModalLabel"} %p#dynamic_column_name
+            %button.close{type: "button", data: {dismiss: "modal"}, aria: {label: "Close"}}
+              %span{aria: {hidden: true}} &times;
+          .modal-body{style: "max-height: calc(100vh - 200px); overflow-y: auto;"}
+            %p.modal-subtitle
+            %pre.modal-body-content.p-3

--- a/app/views/comfy/admin/api_namespaces/index.html.haml
+++ b/app/views/comfy/admin/api_namespaces/index.html.haml
@@ -2,45 +2,14 @@
   = render "comfy/admin/cms/categories/index", type: "ApiNamespace"
 
 .page-header
-  = link_to 'New Namespace', new_api_namespace_path, class: 'btn btn-secondary float-right'
-  = link_to 'Api Keys', api_keys_path, class: 'btn btn-secondary float-right mr-3'
+  = link_to 'New Namespace', new_api_namespace_path, class: 'btn btn-primary float-right'
+  = link_to 'Api Keys', api_keys_path, class: 'btn btn-primary float-right mr-3'
   %h2 API Namespaces
-= render partial: 'search_filters', locals: { objects: @api_namespaces_q, path: api_namespaces_path }
-= render partial: 'pagination', locals: { objects: @api_namespaces }
-%table.table.table-responsive
-  %thead
-    %tr
-      %th 
-        = sort_link @api_namespaces_q, :name
-      %th
-        = sort_link @api_namespaces_q, :version
-      %th 
-        = sort_link @api_namespaces_q, :properties
-      %th 
-        = sort_link @api_namespaces_q, :requires_authentication
-      %th 
-        = sort_link @api_namespaces_q, :namespace_type
-      %th 
-        = sort_link @api_namespaces_q, 'CMS Associations'
-      %th
-      %th
-
-
-  %tbody
-    - @api_namespaces.each do |api_namespace|
-      %tr
-        %td
-          = link_to api_namespace.name, api_namespace
-          .item-categories
-            = render "comfy/admin/cms/categories/categories", object: api_namespace
-        %td= api_namespace.version
-        %td= api_namespace.properties
-        %td= api_namespace.requires_authentication
-        %td= api_namespace.namespace_type
-        %td= api_namespace.cms_associations.present? ? '<i class="fa fa-solid fa-check text-success" style="width: 30px; height: 30px;"></i>'.html_safe : '<i class="fa fa-solid fa-times text-danger" style="width: 30px; height: 30px;"></i>'.html_safe
-        %td= link_to 'Edit', edit_api_namespace_path(api_namespace)
-        %td= link_to 'Destroy', api_namespace, method: :delete, data: { confirm: 'Are you sure?' }
-
-%br
-
-
+#api-namespaces-list.list-view{ data: { controller: 'api-namespaces list-view' } }
+  = search_form_for @api_namespaces_q, url: api_namespaces_path, data: { list_view_target: 'searchForm', turbo_frame: 'api-namespaces', turbo_action: 'advance' } do |f|
+    .form-group
+      = f.label "Search by Name or Properties", class: 'col-form-label'
+      .d-flex
+        = f.search_field :properties_or_name_cont, value: params[:q][:properties_cont], class: 'form-control', placeholder: 'Enter the value of name or properties you want to search'
+        = f.submit class: 'btn btn-primary ml-2'
+  = render partial: 'table', locals: { api_namespaces: @api_namespaces, api_namespaces_q: @api_namespaces_q }

--- a/test/controllers/admin/comfy/api_namespaces_controller_test.rb
+++ b/test/controllers/admin/comfy/api_namespaces_controller_test.rb
@@ -793,6 +793,128 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_select "pre", {count: 1, text: "{{ cms:helper render_api_namespace_resource '#{@api_namespace.slug}', scope: { properties: { arr: { value: [1], option: \"KEYWORDS\" }, title: { value: \"Hello\", option: \"KEYWORDS\" }, alpha_arr: { value: [\"a\"], option: \"KEYWORDS\" } } } }}"}
   end
 
+  test "#index: list view should have a Search form" do
+    sign_in(@user)
+    get api_namespaces_url
+    assert_response :success
+
+    assert_select ".list-view form.api_namespace_search", { count: 1 }
+  end
+
+  test "#index: list view should include pagination elements" do
+    sign_in(@user)
+    get api_namespaces_url
+    assert_response :success
+
+    assert_select ".list-view .digg_pagination .page-info", { count: 1 }
+    assert_select ".list-view .digg_pagination .links", { count: 1 }
+  end
+
+  test "#index: list view should have table headings that are sort links" do
+    sign_in(@user)
+    get api_namespaces_url
+    assert_response :success
+
+    assert_select ".list-view table th .sort_link", { count: 1, text: "Name" }
+    assert_select ".list-view table th .sort_link", { count: 1, text: "Version" }
+    assert_select ".list-view table th .sort_link", { count: 1, text: "Properties" }
+    assert_select ".list-view table th .sort_link", { count: 1, text: "Requires authentication" }
+    assert_select ".list-view table th .sort_link", { count: 1, text: "Namespace type" }
+    assert_select ".list-view table th .sort_link", { count: 1, text: "Cms associations" }
+  end
+
+  test "#index: should paginate API namespaces" do
+    items_per_page = 10
+
+    sign_in(@user)
+    get api_namespaces_url
+    assert_response :success
+
+    assert_equal items_per_page, @controller.view_assigns['api_namespaces'].length
+  end
+
+  test "#index: should paginate sorted API namespaces" do
+    items_per_page = 10
+
+    sign_in(@user)
+    get api_namespaces_url, params: { q: { s: 'name asc' } }
+    assert_response :success
+
+    assert_equal items_per_page, @controller.view_assigns['api_namespaces'].length
+  end
+
+  test "#index: should allow searching by name" do
+    searchTerm = 'clients'
+
+    sign_in(@user)
+    get api_namespaces_url, params: { q: { properties_or_name_cont: searchTerm } }
+
+    @controller.view_assigns['api_namespaces_q'].result.each do |namespace|
+      assert namespace.name.include? searchTerm
+    end
+  end
+
+  test "#index: should allow searching by property value" do
+    searchTerm = 'first_name'
+
+    sign_in(@user)
+    get api_namespaces_url, params: { q: { properties_or_name_cont: searchTerm } }
+
+    @controller.view_assigns['api_namespaces_q'].result.each do |namespace|
+      assert namespace.properties.to_s.include? searchTerm
+    end
+  end
+
+  test "#index: should allow sorting by CMS associations count in ascending order" do
+    # All namespaces have no cms associations by default
+    api_form = api_forms(:one)
+    api_form.update!(api_namespace: @api_namespace)
+    root_page = comfy_cms_pages(:root)
+    namespace_snippet = @api_namespace.snippet
+
+    # root page will be a CMS association of @api_namespace since the namespace's form is being rendered there
+    root_page.fragments.create!(content: namespace_snippet, identifier: 'content')
+
+    # Need the last page number to assert that @api_namespace is the very last item
+    # Since @api_namespace is the only namespace with a CMS association, it will be the last item on the last page
+    items_per_page = 10.0
+    last_page_number = (ApiNamespace.all.length / items_per_page).ceil
+
+    sign_in(@user)
+    get api_namespaces_url, params: { page: last_page_number.to_s, q: { s: 'CMS asc' } }
+    assert_response :success
+
+    assert_select '.list-view tbody tr' do |rows|
+      assert_includes rows[rows.length - 1].to_s, @api_namespace.name
+    end
+  end
+
+  test "#index: should allow sorting by CMS associations count in descending order" do
+    api_form = api_forms(:one)
+    api_form.update!(api_namespace: @api_namespace)
+    root_page = comfy_cms_pages(:root)
+    namespace_snippet = @api_namespace.snippet
+
+    root_page.fragments.create!(content: namespace_snippet, identifier: 'content')
+
+    sign_in(@user)
+    get api_namespaces_url, params: { q: { s: 'CMS desc' } }
+    assert_response :success
+
+    # Since @api_namespace is the only namespace with a CMS association, it will be the very first list item
+    assert_select '.list-view tbody tr' do |rows|
+      assert_includes rows[0].to_s, @api_namespace.name
+    end
+  end
+
+  test "#index: should render table partial in case of a turbo frame request" do
+    sign_in(@user)
+    get api_namespaces_url, headers: { 'Turbo-Frame' => 'api-namespaces' }
+    assert_response :success
+
+    assert_template partial: 'comfy/admin/api_namespaces/_table'
+  end
+
   ######## API Accessibility Tests - START #########
 
   # INDEX


### PR DESCRIPTION
Addresses: #1503 

## Before


<img width="1728" alt="Screen Shot 2023-04-11 at 11 52 53 AM" src="https://user-images.githubusercontent.com/35935196/231219239-62a8b25d-7530-462d-8e2d-c7576c8d54a9.png">

When you had a big API Namespace it would break the view: 
<img width="1728" alt="Screen Shot 2023-04-11 at 12 34 52 PM" src="https://user-images.githubusercontent.com/35935196/231229768-99ed0dc8-ec9e-42c0-8f67-ff08addfa93c.png">

## After


<img width="1728" alt="Screen Shot 2023-04-11 at 12 32 57 PM" src="https://user-images.githubusercontent.com/35935196/231229303-41a3b3ec-bbb5-46ba-bd9d-8a7abb450c7d.png">

## VIdeo demo
https://user-images.githubusercontent.com/73725297/230971387-635f4744-4acb-46f7-a056-12a1541a4351.mp4