### PR TITLE
API namespace associations

### DIFF
--- a/app/assets/stylesheets/api_namespaces.scss
+++ b/app/assets/stylesheets/api_namespaces.scss
@@ -145,6 +145,9 @@
       border: 1px solid #dee2e6;
       background: #ffffff;
       text-align: center;
+      font-size: 12px;
+      color: #6B7280;
+      text-transform: uppercase;
 
       a {
         text-transform: uppercase;

--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -261,7 +261,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
-      params[:api_namespace][:associations] = params[:api_namespace][:associations].respond_to?(:values) ? params[:api_namespace][:associations].values : []
+      params[:api_namespace][:associations] = (params[:api_namespace][:associations].respond_to?(:values) ? params[:api_namespace][:associations].values : params[:api_namespace][:associations]) || []
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,

--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -261,7 +261,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
-      params[:api_namespace][:associations] = params[:api_namespace][:associations].values if params[:api_namespace][:associations].respond_to?(:values)
+      params[:api_namespace][:associations] = params[:api_namespace][:associations].respond_to?(:values) ? params[:api_namespace][:associations].values : []
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,

--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -261,6 +261,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
+      params[:api_namespace][:associations] = params[:api_namespace][:associations].values if params[:api_namespace][:associations].respond_to?(:values)
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,
@@ -268,7 +269,8 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
                                             :namespace_type,
                                             :has_form,
                                             non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :allow_attachments, :_destroy],
-                                            category_ids: []
+                                            category_ids: [],
+                                            associations: [:type, :namespace]
                                            )
     end
 

--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -270,7 +270,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
                                             :has_form,
                                             non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :allow_attachments, :_destroy],
                                             category_ids: [],
-                                            associations: [:type, :namespace]
+                                            associations: [:type, :namespace, :dependent]
                                            )
     end
 

--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -62,12 +62,17 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
   # DELETE /api_resources/1 or /api_resources/1.json
   def destroy
-    @api_resource.destroy
-
     respond_to do |format|
-      format.html { redirect_to api_namespace_path(id: @api_namespace.id), notice: "Api resource was successfully destroyed." }
-      format.json { head :no_content }
-      format.js
+      if @api_resource.destroy
+        format.html { redirect_to api_namespace_path(id: @api_namespace.id), notice: "Api resource was successfully destroyed." }
+        format.json { head :no_content }
+        format.js
+      else
+        flash[:danger] =  @api_resource.errors.full_messages.join('\n')
+        format.html { redirect_back fallback_location: root_path}
+        format.json { render json: { success: false, message: @api_resource.errors.full_messages  }, status: :unprocessable_entity }
+        format.js
+      end
     end
   end
 

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -409,8 +409,9 @@ class ApiNamespace < ApplicationRecord
         foreign_key = "#{self.slug.underscore.singularize}_id"
         api_namespace = ApiNamespace.friendly.find(association['namespace'])
         association_object = { "type" => 'belongs_to', "namespace" => self.slug }
-        associations_array = (api_namespace.associations || []) << association_object  unless api_namespace.associations&.include?(association_object)
-        api_namespace.update(properties: api_namespace.properties.merge("#{foreign_key}" => ""), associations: associations_array) unless api_namespace.properties.key?(foreign_key)
+        api_namespace.properties = api_namespace.properties.merge("#{foreign_key}" => "") unless api_namespace.properties.key?(foreign_key)
+        api_namespace.associations = (api_namespace.associations || []) << association_object unless api_namespace.associations&.include?(association_object)
+        api_namespace.save
       end
     end
   end

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -407,8 +407,8 @@ class ApiNamespace < ApplicationRecord
         update(properties: properties.merge("#{foreign_key}" => "")) unless properties.key?(foreign_key)
       else
         foreign_key = "#{self.slug.underscore.singularize}_id"
-        namespace = ApiNamespace.friendly.find(association['namespace'])
-        namespace.update(properties: namespace.properties.merge("#{foreign_key}" => "")) unless namespace.properties.key?(foreign_key)
+        api_namespace = ApiNamespace.friendly.find(association['namespace'])
+        api_namespace.update(properties: api_namespace.properties.merge("#{foreign_key}" => "")) unless api_namespace.properties.key?(foreign_key)
       end
     end
   end

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -408,14 +408,14 @@ class ApiNamespace < ApplicationRecord
 
         parent_namespace = ApiNamespace.friendly.find(association['namespace'])
         has_many_association = { "type" => 'has_many', "namespace" => self.slug }
-        has_one_association = { "type" => 'has_one', "namespace" => self.slug }
-        parent_namespace.update(associations: (parent_namespace.associations || []) << has_many_association) unless (parent_namespace.associations & [has_many_association, has_one_association]).any?
+        parent_association_exist = parent_namespace.associations.any? {|a| (a['type'] == 'has_many' || a['type'] == 'has_one') && a['namespace'] == self.slug } 
+        parent_namespace.update(associations: (parent_namespace.associations || []) << has_many_association) unless parent_association_exist
       else
         foreign_key = "#{self.slug.underscore.singularize}_id"
         api_namespace = ApiNamespace.friendly.find(association['namespace'])
         association_object = { "type" => 'belongs_to', "namespace" => self.slug }
         api_namespace.properties = api_namespace.properties.merge("#{foreign_key}" => "") unless api_namespace.properties.key?(foreign_key)
-        api_namespace.associations = (api_namespace.associations || []) << association_object unless api_namespace.associations&.include?(association_object)
+        api_namespace.associations = (api_namespace.associations || []) << association_object unless api_namespace.associations.any? { |a| a['type'] == 'belongs_to' && a['namespace'] == self.slug }
         api_namespace.save
       end
     end

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -408,7 +408,9 @@ class ApiNamespace < ApplicationRecord
       else
         foreign_key = "#{self.slug.underscore.singularize}_id"
         api_namespace = ApiNamespace.friendly.find(association['namespace'])
-        api_namespace.update(properties: api_namespace.properties.merge("#{foreign_key}" => "")) unless api_namespace.properties.key?(foreign_key)
+        association_object = { "type" => 'belongs_to', "namespace" => self.slug }
+        associations_array = (api_namespace.associations || []) << association_object  unless api_namespace.associations&.include?(association_object)
+        api_namespace.update(properties: api_namespace.properties.merge("#{foreign_key}" => ""), associations: associations_array) unless api_namespace.properties.key?(foreign_key)
       end
     end
   end

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -405,6 +405,11 @@ class ApiNamespace < ApplicationRecord
       if association['type'] == 'belongs_to'
         foreign_key = "#{association['namespace'].underscore.singularize}_id"
         update(properties: properties.merge("#{foreign_key}" => "")) unless properties.key?(foreign_key)
+
+        parent_namespace = ApiNamespace.friendly.find(association['namespace'])
+        has_many_association = { "type" => 'has_many', "namespace" => self.slug }
+        has_one_association = { "type" => 'has_one', "namespace" => self.slug }
+        parent_namespace.update(associations: (parent_namespace.associations || []) << has_many_association) unless (parent_namespace.associations & [has_many_association, has_one_association]).any?
       else
         foreign_key = "#{self.slug.underscore.singularize}_id"
         api_namespace = ApiNamespace.friendly.find(association['namespace'])

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -9,7 +9,7 @@ class ApiNamespace < ApplicationRecord
 
   after_save :update_api_form
 
-  after_save :add_foreign_key, if: -> { self.saved_change_to_associations? }
+  after_save :add_foreign_key, if: -> { attributes.key?('associations') && self.saved_change_to_associations? }
   
   has_many :api_resources, dependent: :destroy
   accepts_nested_attributes_for :api_resources

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -115,6 +115,8 @@ class ApiResource < ApplicationRecord
   end
 
   def define_associations
+    return if api_namespace.nil?
+
     # [{type: 'has_many', namespace: 'products', version: '1'}]
     api_namespace.associations.each do |association|
       case association['type']

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -42,6 +42,8 @@ class ApiResource < ApplicationRecord
 
   has_many :error_api_actions, dependent: :destroy
 
+  before_destroy :handle_associations, prepend: true, if: -> { self.api_namespace.associations.present? }
+
   ransacker :properties do |_parent|
     Arel.sql("api_resources.properties::text") 
   end
@@ -131,6 +133,22 @@ class ApiResource < ApplicationRecord
       when 'belongs_to'
         define_singleton_method(association['namespace'].underscore.singularize.to_sym) do
           ApiNamespace.friendly.find(association['namespace']).api_resources.find_by_id(self.properties["#{association['namespace'].underscore.singularize}_id"])
+        end
+      end
+    end
+  end
+
+  def handle_associations
+    ActiveRecord::Base.transaction do
+      api_namespace.associations.each do |association|
+        associated_resources = ApiNamespace.friendly.find(association['namespace']).api_resources.jsonb_search(:properties, { "#{api_namespace.slug.underscore.singularize}_id" => self.id })
+        if association['dependent'] == 'destroy'
+          associated_resources.destroy_all
+        elsif association['dependent'] == 'restrict_with_error'
+          if associated_resources.present?
+            self.errors.add(:base, "Cannot delete record because dependent #{association['namespace']} exist")
+            throw(:abort)
+          end
         end
       end
     end

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -9,6 +9,8 @@ class ApiResource < ApplicationRecord
     api_namespace.api_form.api_resource = self unless api_namespace&.api_form.nil?
   end
 
+  after_initialize :define_associations
+
   # Need to convert and then parse again in order to preserve keys as strings
   scope :jsonb_order_pre, -> (query_obj) { jsonb_order(JSON.parse(query_obj.to_json)) }
 
@@ -110,5 +112,25 @@ class ApiResource < ApplicationRecord
   def execute_update_api_actions
     initialize_api_resource_actions('update_api_actions')
     UpdateApiAction.where(id: self.update_api_actions.pluck(:id)).execute_model_context_api_actions
+  end
+
+  def define_associations
+    # [{type: 'has_many', namespace: 'products', version: '1'}]
+    api_namespace.associations.each do |association|
+      case association['type']
+      when 'has_many'
+        define_singleton_method(association['namespace'].underscore.to_sym) do
+          ApiNamespace.friendly.find(association['namespace']).api_resources.jsonb_search(:properties, { "#{api_namespace.slug.underscore.singularize}_id" => self.id })
+        end
+      when 'has_one'
+        define_singleton_method(association['namespace'].underscore.singularize.to_sym) do
+          ApiNamespace.friendly.find(association['namespace']).api_resources.jsonb_search(:properties, { "#{api_namespace.slug.underscore.singularize}_id" => self.id }).last
+        end
+      when 'belongs_to'
+        define_singleton_method(association['namespace'].underscore.singularize.to_sym) do
+          ApiNamespace.friendly.find(association['namespace']).api_resources.find_by_id(self.properties["#{association['namespace'].underscore.singularize}_id"])
+        end
+      end
+    end
   end
 end

--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -83,7 +83,7 @@ WebhookDrivenConnection"
     self.default_webhook_driven_model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION
     self.default_model_definition = DEFAULT_MODEL_DEFINITION
 
-    self.model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION if drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:webhook] && self.new_record?
+    self.model_definition ||= DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION if drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:webhook] && self.new_record?
   end
 
   friendly_id :label, use: :slugged

--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -83,7 +83,7 @@ WebhookDrivenConnection"
     self.default_webhook_driven_model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION
     self.default_model_definition = DEFAULT_MODEL_DEFINITION
 
-    self.model_definition ||= DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION if drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:webhook] && self.new_record?
+    self.model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION if drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:webhook] && self.new_record? && !self.will_save_change_to_model_definition?
   end
 
   friendly_id :label, use: :slugged

--- a/app/views/comfy/admin/api_namespaces/_association_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_association_form.html.haml
@@ -2,10 +2,13 @@
   .position-absolute{style: "top: 6px; right: 6px"}
     %a.text-danger{style: "cursor: pointer;", onclick: "$('#association_form_#{index}').remove()"}
       %i.fas.fa-times
-  .row
-    .field.col.col-6
+  .row.association_form_fields
+    .field.col.col-4
       = label_tag 'type'
-      = select_tag "api_namespace[associations][#{index}][type]", options_for_select(['has_many', 'has_one', 'belongs_to'], association['type']), class: 'form-control form-control-sm', required: true
-    .field.col.col-6
+      = select_tag "api_namespace[associations][#{index}][type]", options_for_select(['has_many', 'has_one', 'belongs_to'], association['type']), class: 'form-control form-control-sm association-type-field', required: true, onchange: "toggleDependent(this);"
+    .field.col.col-4
       = label_tag 'namespace'
       = select_tag "api_namespace[associations][#{index}][namespace]", options_for_select(ApiNamespace.all.excluding(@api_namespace).map { |namespace| ["#{namespace.name}   [slug: #{namespace.slug}, id: #{namespace.id}]", namespace.slug] }, association['namespace']), class: 'form-control form-control-sm', required: true
+    .field.col.col-4
+      = label_tag 'dependent'
+      = select_tag "api_namespace[associations][#{index}][dependent]", options_for_select(['destroy', 'restrict_with_error'], association['dependent']), include_blank: true, class: 'form-control form-control-sm dependent-field', required: false

--- a/app/views/comfy/admin/api_namespaces/_association_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_association_form.html.haml
@@ -8,4 +8,4 @@
       = select_tag "api_namespace[associations][#{index}][type]", options_for_select(['has_many', 'has_one', 'belongs_to'], association['type']), class: 'form-control form-control-sm', required: true
     .field.col.col-6
       = label_tag 'namespace'
-      = select_tag "api_namespace[associations][#{index}][namespace]", options_for_select(ApiNamespace.all.excluding(@api_namespace.slug).map { |namespace| ["#{namespace.name}   [slug: #{namespace.slug}, id: #{namespace.id}]", namespace.slug] }, association['namespace']), class: 'form-control form-control-sm', required: true
+      = select_tag "api_namespace[associations][#{index}][namespace]", options_for_select(ApiNamespace.all.excluding(@api_namespace).map { |namespace| ["#{namespace.name}   [slug: #{namespace.slug}, id: #{namespace.id}]", namespace.slug] }, association['namespace']), class: 'form-control form-control-sm', required: true

--- a/app/views/comfy/admin/api_namespaces/_association_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_association_form.html.haml
@@ -8,4 +8,4 @@
       = select_tag "api_namespace[associations][#{index}][type]", options_for_select(['has_many', 'has_one', 'belongs_to'], association['type']), class: 'form-control form-control-sm', required: true
     .field.col.col-6
       = label_tag 'namespace'
-      = select_tag "api_namespace[associations][#{index}][namespace]", options_for_select(ApiNamespace.all.pluck(:slug).excluding(@api_namespace.slug), association['namespace']), class: 'form-control form-control-sm', required: true
+      = select_tag "api_namespace[associations][#{index}][namespace]", options_for_select(ApiNamespace.all.excluding(@api_namespace.slug).map { |namespace| ["#{namespace.name}   [slug: #{namespace.slug}, id: #{namespace.id}]", namespace.slug] }, association['namespace']), class: 'form-control form-control-sm', required: true

--- a/app/views/comfy/admin/api_namespaces/_association_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_association_form.html.haml
@@ -1,0 +1,11 @@
+.card.form-container.font-size-sm.position-relative.p-3.mb-4{id: "association_form_#{index}"}
+  .position-absolute{style: "top: 6px; right: 6px"}
+    %a.text-danger{style: "cursor: pointer;", onclick: "$('#association_form_#{index}').remove()"}
+      %i.fas.fa-times
+  .row
+    .field.col.col-6
+      = label_tag 'type'
+      = select_tag "api_namespace[associations][#{index}][type]", options_for_select(['has_many', 'has_one', 'belongs_to'], association['type']), class: 'form-control form-control-sm', required: true
+    .field.col.col-6
+      = label_tag 'namespace'
+      = select_tag "api_namespace[associations][#{index}][namespace]", options_for_select(ApiNamespace.all.pluck(:slug).excluding(@api_namespace.slug), association['namespace']), class: 'form-control form-control-sm', required: true

--- a/app/views/comfy/admin/api_namespaces/_associations.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_associations.html.haml
@@ -1,0 +1,5 @@
+- api_namespace.associations.each do |association|
+  .d-flex
+    .mr-3= association['type']
+    .mr-3
+      = link_to association['namespace'], api_namespace_path(id: association['namespace'])

--- a/app/views/comfy/admin/api_namespaces/_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_form.html.haml
@@ -86,10 +86,19 @@
     $('#associations_forms').append("#{escape_javascript( render :partial => 'comfy/admin/api_namespaces/association_form', :locals => {index: 'index_to_replace', association: {} })}".replace(/index_to_replace/g, index))
   }
 
+  function toggleDependent(el) {
+    var dependentField = $(el).closest('.association_form_fields').find('.dependent-field').first();
+    if($(el).val() == 'belongs_to') {
+      dependentField.val('');
+      dependentField.attr('disabled', true);
+    } else {
+      dependentField.attr('disabled', false);
+    }
+  }
 
-
-
-
+  $(document).ready(function() {
+    $('.association-type-field').change();
+  })
 
 
 

--- a/app/views/comfy/admin/api_namespaces/_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_form.html.haml
@@ -25,6 +25,18 @@
     %a.btn.btn-primary.text-white{onclick: "appendNonPrimitiveForm()"}
       %i.fa.fa-plus
 
+
+  .associations.mb-4
+    .h4.mt-3
+      Associations
+    
+    .form-group#associations_forms
+      - @api_namespace.associations.each_with_index do |association, index|
+        = render partial: 'association_form', locals: { index: index, association: association }
+
+    %a.btn.btn-primary.text-white{onclick: "appendAssociations()"}
+      %i.fa.fa-plus
+
   .field
     = f.label :requires_authentication
     = f.check_box :requires_authentication
@@ -54,7 +66,7 @@
 
   function removeForm(form_id, destroy_field_id) {
     $("#" + form_id).hide();
-    $("#" + destroy_field_id).val(true)
+    $("#" + destroy_field_id)?.val(true)
   }
 
   function appendNonPrimitiveForm() {
@@ -68,3 +80,20 @@
       success: function(response) {}
     });
   }
+
+  function appendAssociations() {
+    var index = $("#associations_forms > .form-container").length
+    $('#associations_forms').append("#{escape_javascript( render :partial => 'comfy/admin/api_namespaces/association_form', :locals => {index: 'index_to_replace', association: {} })}".replace(/index_to_replace/g, index))
+  }
+
+
+
+
+
+
+
+
+
+
+
+

--- a/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
+++ b/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
@@ -64,7 +64,7 @@
               - api_namespace.associations.each do |association|
                 %td.px-3
                   - if association['type'] == 'has_many'
-                    = link_to association['namespace'], api_namespace_path(id: association['namespace'], q: {properties_cont: "\"#{api_namespace.slug.underscore.singularize}_id\": #{api_namespace.id}"})
+                    = link_to association['namespace'], api_namespace_path(id: association['namespace'], q: {properties_cont: "\"#{api_namespace.slug.underscore.singularize}_id\": #{api_resource.id}"})
                   - else
                     - associated_resource = api_resource.send(association['namespace'].underscore.singularize.to_sym)
                     = link_to associated_resource.id, api_namespace_resource_path(api_namespace_id: associated_resource.api_namespace.id, id: associated_resource.id) if associated_resource.present?

--- a/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
+++ b/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
@@ -44,7 +44,7 @@
                       %div
                         - if api_resource.properties[dynamic_column]&.is_a?(Array)
                           - array = api_resource.properties[dynamic_column]
-                          - if array.length > 10
+                          - if array.length > 10 || array.to_s.length > 100
                             .clamp-content
                               = "[#{array.first(2).join(', ')}, ... ,#{array.last(1).join}]"
                             = link_to "View #{dynamic_column}", '#',  class: 'd-block view-dynamic-column', data: { toggle: 'modal', target: "#myModal", namespace_id: api_resource.api_namespace_id, id: api_resource.id, column: dynamic_column , value: "[#{api_resource.properties[dynamic_column].join(', ')}]", action: "click->api-resources#showModal" }

--- a/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
+++ b/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
@@ -6,14 +6,17 @@
   .table-responsive.bg-white
     %div.list-view__table-container
       %table.table.table-striped.table-bordered
+        - belongs_to_keys = api_namespace.associations.map { |association| "#{association['namespace'].underscore.singularize}_id" if association['type'] == 'belongs_to' }.compact
         %thead
           %tr
             %th.px-3= sort_link api_resources_q, :id, {}, data: { turbo: true, turbo_action: 'advance'}
             %th.px-3= sort_link api_resources_q, :created_at, {}, data: { turbo: true, turbo_action: 'advance'}
             %th.px-3= sort_link api_resources_q, :updated_at, {}, data: { turbo: true, turbo_action: 'advance'}
-            - dynamic_columns = api_namespace.properties.keys
-            - api_namespace.properties.keys.each do |dynamic_column|
+            - dynamic_columns = api_namespace.properties.keys.excluding(belongs_to_keys)
+            - dynamic_columns.each do |dynamic_column|
               %th.px-3= sort_link api_resources_q, dynamic_column, {}, data: { turbo: true, turbo_action: 'advance'}
+            - api_namespace.associations.each do |association|
+              %th.px-3= association['type'] == 'has_many' ? association['namespace'] : association['namespace'].singularize
 
         %tbody
           - api_resources.each do |api_resource|
@@ -58,6 +61,16 @@
                             = link_to "View #{dynamic_column}", '#' , class: 'd-block view-dynamic-column', data: { toggle: 'modal', target: "#myModal" , column: dynamic_column, namespace_id: api_resource.api_namespace_id, id: api_resource.id, value: value, action: "click->api-resources#showModal" }
                           - else
                             = value 
+              - api_namespace.associations.each do |association|
+                %td.px-3
+                  - if association['type'] == 'has_many'
+                    = link_to association['namespace'], api_namespace_path(id: association['namespace'], q: {properties_cont: "\"#{api_namespace.slug.underscore.singularize}_id\": #{api_namespace.id}"})
+                  - else
+                    - associated_resource = api_resource.send(association['namespace'].underscore.singularize.to_sym)
+                    = link_to associated_resource.id, api_namespace_resource_path(api_namespace_id: associated_resource.api_namespace.id, id: associated_resource.id) if associated_resource.present?
+
+
+
    
   .modal.fade#myModal{tabindex: -1, role: "dialog", aria: {labelledby: "myModalLabel", hidden: true}, data: { api_resources_target: 'modal' }}
     .modal-dialog-container

--- a/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
+++ b/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
@@ -19,6 +19,7 @@
               %th.px-3= association['type'] == 'has_many' ? association['namespace'] : association['namespace'].singularize
 
         %tbody
+          - dependent_destroy_associations = api_namespace.associations.filter { |a| a['dependent'] == 'destroy'}.pluck('namespace')
           - api_resources.each do |api_resource|
             %tr
               %td.px-3.py-2
@@ -28,7 +29,7 @@
                     .d-flex.mt-3
                       = link_to edit_api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), class: 'mr-3' do 
                         %i.fas.fa-edit
-                      = link_to api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), remote: true, method: :delete, data: { confirm: 'Are you sure?', page: params[:page], action: "ajax:success->list-view#reloadTable" } do
+                      = link_to api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), remote: true, method: :delete, data: { confirm: (dependent_destroy_associations.present? ? "All the dependent #{dependent_destroy_associations.to_sentence } will be deleted. Are you sure? " : "Are you sure?"), page: params[:page], action: "ajax:success->list-view#reloadTable" } do
                         %i.fas.fa-trash
               %td.px-3.date-col
                 .td-content

--- a/app/views/comfy/admin/api_namespaces/show.html.haml
+++ b/app/views/comfy/admin/api_namespaces/show.html.haml
@@ -31,7 +31,10 @@
         %a#export-tab.nav-link{"aria-controls" => "export", "aria-selected" => "false", "data-toggle" => "tab", :href => "#export", :role => "tab"} 
           Export
       %li.nav-item
-        %a#cms-associations-tab.nav-link{"aria-controls" => "export", "aria-selected" => "false", "data-toggle" => "tab", :href => "#cms-associations", :role => "tab"} 
+        %a#associations-tab.nav-link{"aria-controls" => "associations", "aria-selected" => "false", "data-toggle" => "tab", :href => "#associations", :role => "tab"} 
+          Associations
+      %li.nav-item
+        %a#cms-associations-tab.nav-link{"aria-controls" => "cms-associations", "aria-selected" => "false", "data-toggle" => "tab", :href => "#cms-associations", :role => "tab"} 
           CMS Associations
       %li.nav-item
         %a#social-tab.nav-link{"aria-controls" => "social", "aria-selected" => "false", "data-toggle" => "tab", :href => "#social", :role => "tab"} 
@@ -88,6 +91,9 @@
         = link_to 'Export JSON with associations', export_with_associations_as_json_api_namespace_path(id: @api_namespace.id), method: :get, class: 'btn btn-info'
       .my-3
         = link_to 'Export JSON without associations', export_without_associations_as_json_api_namespace_path(id: @api_namespace.id), method: :get, class: 'btn btn-info'
+    
+    #associations.tab-pane.fade{"aria-labelledby" => "associations-tab", :role => "tabpanel"} 
+      = render partial: 'associations', locals: { api_namespace: @api_namespace }
 
     #cms-associations.tab-pane.fade{"aria-labelledby" => "cms-associations-tab", :role => "tabpanel"} 
       - if (cms_associations = @api_namespace.cms_associations).present?

--- a/app/views/comfy/admin/api_resources/show.html.haml
+++ b/app/views/comfy/admin/api_resources/show.html.haml
@@ -8,6 +8,19 @@
   = @api_resource.id
 = render 'comfy/admin/api_namespaces/editor', {api_resource: @api_resource, form_properties: @api_resource.api_namespace&.api_form&.properties&.symbolize_keys, read_only: true}
 
+.my-3
+  %b.mb-2.d-block Associations
+  - @api_resource.api_namespace.associations.each do |association|
+    .m-3.d-flex
+      %div.mr-3
+        = association['type'] == 'has_many' ? "#{association['namespace']}:" : "#{association['namespace'].singularize}:"
+      %div
+        - if association['type'] == 'has_many'
+          = link_to association['namespace'], api_namespace_path(id: association['namespace'], q: {properties_cont: "\"#{@api_resource.api_namespace.slug.underscore.singularize}_id\": #{@api_resource.api_namespace.id}"})
+        - else
+          - associated_resource = @api_resource.send(association['namespace'].underscore.singularize.to_sym)
+          = link_to associated_resource.id, api_namespace_resource_path(api_namespace_id: associated_resource.api_namespace.id, id: associated_resource.id) if associated_resource.present?
+
 - user = @api_resource.tracked_user
 - if user
   %p 

--- a/app/views/comfy/admin/api_resources/show.html.haml
+++ b/app/views/comfy/admin/api_resources/show.html.haml
@@ -16,7 +16,7 @@
         = association['type'] == 'has_many' ? "#{association['namespace']}:" : "#{association['namespace'].singularize}:"
       %div
         - if association['type'] == 'has_many'
-          = link_to association['namespace'], api_namespace_path(id: association['namespace'], q: {properties_cont: "\"#{@api_resource.api_namespace.slug.underscore.singularize}_id\": #{@api_resource.api_namespace.id}"})
+          = link_to association['namespace'], api_namespace_path(id: association['namespace'], q: {properties_cont: "\"#{@api_resource.api_namespace.slug.underscore.singularize}_id\": #{@api_resource.id}"})
         - else
           - associated_resource = @api_resource.send(association['namespace'].underscore.singularize.to_sym)
           = link_to associated_resource.id, api_namespace_resource_path(api_namespace_id: associated_resource.api_namespace.id, id: associated_resource.id) if associated_resource.present?

--- a/config/database.yml
+++ b/config/database.yml
@@ -63,7 +63,7 @@ test:
   <<: *default
   host: <%= ENV['DATABASE_HOST'] %>
   port: <%= ENV['DATABASE_PORT'] %>
-  database: r_solutions_test
+  database: <%= ENV['DATABASE_NAME'] %>
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -63,7 +63,7 @@ test:
   <<: *default
   host: <%= ENV['DATABASE_HOST'] %>
   port: <%= ENV['DATABASE_PORT'] %>
-  database: <%= ENV['DATABASE_NAME'] %>
+  database: r_solutions_test
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
 

--- a/db/migrate/20230516012035_add_associations_to_api_namespace.rb
+++ b/db/migrate/20230516012035_add_associations_to_api_namespace.rb
@@ -1,0 +1,5 @@
+class AddAssociationsToApiNamespace < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_namespaces, :associations, :jsonb, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_24_080541) do
+ActiveRecord::Schema.define(version: 2023_05_16_012035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -193,6 +193,7 @@ ActiveRecord::Schema.define(version: 2023_03_24_080541) do
     t.jsonb "social_share_metadata"
     t.jsonb "analytics_metadata"
     t.string "purge_resources_older_than", default: "never"
+    t.jsonb "associations", default: []
     t.index ["properties"], name: "index_api_namespaces_on_properties", opclass: :jsonb_path_ops, using: :gin
   end
 

--- a/test/controllers/admin/comfy/api_namespaces_controller_test.rb
+++ b/test/controllers/admin/comfy/api_namespaces_controller_test.rb
@@ -243,7 +243,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,#{api_namespace.social_share_metadata}\nanalytics_metadata,#{api_namespace.analytics_metadata}\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,#{api_namespace.social_share_metadata}\nanalytics_metadata,#{api_namespace.analytics_metadata}\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2411,7 +2411,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2425,7 +2425,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2439,7 +2439,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2470,7 +2470,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2486,7 +2486,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2502,7 +2502,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2516,7 +2516,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"

--- a/test/models/api_namespace_test.rb
+++ b/test/models/api_namespace_test.rb
@@ -368,4 +368,12 @@ class ApiNamespaceTest < ActiveSupport::TestCase
     assert_includes associations, layout
     assert_includes associations, snippet
   end
+
+  test 'should add foreign key and belongs_to to associated namespace' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_many', namespace: 'products'}]);
+
+    assert namespace_1.reload.properties.key?('shop_id')
+    assert_includes namespace_1.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+  end
 end

--- a/test/models/api_namespace_test.rb
+++ b/test/models/api_namespace_test.rb
@@ -369,11 +369,28 @@ class ApiNamespaceTest < ActiveSupport::TestCase
     assert_includes associations, snippet
   end
 
-  test 'should add foreign key and belongs_to to associated namespace' do
+  test 'has_many: should add foreign key and belongs_to association to child namespace' do
     namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
     namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_many', namespace: 'products'}]);
 
     assert namespace_1.reload.properties.key?('shop_id')
     assert_includes namespace_1.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+  end
+
+  test 'has_one: should add foreign key and belongs_to association to child namespace' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_one', namespace: 'products'}]);
+
+    assert namespace_1.reload.properties.key?('shop_id')
+    assert_includes namespace_1.reload.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+  end
+
+  test 'belongs_to: should add foreign key and has_many association to parent namespace' do
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' });
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' }, associations: [{type: 'belongs_to', namespace: 'shops'}]);
+
+    assert namespace_1.reload.properties.key?('shop_id')
+    assert_includes namespace_1.reload.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+    assert_includes namespace_2.reload.associations, { "type" => 'has_many', "namespace" => 'products' }
   end
 end

--- a/test/models/api_resource_test.rb
+++ b/test/models/api_resource_test.rb
@@ -200,4 +200,43 @@ class ApiResourceTest < ActiveSupport::TestCase
     # rich text
     assert_equal prop_2.content, api_resource.props['text'].content
   end
+
+  test 'should define associations: has_many' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_many', namespace: 'products'}]);
+
+    namespace_1.reload
+    namespace_2.reload
+
+    shop_1 = namespace_2.api_resources.create(properties: {name: 'Restarone'})
+    shop_2 = namespace_2.api_resources.create(properties: {name: 'Engineering'})
+
+    product_1 = namespace_1.api_resources.create(properties: {title: 'T-shirt', shop_id: shop_1.id})
+    product_2 = namespace_1.api_resources.create(properties: {title: 'Jeans', shop_id: shop_1.id})
+
+    assert_equal [product_1.id, product_2.id], shop_1.products.pluck(:id)
+    assert_equal [], shop_2.products.pluck(:id)
+
+    assert_equal shop_1, product_1.shop
+    assert_equal shop_1, product_2.shop
+  end
+
+  test 'should define associations: has_one' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_one', namespace: 'products'}]);
+
+    namespace_1.reload
+    namespace_2.reload
+
+    shop_1 = namespace_2.api_resources.create(properties: {name: 'Restarone'})
+    shop_2 = namespace_2.api_resources.create(properties: {name: 'Engineering'})
+
+    product_1 = namespace_1.api_resources.create(properties: {title: 'T-shirt', shop_id: shop_1.id})
+    product_2 = namespace_1.api_resources.create(properties: {title: 'Jeans', shop_id: shop_1.id})
+
+    assert_equal product_2, shop_1.product
+    assert_equal nil, shop_2.product
+
+    assert_equal shop_1, product_1.shop
+  end
 end


### PR DESCRIPTION
## API Namespace Association Feature

### Introduction

The API Namespace Association feature allows you to define associations between different API namespaces in your application. It enables you to establish relationships such as has_one, has_many, and belongs_to between API namespaces. This feature enhances the flexibility and convenience of working with API resources by automatically generating dynamic methods for accessing associated resources.

### Usage
Associations can be defined while creating or editing API namespaces

https://github.com/restarone/violet_rails/assets/50227291/4e0a6736-846c-4ac1-88bb-165db5e0df98

OR using rails console

`ApiNamespace.friendly.find('shops').update(associations: [{type: 'has_many', namespace: 'products'}])`

NOTE: Associated namespace (products) must exist before creating an association.

### Foreign Key Properties
After assigning associations between API namespaces, the associated API namespace will automatically have a foreign key property added to its definition.

For example, if you have a belongs_to association between the product API namespace and the shop API namespace, the product resources will have a `shop_id` property added to them. This property represents the foreign key relationship to the associated shop resource.

### Corresponding Associations
Corresponding associations are generated 

When defining an association between two API namespaces, the corresponding association is automatically set up in the associated namespace.

- For `has_one` association: The associated namespace will have a `belongs_to` association with the original namespace.

- For `belongs_to` association: The associated namespace will have a `has_many` association with the original namespace, if an association between them is already not defined in associated namespace.

- For `has_many` association: The associated namespace will have a `belongs_to` association with the original namespace.

This ensures that the associations between the API namespaces are properly set up, allowing you to access the associated resources conveniently.

### Dependent option
You can specify the following association dependent options for each association:

blank: if set to `blank`, the associated resources will be left as it is when the parent resource is destroyed

destroy: If set to `destroy`, all the associated resources will be destroyed along with the parent resource

restrict_with_error: If set to `restrict_with_error`, the parent resource cannot be deleted if it has associated resources. An error will be added to the parent resource.

https://github.com/restarone/violet_rails/assets/50227291/39a33377-dfd2-42d8-ad77-2c820c613eeb


### Dynamic Methods
Once you have defined the associations between API namespaces, the API resources within these namespaces will automatically have dynamic methods generated based on the association type. These methods provide easy access to associated resources.

For each association type, the following dynamic methods are available:

#### `has_many` Association:
If a `shops` API namespace has a `has_many` association with a `products` API namespace, the dynamic method generated would be:

```
shop = ApiNamespace.friendly.find('shops').api_resources.first
shop.products
```

#### `has_one` Association:
If a `shops` API namespace has a `has_one` association with a `users` API namespace, the dynamic method generated would be:

```
shop = ApiNamespace.friendly.find('shops').api_resources.first
shop.user
```

#### `belongs_to` Association:
If a `products` API namespace has a `belongs_to` association with a `shops` API namespace, the dynamic method generated would be:

```
product = ApiNamespace.friendly.find('products').api_resources.first
product.shop
```

https://github.com/restarone/violet_rails/assets/50227291/47b12a92-a45b-4a75-8155-fb721010f076


DEMO:

https://github.com/restarone/violet_rails/assets/50227291/54cbb05f-84af-4ae7-9d29-1b16dab78567





