### PR TITLE
[feature] API Namespace Associations, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Violet enables subdomain based:
 - 🦾 Automation 
 - 🤝 Collaboration  
 
-So you can have your marketing site hosted on `www.mywebsite.com`, while recieving support requests under `support@mywebsite.com` and building the Next Big Thing®️™️ at `app.mywebsite.com`-- all powered by Violet Rails.
+So you can have your marketing site hosted on `www.mywebsite.com`, while receiving support requests under `support@mywebsite.com` and building the Next Big Thing®️™️ at `app.mywebsite.com`-- all powered by Violet Rails.
 
 Feel the power & productivity of the Majestic Monolith! 🐘
 
@@ -42,7 +42,7 @@ Powered by a rich Content Management System with out of the box support for Boot
 ### ✨ **A flexible app, automation and analytics platform** 🦾
 Build apps and automation with Violet Rails API Namespace: https://github.com/restarone/violet_rails/wiki/API:-Entities,-Form-Rendering,-Interfaces-and-Actions
 #### **Building forms** 📜
-Build spam-resistant forms with Google Recaptcha v2 or v3. Since all systems in Violet Rails are vertically intergrated, your forms can talk to your automations and analytics. 
+Build spam-resistant forms with Google Recaptcha v2 or v3. Since all systems in Violet Rails are vertically integrated, your forms can talk to your automations and analytics. 
 <img width="1728" alt="Screen Shot 2022-06-26 at 5 59 10 PM" src="https://user-images.githubusercontent.com/35935196/175835386-4dca9672-425b-4be0-b415-f488470d22c8.png">
 #### **Automation** 🤖
 Build custom automation (eg mailchimp: https://github.com/restarone/violet_rails/issues/720) with ease with Ruby code or our HTTP API Editor (https://github.com/restarone/violet_rails/wiki/API:-Entities,-Form-Rendering,-Interfaces-and-Actions#http-api-editor-example-discord-bot)
@@ -75,7 +75,7 @@ Allow your outreach team to support the forum and blog, while the designers and 
 
 ### ✨ **Simplest Email Service** 📧
 Each Violet Rails 
-subdomain will have access to its own emailbox for sending and recieving emails:
+subdomain will have access to its own emailbox for sending and receiving emails:
 <img width="1728" alt="Screen Shot 2022-06-26 at 5 55 10 PM" src="https://user-images.githubusercontent.com/35935196/175835219-831a78f9-809f-4b9e-a99e-d3406983cf7b.png">
 
 ### ✨ **Forum** 🤝
@@ -94,15 +94,15 @@ Domain admins have control over which subdomains can be created (via approval) a
 
 ## ✨ **Sensible architecture and safe defaults**
 
-* database multi-tenancy: Serious SaaS and XaaS apps need to support database multi-tenancy. So if you ship Violet with Postgres you will have schema based multi-tenancy with the option of routing each client at run-time to an external Postgres server. All of this is implemented in a simple way, just by subdomain (eg: design.your-website.com).
-* Flexible and code first: The Violet CMS is powered  by `comfortable_mexican_sofa` and offers the customizability of a Rails engine with full WSIWYG functionality (its recommended that you stick to HTML/CSS/JS for static web hosting). Outside of this, its just Ruby on Rails -- the world is your oyster.
+* Database multi-tenancy: Serious SaaS and XaaS apps need to support database multi-tenancy. So if you ship Violet with Postgres you will have schema based multi-tenancy with the option of routing each client at run-time to an external Postgres server. All of this is implemented in a simple way, just by subdomain (eg: design.your-website.com).
+* Flexible and code first: The Violet CMS is powered by `comfortable_mexican_sofa` and offers the customizability of a Rails engine with full WYSIWYG functionality (its recommended that you stick to HTML/CSS/JS for static web hosting). Outside of this, its just Ruby on Rails -- the world is your oyster.
 * Ready to Deploy: Violet comes with a barebones App Owner UI that helps you hit the ground running by managing subdomain requests. Each subdomain has its own roster of Users and an automatically allocated email-box (eg: design@your-website.com), blog (eg: www.your-website.com/blog) and landing page (www.yourwebsite.com). Granular permissioning for users can be managed at the subdomain level.
 
 ## ✨ **Authorization layers**
-After deploying violet, you will be able to connect and setup your cannonical page and user account from the Rails console
+After deploying violet, you will be able to connect and setup your cannonical page and user account from the Rails console.
 ### 1. App Owners (Violet Sys Admin)
 * If you are a domain owner (eg: https://yourdomain.com) you can find the Violet SysAdmin at https://www.yourdomain.com/sysadmin or https://yourdomain.com/sysadmin
-* Any subdomain name on your domain can be reserved for web hosting, blog and email functionality. For example, registering https://hello.yourdomain.com will automatically generate a website for https://hello.yourdomain.com , an email address at hello@yourdomain.com, a blog at https://hello.yourdomain.com/blog and a forum at https://hello.yourdomain.com/forum
+* Any subdomain name on your domain can be reserved for web hosting, blog, and email functionality. For example, registering https://hello.yourdomain.com will automatically generate a website for https://hello.yourdomain.com, an email address at hello@yourdomain.com, a blog at https://hello.yourdomain.com/blog and a forum at https://hello.yourdomain.com/forum
 * All these components can be administrated at https://hello.yourdomain.com/admin with granular user permissions 
 ### Subdomain Owners (Web Admin)
 To register a subdomain, visit https://yourdomain.com/signup_wizard 
@@ -111,9 +111,9 @@ For security purposes, this only generates a request-- so the sysadmin will need
 * If you are the first user in a subdomain, you are conferred maximum permissions
 
 ## Deployment 🚀
-### There are 2 options for deployment. AWS EC2 and Heroku
+### There are 2 options for deployment using AWS EC2 and Heroku
 
-The [Demo](https://violet.restarone.solutions/) of `violet_rails` is deployed on AWS EC2 (using Ubuntu 20.04LTS) & requires some server setup/automation with Capistrano. The steps are outlined in-detail here: https://github.com/restarone/violet_rails/wiki/Deploying-to-EC2-(with-Capistrano)
+The [Demo](https://violet.restarone.solutions/) of `violet_rails` is deployed on AWS EC2 (using Ubuntu 20.04 LTS) & requires some server setup/automation with Capistrano. The steps are outlined in-detail here: https://github.com/restarone/violet_rails/wiki/Deploying-to-EC2-(with-Capistrano)
 
 If you prefer deploying to Heroku, [you can view the guide for that here](https://github.com/restarone/violet_rails/wiki/Deploying-to-Heroku)
 

--- a/app/assets/stylesheets/api_namespaces.scss
+++ b/app/assets/stylesheets/api_namespaces.scss
@@ -145,6 +145,9 @@
       border: 1px solid #dee2e6;
       background: #ffffff;
       text-align: center;
+      font-size: 12px;
+      color: #6B7280;
+      text-transform: uppercase;
 
       a {
         text-transform: uppercase;

--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -261,6 +261,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
 
     # Only allow a list of trusted parameters through.
     def api_namespace_params
+      params[:api_namespace][:associations] = (params[:api_namespace][:associations].respond_to?(:values) ? params[:api_namespace][:associations].values : params[:api_namespace][:associations]) || []
       params.require(:api_namespace).permit(:name,
                                             :version,
                                             :properties,
@@ -268,7 +269,8 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
                                             :namespace_type,
                                             :has_form,
                                             non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :allow_attachments, :_destroy],
-                                            category_ids: []
+                                            category_ids: [],
+                                            associations: [:type, :namespace, :dependent]
                                            )
     end
 

--- a/app/controllers/comfy/admin/api_resources_controller.rb
+++ b/app/controllers/comfy/admin/api_resources_controller.rb
@@ -62,12 +62,17 @@ class Comfy::Admin::ApiResourcesController < Comfy::Admin::Cms::BaseController
 
   # DELETE /api_resources/1 or /api_resources/1.json
   def destroy
-    @api_resource.destroy
-
     respond_to do |format|
-      format.html { redirect_to api_namespace_path(id: @api_namespace.id), notice: "Api resource was successfully destroyed." }
-      format.json { head :no_content }
-      format.js
+      if @api_resource.destroy
+        format.html { redirect_to api_namespace_path(id: @api_namespace.id), notice: "Api resource was successfully destroyed." }
+        format.json { head :no_content }
+        format.js
+      else
+        flash[:danger] =  @api_resource.errors.full_messages.join('\n')
+        format.html { redirect_back fallback_location: root_path}
+        format.json { render json: { success: false, message: @api_resource.errors.full_messages  }, status: :unprocessable_entity }
+        format.js
+      end
     end
   end
 

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -8,6 +8,8 @@ class ApiNamespace < ApplicationRecord
   attr_accessor :has_form
 
   after_save :update_api_form
+
+  after_save :add_foreign_key, if: -> { attributes.key?('associations') && self.saved_change_to_associations? }
   
   has_many :api_resources, dependent: :destroy
   accepts_nested_attributes_for :api_resources
@@ -396,5 +398,26 @@ class ApiNamespace < ApplicationRecord
 
   def destroy_old_api_resources_in_batches
     api_resources.where("created_at < ?", eval("#{purge_resources_older_than}.ago")).in_batches(&:destroy_all)
+  end
+
+  def add_foreign_key
+    associations.each do |association|
+      if association['type'] == 'belongs_to'
+        foreign_key = "#{association['namespace'].underscore.singularize}_id"
+        update(properties: properties.merge("#{foreign_key}" => "")) unless properties.key?(foreign_key)
+
+        parent_namespace = ApiNamespace.friendly.find(association['namespace'])
+        has_many_association = { "type" => 'has_many', "namespace" => self.slug }
+        parent_association_exist = parent_namespace.associations.any? {|a| (a['type'] == 'has_many' || a['type'] == 'has_one') && a['namespace'] == self.slug } 
+        parent_namespace.update(associations: (parent_namespace.associations || []) << has_many_association) unless parent_association_exist
+      else
+        foreign_key = "#{self.slug.underscore.singularize}_id"
+        api_namespace = ApiNamespace.friendly.find(association['namespace'])
+        association_object = { "type" => 'belongs_to', "namespace" => self.slug }
+        api_namespace.properties = api_namespace.properties.merge("#{foreign_key}" => "") unless api_namespace.properties.key?(foreign_key)
+        api_namespace.associations = (api_namespace.associations || []) << association_object unless api_namespace.associations.any? { |a| a['type'] == 'belongs_to' && a['namespace'] == self.slug }
+        api_namespace.save
+      end
+    end
   end
 end

--- a/app/models/external_api_client.rb
+++ b/app/models/external_api_client.rb
@@ -83,7 +83,7 @@ WebhookDrivenConnection"
     self.default_webhook_driven_model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION
     self.default_model_definition = DEFAULT_MODEL_DEFINITION
 
-    self.model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION if drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:webhook] && self.new_record?
+    self.model_definition = DEFAULT_WEBHOOK_DRIVEN_MODEL_DEFINITION if drive_strategy == ExternalApiClient::DRIVE_STRATEGIES[:webhook] && self.new_record? && !self.will_save_change_to_model_definition?
   end
 
   friendly_id :label, use: :slugged

--- a/app/views/comfy/admin/api_namespaces/_association_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_association_form.html.haml
@@ -1,0 +1,14 @@
+.card.form-container.font-size-sm.position-relative.p-3.mb-4{id: "association_form_#{index}"}
+  .position-absolute{style: "top: 6px; right: 6px"}
+    %a.text-danger{style: "cursor: pointer;", onclick: "$('#association_form_#{index}').remove()"}
+      %i.fas.fa-times
+  .row.association_form_fields
+    .field.col.col-4
+      = label_tag 'type'
+      = select_tag "api_namespace[associations][#{index}][type]", options_for_select(['has_many', 'has_one', 'belongs_to'], association['type']), class: 'form-control form-control-sm association-type-field', required: true, onchange: "toggleDependent(this);"
+    .field.col.col-4
+      = label_tag 'namespace'
+      = select_tag "api_namespace[associations][#{index}][namespace]", options_for_select(ApiNamespace.all.excluding(@api_namespace).map { |namespace| ["#{namespace.name}   [slug: #{namespace.slug}, id: #{namespace.id}]", namespace.slug] }, association['namespace']), class: 'form-control form-control-sm', required: true
+    .field.col.col-4
+      = label_tag 'dependent'
+      = select_tag "api_namespace[associations][#{index}][dependent]", options_for_select(['destroy', 'restrict_with_error'], association['dependent']), include_blank: true, class: 'form-control form-control-sm dependent-field', required: false

--- a/app/views/comfy/admin/api_namespaces/_associations.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_associations.html.haml
@@ -1,0 +1,5 @@
+- api_namespace.associations.each do |association|
+  .d-flex
+    .mr-3= association['type']
+    .mr-3
+      = link_to association['namespace'], api_namespace_path(id: association['namespace'])

--- a/app/views/comfy/admin/api_namespaces/_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_form.html.haml
@@ -25,6 +25,18 @@
     %a.btn.btn-primary.text-white{onclick: "appendNonPrimitiveForm()"}
       %i.fa.fa-plus
 
+
+  .associations.mb-4
+    .h4.mt-3
+      Associations
+    
+    .form-group#associations_forms
+      - @api_namespace.associations.each_with_index do |association, index|
+        = render partial: 'association_form', locals: { index: index, association: association }
+
+    %a.btn.btn-primary.text-white{onclick: "appendAssociations()"}
+      %i.fa.fa-plus
+
   .field
     = f.label :requires_authentication
     = f.check_box :requires_authentication
@@ -54,7 +66,7 @@
 
   function removeForm(form_id, destroy_field_id) {
     $("#" + form_id).hide();
-    $("#" + destroy_field_id).val(true)
+    $("#" + destroy_field_id)?.val(true)
   }
 
   function appendNonPrimitiveForm() {
@@ -68,3 +80,29 @@
       success: function(response) {}
     });
   }
+
+  function appendAssociations() {
+    var index = $("#associations_forms > .form-container").length
+    $('#associations_forms').append("#{escape_javascript( render :partial => 'comfy/admin/api_namespaces/association_form', :locals => {index: 'index_to_replace', association: {} })}".replace(/index_to_replace/g, index))
+  }
+
+  function toggleDependent(el) {
+    var dependentField = $(el).closest('.association_form_fields').find('.dependent-field').first();
+    if($(el).val() == 'belongs_to') {
+      dependentField.val('');
+      dependentField.attr('disabled', true);
+    } else {
+      dependentField.attr('disabled', false);
+    }
+  }
+
+  $(document).ready(function() {
+    $('.association-type-field').change();
+  })
+
+
+
+
+
+
+

--- a/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
+++ b/app/views/comfy/admin/api_namespaces/api_resources/_table.html.haml
@@ -6,16 +6,20 @@
   .table-responsive.bg-white
     %div.list-view__table-container
       %table.table.table-striped.table-bordered
+        - belongs_to_keys = api_namespace.associations.map { |association| "#{association['namespace'].underscore.singularize}_id" if association['type'] == 'belongs_to' }.compact
         %thead
           %tr
             %th.px-3= sort_link api_resources_q, :id, {}, data: { turbo: true, turbo_action: 'advance'}
             %th.px-3= sort_link api_resources_q, :created_at, {}, data: { turbo: true, turbo_action: 'advance'}
             %th.px-3= sort_link api_resources_q, :updated_at, {}, data: { turbo: true, turbo_action: 'advance'}
-            - dynamic_columns = api_namespace.properties.keys
-            - api_namespace.properties.keys.each do |dynamic_column|
+            - dynamic_columns = api_namespace.properties.keys.excluding(belongs_to_keys)
+            - dynamic_columns.each do |dynamic_column|
               %th.px-3= sort_link api_resources_q, dynamic_column, {}, data: { turbo: true, turbo_action: 'advance'}
+            - api_namespace.associations.each do |association|
+              %th.px-3= association['type'] == 'has_many' ? association['namespace'] : association['namespace'].singularize
 
         %tbody
+          - dependent_destroy_associations = api_namespace.associations.filter { |a| a['dependent'] == 'destroy'}.pluck('namespace')
           - api_resources.each do |api_resource|
             %tr
               %td.px-3.py-2
@@ -25,7 +29,7 @@
                     .d-flex.mt-3
                       = link_to edit_api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), class: 'mr-3' do 
                         %i.fas.fa-edit
-                      = link_to api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), remote: true, method: :delete, data: { confirm: 'Are you sure?', page: params[:page], action: "ajax:success->list-view#reloadTable" } do
+                      = link_to api_namespace_resource_path(api_namespace_id: api_resource.api_namespace_id, id: api_resource.id), remote: true, method: :delete, data: { confirm: (dependent_destroy_associations.present? ? "All the dependent #{dependent_destroy_associations.to_sentence } will be deleted. Are you sure? " : "Are you sure?"), page: params[:page], action: "ajax:success->list-view#reloadTable" } do
                         %i.fas.fa-trash
               %td.px-3.date-col
                 .td-content
@@ -44,7 +48,7 @@
                       %div
                         - if api_resource.properties[dynamic_column]&.is_a?(Array)
                           - array = api_resource.properties[dynamic_column]
-                          - if array.length > 10
+                          - if array.length > 10 || array.to_s.length > 100
                             .clamp-content
                               = "[#{array.first(2).join(', ')}, ... ,#{array.last(1).join}]"
                             = link_to "View #{dynamic_column}", '#',  class: 'd-block view-dynamic-column', data: { toggle: 'modal', target: "#myModal", namespace_id: api_resource.api_namespace_id, id: api_resource.id, column: dynamic_column , value: "[#{api_resource.properties[dynamic_column].join(', ')}]", action: "click->api-resources#showModal" }
@@ -58,6 +62,16 @@
                             = link_to "View #{dynamic_column}", '#' , class: 'd-block view-dynamic-column', data: { toggle: 'modal', target: "#myModal" , column: dynamic_column, namespace_id: api_resource.api_namespace_id, id: api_resource.id, value: value, action: "click->api-resources#showModal" }
                           - else
                             = value 
+              - api_namespace.associations.each do |association|
+                %td.px-3
+                  - if association['type'] == 'has_many'
+                    = link_to association['namespace'], api_namespace_path(id: association['namespace'], q: {properties_cont: "\"#{api_namespace.slug.underscore.singularize}_id\": #{api_resource.id}"})
+                  - else
+                    - associated_resource = api_resource.send(association['namespace'].underscore.singularize.to_sym)
+                    = link_to associated_resource.id, api_namespace_resource_path(api_namespace_id: associated_resource.api_namespace.id, id: associated_resource.id) if associated_resource.present?
+
+
+
    
   .modal.fade#myModal{tabindex: -1, role: "dialog", aria: {labelledby: "myModalLabel", hidden: true}, data: { api_resources_target: 'modal' }}
     .modal-dialog-container

--- a/app/views/comfy/admin/api_namespaces/show.html.haml
+++ b/app/views/comfy/admin/api_namespaces/show.html.haml
@@ -31,7 +31,10 @@
         %a#export-tab.nav-link{"aria-controls" => "export", "aria-selected" => "false", "data-toggle" => "tab", :href => "#export", :role => "tab"} 
           Export
       %li.nav-item
-        %a#cms-associations-tab.nav-link{"aria-controls" => "export", "aria-selected" => "false", "data-toggle" => "tab", :href => "#cms-associations", :role => "tab"} 
+        %a#associations-tab.nav-link{"aria-controls" => "associations", "aria-selected" => "false", "data-toggle" => "tab", :href => "#associations", :role => "tab"} 
+          Associations
+      %li.nav-item
+        %a#cms-associations-tab.nav-link{"aria-controls" => "cms-associations", "aria-selected" => "false", "data-toggle" => "tab", :href => "#cms-associations", :role => "tab"} 
           CMS Associations
       %li.nav-item
         %a#social-tab.nav-link{"aria-controls" => "social", "aria-selected" => "false", "data-toggle" => "tab", :href => "#social", :role => "tab"} 
@@ -88,6 +91,9 @@
         = link_to 'Export JSON with associations', export_with_associations_as_json_api_namespace_path(id: @api_namespace.id), method: :get, class: 'btn btn-info'
       .my-3
         = link_to 'Export JSON without associations', export_without_associations_as_json_api_namespace_path(id: @api_namespace.id), method: :get, class: 'btn btn-info'
+    
+    #associations.tab-pane.fade{"aria-labelledby" => "associations-tab", :role => "tabpanel"} 
+      = render partial: 'associations', locals: { api_namespace: @api_namespace }
 
     #cms-associations.tab-pane.fade{"aria-labelledby" => "cms-associations-tab", :role => "tabpanel"} 
       - if (cms_associations = @api_namespace.cms_associations).present?

--- a/app/views/comfy/admin/api_resources/show.html.haml
+++ b/app/views/comfy/admin/api_resources/show.html.haml
@@ -8,6 +8,19 @@
   = @api_resource.id
 = render 'comfy/admin/api_namespaces/editor', {api_resource: @api_resource, form_properties: @api_resource.api_namespace&.api_form&.properties&.symbolize_keys, read_only: true}
 
+.my-3
+  %b.mb-2.d-block Associations
+  - @api_resource.api_namespace.associations.each do |association|
+    .m-3.d-flex
+      %div.mr-3
+        = association['type'] == 'has_many' ? "#{association['namespace']}:" : "#{association['namespace'].singularize}:"
+      %div
+        - if association['type'] == 'has_many'
+          = link_to association['namespace'], api_namespace_path(id: association['namespace'], q: {properties_cont: "\"#{@api_resource.api_namespace.slug.underscore.singularize}_id\": #{@api_resource.id}"})
+        - else
+          - associated_resource = @api_resource.send(association['namespace'].underscore.singularize.to_sym)
+          = link_to associated_resource.id, api_namespace_resource_path(api_namespace_id: associated_resource.api_namespace.id, id: associated_resource.id) if associated_resource.present?
+
 - user = @api_resource.tracked_user
 - if user
   %p 

--- a/db/migrate/20230516012035_add_associations_to_api_namespace.rb
+++ b/db/migrate/20230516012035_add_associations_to_api_namespace.rb
@@ -1,0 +1,5 @@
+class AddAssociationsToApiNamespace < ActiveRecord::Migration[6.1]
+  def change
+    add_column :api_namespaces, :associations, :jsonb, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_24_080541) do
+ActiveRecord::Schema.define(version: 2023_05_16_012035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -193,6 +193,7 @@ ActiveRecord::Schema.define(version: 2023_03_24_080541) do
     t.jsonb "social_share_metadata"
     t.jsonb "analytics_metadata"
     t.string "purge_resources_older_than", default: "never"
+    t.jsonb "associations", default: []
     t.index ["properties"], name: "index_api_namespaces_on_properties", opclass: :jsonb_path_ops, using: :gin
   end
 

--- a/test/controllers/admin/comfy/api_namespaces_controller_test.rb
+++ b/test/controllers/admin/comfy/api_namespaces_controller_test.rb
@@ -243,7 +243,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,#{api_namespace.social_share_metadata}\nanalytics_metadata,#{api_namespace.analytics_metadata}\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,#{api_namespace.social_share_metadata}\nanalytics_metadata,#{api_namespace.analytics_metadata}\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -495,7 +495,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_match expected_message, flash[:alert]
   end
 
-  test "should allow import api_namespace provided as json without asscociations and the newly created api_namespace should be followed by secure-random if api_namespace with such name exists" do
+  test "should allow import api_namespace provided as json without associations and the newly created api_namespace should be followed by secure-random if api_namespace with such name exists" do
     json_file = Tempfile.new(['api_namespace.json', '.json'])
     json_file.write(@api_namespace.export_as_json(include_associations: false))
     json_file.rewind
@@ -526,7 +526,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_match @api_namespace.name, ApiNamespace.last.name
   end
 
-  test "should allow import api_namespace provided as json with its asscociations and the newly created api_namespace should be followed by secure-random if api_namespace with such name exists" do
+  test "should allow import api_namespace provided as json with its associations and the newly created api_namespace should be followed by secure-random if api_namespace with such name exists" do
     api_resources_count = @api_namespace.api_resources.count
     api_actions_count = @api_namespace.api_actions.count + @api_namespace.api_resources.map(&:api_actions).flatten.count
     api_namespace_keys_count = @api_namespace.api_namespace_keys.count
@@ -563,7 +563,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_match @api_namespace.name, ApiNamespace.last.name
   end
 
-  test "should allow import api_namespace provided as json with its asscociations and the newly created api_namespace's name should be as provided if api_namespace with such name does not exist" do
+  test "should allow import api_namespace provided as json with its associations and the newly created api_namespace's name should be as provided if api_namespace with such name does not exist" do
     api_resources_count = @api_namespace.api_resources.count
     api_actions_count = @api_namespace.api_actions.count + @api_namespace.api_resources.map(&:api_actions).flatten.count
     api_namespace_keys_count = @api_namespace.api_namespace_keys.count
@@ -2411,7 +2411,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2425,7 +2425,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2439,7 +2439,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2470,7 +2470,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2486,7 +2486,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2502,7 +2502,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -2516,7 +2516,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     stubbed_date = DateTime.new(2022, 1, 1)
     DateTime.stubs(:now).returns(stubbed_date)
     get export_api_namespace_url(api_namespace, format: :csv)
-    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\n"
+    expected_csv = "id,#{api_namespace.id}\nname,namespace_with_all_types\nslug,namespace_with_all_types\nversion,1\nnull,\narray,\"[\"\"yes\"\", \"\"no\"\"]\"\nnumber,123\nobject,\"{\"\"a\"\"=>\"\"b\"\", \"\"c\"\"=>\"\"d\"\"}\"\nstring,string\nboolean,true\nrequires_authentication,false\nnamespace_type,create-read-update-delete\ncreated_at,#{api_namespace.created_at}\nupdated_at,#{api_namespace.updated_at}\nsocial_share_metadata,\nanalytics_metadata,\npurge_resources_older_than,never\nassociations,[]\n"
     assert_response :success
     assert_equal response.body, expected_csv
     assert_equal response.header['Content-Disposition'], "attachment; filename=api_namespace_#{api_namespace.id}_#{DateTime.now.to_i}.csv"
@@ -3355,5 +3355,226 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     expected_message = 'You do not have the permission to do that. Only users who can_manage_analytics are allowed to perform that action.'
     assert_equal expected_message, flash[:alert]
     refute_equal payload[:api_namespace]['analytics_metadata'], @api_namespace.reload.analytics_metadata
+  end
+
+  test "should create api_namespace with parent associations" do
+    shops_namespace = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' })
+
+    shops_namespace.api_resources.create(properties: {
+      name: 'my shop'
+    })
+
+    sign_in(@user)
+    assert_difference('ApiNamespace.count', 1) do
+      post api_namespaces_url, params: { api_namespace: { name: 'products', properties: { title: '' }.to_json, associations: [{type: 'belongs_to', namespace: 'shops'}], version: 1 } }
+    end
+    products_namespace = ApiNamespace.last
+    shops_namespace.reload
+
+    shop_resource = shops_namespace.api_resources.first
+
+    assert products_namespace.reload.properties.key?('shop_id')
+    assert_includes products_namespace.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+    assert_includes shops_namespace.associations, { "type" => 'has_many', "namespace" => 'products' }
+
+    assert_difference('ApiResource.count') do
+      post api_namespace_resources_url(api_namespace_id: products_namespace.id), params: { api_resource: { properties: { title: 'My product', shop_id: shop_resource.id }.to_json } }
+    end
+
+    assert_equal products_namespace.api_resources.pluck(:id), shop_resource.products.pluck(:id)
+
+    assert_equal shop_resource, products_namespace.api_resources.first.shop
+  end
+
+  test "should create api_namespace with child associations" do
+    products_namespace = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' })
+
+    products_namespace.api_resources.create(properties: {
+      title: 'my product'
+    })
+
+    sign_in(@user)
+    assert_difference('ApiNamespace.count', 1) do
+      post api_namespaces_url, params: { api_namespace: { name: 'shops', properties: { name: '' }.to_json, associations: [{type: 'has_many', namespace: 'products'}], version: 1 } }
+    end
+
+    shops_namespace = ApiNamespace.last
+    products_namespace.reload
+
+    assert products_namespace.properties.key?('shop_id')
+    assert_includes products_namespace.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+    assert_includes shops_namespace.associations, { "type" => 'has_many', "namespace" => 'products' }
+
+    assert_difference('ApiResource.count') do
+      post api_namespace_resources_url(api_namespace_id: shops_namespace.id), params: { api_resource: { properties: { name: 'My shop'}.to_json } }
+    end
+
+    shop_resource = shops_namespace.api_resources.first
+
+    assert_difference('ApiResource.count') do
+      post api_namespace_resources_url(api_namespace_id: products_namespace.id), params: { api_resource: { properties: { title: 'My product', shop_id: shop_resource.id }.to_json } }
+    end
+
+    assert_equal [products_namespace.api_resources.last.id], shop_resource.products.pluck(:id)
+
+    assert_equal shop_resource, products_namespace.api_resources.last.shop
+
+    # already existing product resource 
+    refute products_namespace.api_resources.first.shop
+  end
+
+  test "#update should add association" do
+    shops_namespace = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' })
+    products_namespace = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' })
+
+    shop = shops_namespace.api_resources.create(properties: {
+      name: 'my shop'
+    })
+
+    products_namespace.api_resources.create(properties: {
+      title: 'my product',
+      shop_id: shop.id
+    })
+
+    # does not have dynamic methods defined without associations
+    refute products_namespace.api_resources.first.reload.respond_to?(:shop)
+    refute shops_namespace.api_resources.first.reload.respond_to?(:products)
+
+    sign_in(@user)
+    assert_changes('shops_namespace.reload.associations') do
+      assert_changes('products_namespace.reload.associations') do
+        assert_changes('products_namespace.reload.properties') do
+          patch api_namespace_url(shops_namespace), params: { api_namespace: { associations: [{type: 'has_many', namespace: 'products'}], version: 1 } }
+        end
+      end
+    end
+
+    assert products_namespace.properties.key?('shop_id')
+    assert_includes products_namespace.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+    assert_includes shops_namespace.associations, { "type" => 'has_many', "namespace" => 'products' }
+
+    products_namespace.reload
+    shops_namespace.reload
+
+    # should have dynamic methods defined
+    assert products_namespace.api_resources.first.respond_to?(:shop)
+    assert shops_namespace.api_resources.first.respond_to?(:products)
+  end
+
+  test "update association" do
+    products_namespace = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' })
+    shops_namespace = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_many', namespace: 'products'}])
+
+    assert products_namespace.reload.properties.key?('shop_id')
+    assert_includes products_namespace.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+    assert_includes shops_namespace.reload.associations, { "type" => 'has_many', "namespace" => 'products' }
+
+    shop = shops_namespace.api_resources.create(properties: {
+      name: 'my shop'
+    })
+
+    products_namespace.api_resources.create(properties: {
+      title: 'my product',
+      shop_id: shop.id
+    })
+
+    # should have dynamic methods defined without associations
+    assert products_namespace.api_resources.first.reload.respond_to?(:shop)
+    assert shops_namespace.api_resources.first.reload.respond_to?(:products)
+
+    sign_in(@user)
+    assert_changes('shops_namespace.reload.associations') do
+      assert_no_changes('products_namespace.reload.associations') do
+        assert_no_changes('products_namespace.reload.properties') do
+          patch api_namespace_url(shops_namespace), params: { api_namespace: { associations: [{type: 'has_one', namespace: 'products'}], version: 1 } }
+        end
+      end
+    end
+
+    refute_includes shops_namespace.reload.associations, { "type" => 'has_many', "namespace" => 'products' }
+
+    assert_includes shops_namespace.reload.associations, { "type" => 'has_one', "namespace" => 'products' }
+
+    assert products_namespace.reload.properties.key?('shop_id')
+    assert_includes products_namespace.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+
+    # should remove has_many dynamic method and add has_one methods
+    assert products_namespace.api_resources.first.reload.respond_to?(:shop)
+    refute shops_namespace.api_resources.first.reload.respond_to?(:products)
+    assert shops_namespace.api_resources.first.reload.respond_to?(:product)
+  end
+
+  test "update api_namespace to remove associations" do
+    shops_namespace = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' })
+    products_namespace = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' }, associations: [{type: 'belongs_to', namespace: 'shops'}])
+
+    assert products_namespace.reload.properties.key?('shop_id')
+    assert_includes products_namespace.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+    assert_includes shops_namespace.reload.associations, { "type" => 'has_many', "namespace" => 'products' }
+
+    shop = shops_namespace.api_resources.create(properties: {
+      name: 'my shop'
+    })
+
+    products_namespace.api_resources.create(properties: {
+      title: 'my product',
+      shop_id: shop.id
+    })
+
+    # should have dynamic methods defined
+    assert products_namespace.api_resources.first.reload.respond_to?(:shop)
+    assert shops_namespace.api_resources.first.reload.respond_to?(:products)
+
+    sign_in(@user)
+    assert_changes('shops_namespace.reload.associations') do
+      assert_no_changes('products_namespace.reload.associations') do
+        assert_no_changes('products_namespace.reload.properties') do
+          patch api_namespace_url(shops_namespace), params: { api_namespace: { associations: [], version: 1 } }
+        end
+      end
+    end
+
+    refute_includes shops_namespace.reload.associations, { "type" => 'has_many', "namespace" => 'products' }
+
+    # removing foreign key and corresponding associations should be manual, we do not want to unintionally remove existing association
+    assert products_namespace.reload.properties.key?('shop_id')
+    assert_includes products_namespace.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+
+    # should remove dynamic methods
+    assert products_namespace.api_resources.first.reload.respond_to?(:shop)
+    refute shops_namespace.api_resources.first.reload.respond_to?(:products)
+  end
+  
+  test "should show link to associated resources" do
+    owner_namespace = ApiNamespace.create(name: 'owners', version: 1, properties: {} )
+    shops_namespace = ApiNamespace.create(name: 'shops', version: 1, properties: { name: ''}, associations: [{type: 'has_one', namespace: 'owners'}])
+    products_namespace = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' }, associations: [{type: 'belongs_to', namespace: 'shops'}])
+
+    shop = shops_namespace.reload.api_resources.create(properties: {
+      name: 'my shop'
+    })
+
+    owner = owner_namespace.reload.api_resources.create(properties: {
+      name: 'owner',
+      shop_id: shop.id
+    })
+
+    product = products_namespace.reload.api_resources.create(properties: {
+      title: 'my product',
+      shop_id: shop.id
+    })
+
+    sign_in(@user)
+    get api_namespace_url(shops_namespace)
+    
+    # should include link to children resources namespace
+    assert_select "tbody tr td a[href=?]", api_namespace_path(id: products_namespace.slug, q: {properties_cont: "\"shop_id\": #{shop.id}"}), { count: 1, text: 'products'}
+
+    # should include link to children resource
+    assert_select "tbody tr td a[href=?]", api_namespace_resource_path(api_namespace_id: owner_namespace.id, id: owner.id), { count: 1, text: owner.id.to_s}
+
+    get api_namespace_url(products_namespace)
+    # should include link to parent resource
+    assert_select "tbody tr td a[href=?]", api_namespace_resource_path(api_namespace_id: shops_namespace.id, id: shop.id), { count: 1, text: shop.id.to_s}
   end
 end

--- a/test/models/api_namespace_test.rb
+++ b/test/models/api_namespace_test.rb
@@ -368,4 +368,29 @@ class ApiNamespaceTest < ActiveSupport::TestCase
     assert_includes associations, layout
     assert_includes associations, snippet
   end
+
+  test 'has_many: should add foreign key and belongs_to association to child namespace' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_many', namespace: 'products'}]);
+
+    assert namespace_1.reload.properties.key?('shop_id')
+    assert_includes namespace_1.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+  end
+
+  test 'has_one: should add foreign key and belongs_to association to child namespace' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_one', namespace: 'products'}]);
+
+    assert namespace_1.reload.properties.key?('shop_id')
+    assert_includes namespace_1.reload.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+  end
+
+  test 'belongs_to: should add foreign key and has_many association to parent namespace' do
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' });
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' }, associations: [{type: 'belongs_to', namespace: 'shops'}]);
+
+    assert namespace_1.reload.properties.key?('shop_id')
+    assert_includes namespace_1.reload.associations, { "type" => 'belongs_to', "namespace" => 'shops' }
+    assert_includes namespace_2.reload.associations, { "type" => 'has_many', "namespace" => 'products' }
+  end
 end

--- a/test/models/api_resource_test.rb
+++ b/test/models/api_resource_test.rb
@@ -200,4 +200,100 @@ class ApiResourceTest < ActiveSupport::TestCase
     # rich text
     assert_equal prop_2.content, api_resource.props['text'].content
   end
+
+  test 'should define associations: has_many' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_many', namespace: 'products'}]);
+
+    namespace_1.reload
+    namespace_2.reload
+
+    shop_1 = namespace_2.api_resources.create(properties: {name: 'Restarone'})
+    shop_2 = namespace_2.api_resources.create(properties: {name: 'Engineering'})
+
+    product_1 = namespace_1.api_resources.create(properties: {title: 'T-shirt', shop_id: shop_1.id})
+    product_2 = namespace_1.api_resources.create(properties: {title: 'Jeans', shop_id: shop_1.id})
+
+    assert_equal [product_1.id, product_2.id], shop_1.products.pluck(:id)
+    assert_equal [], shop_2.products.pluck(:id)
+
+    assert_equal shop_1, product_1.shop
+    assert_equal shop_1, product_2.shop
+  end
+
+  test 'should define associations: has_one' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_one', namespace: 'products'}]);
+
+    namespace_1.reload
+    namespace_2.reload
+
+    shop_1 = namespace_2.api_resources.create(properties: {name: 'Restarone'})
+    shop_2 = namespace_2.api_resources.create(properties: {name: 'Engineering'})
+
+    product_1 = namespace_1.api_resources.create(properties: {title: 'T-shirt', shop_id: shop_1.id})
+    product_2 = namespace_1.api_resources.create(properties: {title: 'Jeans', shop_id: shop_1.id})
+
+    assert_equal product_2, shop_1.product
+    assert_equal nil, shop_2.product
+
+    assert_equal shop_1, product_1.shop
+  end
+
+  test ' should destroy dependent associations when dependent is set to destroy' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_many', namespace: 'products', dependent: 'destroy'}]);
+
+    namespace_1.reload
+    namespace_2.reload
+
+    shop_1 = namespace_2.api_resources.create(properties: {name: 'Restarone'})
+
+    product_1 = namespace_1.api_resources.create(properties: {title: 'T-shirt', shop_id: shop_1.id})
+    product_2 = namespace_1.api_resources.create(properties: {title: 'Jeans', shop_id: shop_1.id})
+
+    assert_difference "namespace_2.reload.api_resources.count", -1 do
+      assert_difference "namespace_1.reload.api_resources.count", -2 do
+        shop_1.destroy
+      end
+    end
+  end
+
+  test 'should not allow destroy if dependent association exist when dependent is set to restrict_with_error' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_one', namespace: 'products', dependent: 'restrict_with_error'}]);
+
+    namespace_1.reload
+    namespace_2.reload
+
+    shop_1 = namespace_2.api_resources.create(properties: {name: 'Restarone'})
+
+    product_1 = namespace_1.api_resources.create(properties: {title: 'T-shirt', shop_id: shop_1.id})
+
+    assert_no_difference "namespace_2.reload.api_resources.count"  do
+      assert_no_difference "namespace_1.reload.api_resources.count"  do
+        shop_1.destroy
+      end
+    end
+
+    assert_equal ["Cannot delete record because dependent products exist"], shop_1.reload.errors.full_messages
+  end
+
+  test 'should not remove dependent association when dependent is not set' do
+    namespace_1 = ApiNamespace.create(name: 'products', version: 1, properties: { title: '' });
+    namespace_2 = ApiNamespace.create(name: 'shops', version: 1, properties: { name: '' }, associations: [{type: 'has_many', namespace: 'products'}]);
+
+    namespace_1.reload
+    namespace_2.reload
+
+    shop_1 = namespace_2.api_resources.create(properties: {name: 'Restarone'})
+
+    product_1 = namespace_1.api_resources.create(properties: {title: 'T-shirt', shop_id: shop_1.id})
+
+    assert_difference "namespace_2.reload.api_resources.count", -1  do
+      assert_no_difference "namespace_1.reload.api_resources.count"  do
+        shop_1.destroy
+      end
+    end
+  end
 end


### PR DESCRIPTION
## API Namespace Association Feature

### Introduction

The API Namespace Association feature allows you to define associations between different API namespaces in your application. It enables you to establish relationships such as has_one, has_many, and belongs_to between API namespaces. This feature enhances the flexibility and convenience of working with API resources by automatically generating dynamic methods for accessing associated resources.

### Usage
Associations can be defined while creating or editing API namespaces

https://github.com/restarone/violet_rails/assets/50227291/4e0a6736-846c-4ac1-88bb-165db5e0df98

OR using rails console

`ApiNamespace.friendly.find('shops').update(associations: [{type: 'has_many', namespace: 'products'}])`

NOTE: Associated namespace (products) must exist before creating an association.

### Foreign Key Properties
After assigning associations between API namespaces, the associated API namespace will automatically have a foreign key property added to its definition.

For example, if you have a belongs_to association between the product API namespace and the shop API namespace, the product resources will have a `shop_id` property added to them. This property represents the foreign key relationship to the associated shop resource.

### Corresponding Associations
Corresponding associations are generated 

When defining an association between two API namespaces, the corresponding association is automatically set up in the associated namespace.

- For `has_one` association: The associated namespace will have a `belongs_to` association with the original namespace.

- For `belongs_to` association: The associated namespace will have a `has_many` association with the original namespace, if an association between them is already not defined in associated namespace.

- For `has_many` association: The associated namespace will have a `belongs_to` association with the original namespace.

This ensures that the associations between the API namespaces are properly set up, allowing you to access the associated resources conveniently.

### Dependent option
You can specify the following association dependent options for each association:

blank: if set to `blank`, the associated resources will be left as it is when the parent resource is destroyed

destroy: If set to `destroy`, all the associated resources will be destroyed along with the parent resource

restrict_with_error: If set to `restrict_with_error`, the parent resource cannot be deleted if it has associated resources. An error will be added to the parent resource.

https://github.com/restarone/violet_rails/assets/50227291/39a33377-dfd2-42d8-ad77-2c820c613eeb


### Dynamic Methods
Once you have defined the associations between API namespaces, the API resources within these namespaces will automatically have dynamic methods generated based on the association type. These methods provide easy access to associated resources.

For each association type, the following dynamic methods are available:

#### `has_many` Association:
If a `shops` API namespace has a `has_many` association with a `products` API namespace, the dynamic method generated would be:

```
shop = ApiNamespace.friendly.find('shops').api_resources.first
shop.products
```

#### `has_one` Association:
If a `shops` API namespace has a `has_one` association with a `users` API namespace, the dynamic method generated would be:

```
shop = ApiNamespace.friendly.find('shops').api_resources.first
shop.user
```

#### `belongs_to` Association:
If a `products` API namespace has a `belongs_to` association with a `shops` API namespace, the dynamic method generated would be:

```
product = ApiNamespace.friendly.find('products').api_resources.first
product.shop
```

https://github.com/restarone/violet_rails/assets/50227291/47b12a92-a45b-4a75-8155-fb721010f076


DEMO:

https://github.com/restarone/violet_rails/assets/50227291/54cbb05f-84af-4ae7-9d29-1b16dab78567




