### PR TITLE
[feature] scaffold renderer at API Namespace creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# ignore DS store on mac
+**/.DS_Store
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/app/controllers/comfy/admin/api_namespaces_controller.rb
+++ b/app/controllers/comfy/admin/api_namespaces_controller.rb
@@ -267,7 +267,7 @@ class Comfy::Admin::ApiNamespacesController < Comfy::Admin::Cms::BaseController
                                             :properties,
                                             :requires_authentication,
                                             :namespace_type,
-                                            :has_form,
+                                            :is_renderable,
                                             non_primitive_properties_attributes: [:id, :label, :field_type, :content, :attachment, :allow_attachments, :_destroy],
                                             category_ids: [],
                                             associations: [:type, :namespace, :dependent]

--- a/app/views/comfy/admin/api_namespaces/_form.html.haml
+++ b/app/views/comfy/admin/api_namespaces/_form.html.haml
@@ -42,7 +42,7 @@
     = f.check_box :requires_authentication
   .field
     = f.label "Renderable (Form, and representation)"
-    = f.check_box :has_form, checked: @api_namespace.api_form.present?
+    = f.check_box :is_renderable, checked: @api_namespace.api_form.present?
 
   - unless has_only_uncategorized_access?(current_user.api_accessibility) 
     = render "comfy/admin/cms/categories/form", form: f

--- a/test/controllers/admin/comfy/api_namespaces_controller_test.rb
+++ b/test/controllers/admin/comfy/api_namespaces_controller_test.rb
@@ -68,10 +68,10 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     assert_redirected_to api_namespaces_url
   end
 
-  test "should create api_form if has_form params is true" do
+  test "should create api_form if is_renderable params is true" do
     sign_in(@user)
     assert_difference('ApiForm.count') do
-      post api_namespaces_url, params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, has_form: "1" ,requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
+      post api_namespaces_url, params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: @api_namespace.properties.to_json, is_renderable: "1" ,requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
     end
     api_namespace = ApiNamespace.last
     assert api_namespace.api_form
@@ -85,31 +85,31 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     }.to_json
 
     assert_difference('ApiForm.count') do
-      post api_namespaces_url, params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: properties, has_form: "1" ,requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
+      post api_namespaces_url, params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, properties: properties, is_renderable: "1" ,requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
     end
     api_namespace = ApiNamespace.last
     assert api_namespace.api_form
     assert_equal api_namespace.api_form.properties["age"]["type_validation"], 'tel'
   end
 
-  test "should create api_form if has_form params is true when updating" do
+  test "should create api_form if is_renderable params is true when updating" do
     sign_in(@user)
     assert_difference('ApiForm.count') do
-      patch api_namespace_url(api_namespaces(:two)), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, has_form: '1', properties: @api_namespace.properties, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
+      patch api_namespace_url(api_namespaces(:two)), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, is_renderable: '1', properties: @api_namespace.properties, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
     end
   end
 
-  test "should reomve api_form if has_form params is false when updating" do
+  test "should reomve api_form if is_renderable params is false when updating" do
     sign_in(@user)
     assert_difference('ApiForm.count', -1) do
-      patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, has_form: '0', properties: @api_namespace.properties, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
+      patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, is_renderable: '0', properties: @api_namespace.properties, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
     end
   end
 
   test "should not create api_form if api_form already exists" do
     sign_in(@user)
     assert_no_difference('ApiForm.count') do
-      patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, has_form: '1', properties: @api_namespace.properties, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
+      patch api_namespace_url(@api_namespace), params: { api_namespace: { name: @api_namespace.name, namespace_type: @api_namespace.namespace_type, is_renderable: '1', properties: @api_namespace.properties, requires_authentication: @api_namespace.requires_authentication, version: @api_namespace.version } }
     end
   end
 
@@ -606,7 +606,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
     sign_in(@user)
     properties = {"attr_1"=>true, "attr_2"=>true, "attr_3"=>true, "attr_4"=>true}
 
-    @api_namespace.has_form = '1'
+    @api_namespace.is_renderable = '1'
     @api_namespace.update(properties: properties)
 
     get api_namespace_url(@api_namespace)
@@ -774,7 +774,7 @@ class Comfy::Admin::ApiNamespacesControllerTest < ActionDispatch::IntegrationTes
 
   test "#index: Rendering tab should include documentation on form snippet and API HTML renderer snippets" do
     sign_in(@user)
-    @api_namespace.has_form = "1"
+    @api_namespace.is_renderable = "1"
     properties = { test_id: 123, obj:{ a:"b", c:"d"}, title: "Hello World", published: true, arr:[ 1, 2, 3], alpha_arr: ["a", "b"] }
 
     @api_namespace.update(properties: properties)

--- a/test/controllers/admin/comfy/api_resources_controller_test.rb
+++ b/test/controllers/admin/comfy/api_resources_controller_test.rb
@@ -549,8 +549,8 @@ class Comfy::Admin::ApiResourcesControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_message, flash[:alert]
   end
 
-  test "should able to create api_resource if has_form params is set false" do
-    @api_namespace.has_form = '0';
+  test "should able to create api_resource if is_renderable params is set false" do
+    @api_namespace.is_renderable = '0';
     @api_namespace.save;
     payload_as_stringified_json = "{\"age\":26,\"alive\":true,\"last_name\":\"Teng\",\"first_name\":\"Jennifer\"}"
 

--- a/test/plugin_fixtures/sync_attribute_to_api_namespace.yml
+++ b/test/plugin_fixtures/sync_attribute_to_api_namespace.yml
@@ -25,7 +25,7 @@ sync_attribute_to_api_namespace_plugin:
 
         # Adding the new-attribute in ApiNamespace
         new_properties = @api_namespace.properties.merge(attribute_name => default_value)
-        @api_namespace.has_form = @api_namespace.api_form.present? ? '1' : '0'
+        @api_namespace.is_renderable = @api_namespace.api_form.present? ? '1' : '0'
         @api_namespace.update!(properties: new_properties)
 
         # Making the new-attribute non-renderable


### PR DESCRIPTION
addresses: https://github.com/restarone/violet_rails/issues/1588

Upon API Namespace creation, an index page (for rendering a list of entities) and show page (for rendering a specific entity by ID) are generated along with Snippets for rendering list and show views. For convenience, a breadcrumb navigation bar and creation form are included in the generated pages. 


# create a namespace with rendering enabled
<img width="1164" alt="Screen Shot 2023-08-22 at 7 44 24 PM" src="https://github.com/restarone/violet_rails/assets/35935196/ac171cc2-3d53-4240-88b8-09f07c52e1b0">

# auto generated index and show pages
<img width="1212" alt="Screen Shot 2023-08-22 at 7 44 35 PM" src="https://github.com/restarone/violet_rails/assets/35935196/b70fe82c-d933-40ac-a864-0699d2c5ca75">


# rendered list view

<img width="1728" alt="Screen Shot 2023-08-22 at 7 50 32 PM" src="https://github.com/restarone/violet_rails/assets/35935196/def0398a-8de6-4b58-b18a-41ca48218690">

# rendered show view

<img width="1728" alt="Screen Shot 2023-08-22 at 7 49 53 PM" src="https://github.com/restarone/violet_rails/assets/35935196/8883963c-5ed1-4489-9a13-db8d861f637f">