### PR TITLE
[feature] Calendar and icalendar meetings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,3 +125,6 @@ gem 'devise-two-factor', "4.0.2"
 gem "slowpoke"
 
 gem "strong_migrations"
+gem "simple_calendar", "~> 3.0"
+
+gem "icalendar", "~> 2.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,9 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    icalendar (2.9.0)
+      ice_cube (~> 0.16)
+    ice_cube (0.16.4)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -417,6 +420,8 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    simple_calendar (3.0.2)
+      rails (>= 6.1)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -535,6 +540,7 @@ DEPENDENCIES
   gravatar_image_tag
   groupdate
   httparty
+  icalendar (~> 2.9)
   image_processing (~> 1.12)
   jbuilder (~> 2.7)
   jsonapi-serializer
@@ -559,6 +565,7 @@ DEPENDENCIES
   ros-apartment-sidekiq
   sass-rails (>= 6)
   selenium-webdriver
+  simple_calendar (~> 3.0)
   simple_discussion!
   simplecov
   sinatra

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@
  @import 'select2/dist/css/select2.css';
  @import './direct_upload.scss';
  @import 'daterangepicker/daterangepicker';
+ @import "simple_calendar";
 
  :root {
   --color-primary: #6C5BF5;

--- a/app/controllers/comfy/admin/calendars_controller.rb
+++ b/app/controllers/comfy/admin/calendars_controller.rb
@@ -1,0 +1,23 @@
+class Comfy::Admin::CalendarsController < Comfy::Admin::Cms::BaseController
+  layout "comfy/admin/cms"
+  before_action :check_email_authorization
+  def new
+
+  end
+
+  def index
+  # Scope your query to the dates being shown:
+  start_date = params.fetch(:start_date, Date.today).to_date
+  @meetings = Meeting.where(start_time: start_date.beginning_of_month.beginning_of_week..start_date.end_of_month.end_of_week)
+  end
+
+  
+  private
+
+  def check_email_authorization
+    unless current_user.can_manage_email
+      flash.alert = 'You do not have permission to manage email'
+      redirect_back(fallback_location: root_path)
+    end
+  end
+end

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -1,0 +1,142 @@
+class MeetingsController < Comfy::Admin::Cms::BaseController
+  before_action :set_meeting, only: %i[ show edit update destroy ]
+  before_action :check_email_authorization
+
+  # GET /meetings or /meetings.json
+  def index
+    @meetings = Meeting.all
+  end
+
+  # GET /meetings/1 or /meetings/1.json
+  def show
+  end
+
+  # GET /meetings/new
+  def new
+    @meeting = Meeting.new
+  end
+
+  # GET /meetings/1/edit
+  def edit
+  end
+
+  # POST /meetings or /meetings.json
+  def create
+    @meeting = Meeting.new(meeting_params)
+    @meeting.external_meeting_id = "#{SecureRandom.uuid}.#{Apartment::Tenant.current}@#{ENV['APP_HOST']}"
+    @meeting.status = 'CONFIRMED'
+    @meeting.participant_emails = meeting_params[:participant_emails].filter{ |node| URI::MailTo::EMAIL_REGEXP.match?(node) }
+  
+    respond_to do |format|
+      if @meeting.save
+        # send .ics file to participants
+        cal = Icalendar::Calendar.new
+        filename = "Invitation: #{@meeting.name}"
+        from_address = "#{Apartment::Tenant.current}@#{ENV['APP_HOST']}"
+        # to generate outlook
+        if false == 'vcs'
+          cal.prodid = '-//Microsoft Corporation//Outlook MIMEDIR//EN'
+          cal.version = '1.0'
+          filename += '.vcs'
+        else # ical
+          cal.prodid = '-//Restarone Solutions, Inc.//NONSGML ExportToCalendar//EN'
+          cal.version = '2.0'
+          filename += '.ics'
+        end
+        cal.append_custom_property('METHOD', 'REQUEST')
+        cal.event do |e|
+          e.dtstart     = Icalendar::Values::DateTime.new(@meeting.start_time, tzid: @meeting.timezone)
+          e.dtend       = Icalendar::Values::DateTime.new(@meeting.end_time, tzid: @meeting.timezone)
+          e.organizer = Icalendar::Values::CalAddress.new("mailto:#{from_address}", cn: from_address)
+          e.attendee = Icalendar::Values::CalAddress.new("mailto:#{from_address}", partstat: 'ACCEPTED')
+          e.uid = @meeting.external_meeting_id
+          @meeting.participant_emails.each do |email|
+            attendee_params = { 
+              "CUTYPE"   => "INDIVIDUAL",
+              "ROLE"     => "REQ-PARTICIPANT",
+              "PARTSTAT" => "NEEDS-ACTION",
+              "RSVP"     => "TRUE",
+            }
+
+            attendee_value = Icalendar::Values::Text.new("MAILTO:#{email}", attendee_params)
+            cal.append_custom_property("ATTENDEE", attendee_value)
+          end
+          e.description = @meeting.description
+          e.location    = @meeting.location
+          e.sequence = Time.now.to_i
+          e.status = "CONFIRMED"
+          e.summary     = @meeting.name
+          
+
+          e.alarm do |a|
+            a.summary = "#{@meeting.name} starts in 30 minutes!"
+            a.trigger = '-PT30M'
+          end
+        end
+        file = cal.to_ical
+        attachment = { filename: filename, mime_type: "text/calendar;method=REQUEST;name=\'#{filename}\'", content: file }
+        blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new(attachment[:content]), filename: attachment[:filename], content_type: attachment[:mime_type], metadata: nil)
+        email_thread = MessageThread.create!(recipients: @meeting.participant_emails, subject: "Invitation: #{@meeting.name}")
+        email_content = <<-HTML
+        <div>
+          <p>You have been invited to the following meeting, please see details below<br><br>
+          </p>
+
+        </div>
+        HTML
+        email_content += ActionText::Content.new("<action-text-attachment sgid='#{blob.attachable_sgid}'></action-text-attachment>").to_s
+        email_message = email_thread.messages.create!(
+          content: email_content.html_safe,
+          from: from_address
+        )
+        EMailer.with(message: email_message, message_thread: email_thread, attachments: [attachment]).ship.deliver_later
+
+        format.html { redirect_to @meeting, notice: "Meeting was successfully created." }
+        format.json { render :show, status: :created, location: @meeting }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @meeting.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /meetings/1 or /meetings/1.json
+  def update
+    respond_to do |format|
+      if @meeting.update(meeting_params)
+        format.html { redirect_to @meeting, notice: "Meeting was successfully updated." }
+        format.json { render :show, status: :ok, location: @meeting }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @meeting.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /meetings/1 or /meetings/1.json
+  def destroy
+    @meeting.destroy
+    respond_to do |format|
+      format.html { redirect_to meetings_url, notice: "Meeting was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_meeting
+      @meeting = Meeting.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def meeting_params
+      params.require(:meeting).permit(:name, :start_time, :end_time, :description, :timezone, :location, participant_emails: [])
+    end
+
+    def check_email_authorization
+      unless current_user.can_manage_email
+        flash.alert = 'You do not have permission to manage email'
+        redirect_back(fallback_location: root_path)
+      end
+    end
+end

--- a/app/mailboxes/e_mailbox.rb
+++ b/app/mailboxes/e_mailbox.rb
@@ -17,15 +17,17 @@ class EMailbox < ApplicationMailbox
               subject: subject
             )
           end
-
+          uploaded_attachments = attachments
+          multipart_attachments = multipart_attached
           message = Message.create!(
             email_message_id: mail.message_id,
             message_thread: message_thread,
-            content: body,
+            content: body(uploaded_attachments),
             from: mail.from.join(', '),
-            attachments: (attachments + multipart_attached).map{ |a| a[:blob] }
+            attachments: (uploaded_attachments + multipart_attachments).map{ |a| a[:blob] }
           )
           message_thread.update(unread: true)
+          process_attachments(uploaded_attachments) if uploaded_attachments.size > 0
           ApiNamespace::Plugin::V1::SubdomainEventsService.new(message).track_event
         end
       end
@@ -60,10 +62,10 @@ class EMailbox < ApplicationMailbox
     return blobs
   end
 
-  def body
+  def body(uploaded_blobs)
     if mail.multipart? && mail.html_part
       document = Nokogiri::HTML(mail.html_part.body.decoded)
-      attachments.map do |attachment_hash|
+      uploaded_blobs.map do |attachment_hash|
         attachment = attachment_hash[:original]
         blob = attachment_hash[:blob]
         if attachment.content_id.present?
@@ -90,5 +92,36 @@ class EMailbox < ApplicationMailbox
     # There are some standard email subject prefixes which gets prepended in the email's subject.
     # examples: 'Re: ', 're: ', 'FWD: ', 'Fwd: ', 'Fw: '
     subject.gsub(/^((re|fw(d)?): )/i, '')
+  end
+
+  def process_attachments(blobs)
+    # process .ics files
+    ics_files = blobs.select {|attachment| attachment[:original].content_type.include?('.ics') }
+    ics_files.each do |ics_file|
+      ics_string = ics_file[:blob].download
+      calendars = Icalendar::Calendar.parse(ics_string)
+      calendars.each do |calendar|
+        calendar.events.each do |event|
+          existing_meeting = Meeting.find_by(external_meeting_id: event.uid.to_s)
+          if existing_meeting
+            # handle replies to meeting invites
+            existing_meeting.update(updated_at: Time.now)
+          else
+            meeting = Meeting.create!(
+              name: event.summary,
+              external_meeting_id: event.uid,
+              start_time: event.dtstart,
+              end_time: event.dtend,
+              timezone: Array.wrap(event.dtstart.ical_params['tzid']).join('-'),
+              description: event.description,
+              participant_emails: event.attendee.map{|uri| uri.to },
+              location: event.location,
+              status: 'TENTATIVE',
+              custom_properties: event.custom_properties,
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,0 +1,6 @@
+class Meeting < ApplicationRecord
+  STATUS_LIST = ['TENTATIVE', 'CONFIRMED', 'CANCELLED']
+  # https://www.kanzaki.com/docs/ical/status.html
+
+  validates :status, inclusion: { in: STATUS_LIST  }
+end

--- a/app/views/comfy/admin/calendars/index.html.haml
+++ b/app/views/comfy/admin/calendars/index.html.haml
@@ -1,0 +1,38 @@
+.page-header
+  .h2
+    Calendar
+  %p Early access, feature under active development
+
+
+= month_calendar(events: @meetings, attribute: :start_time) do |date, meetings|
+  = date
+  - meetings.each do |meeting|
+    %div
+      = meeting.name
+
+.h2 Listing meetings
+
+%table.table
+  %thead
+    %tr
+      %th Name
+      %th Start time
+      %th Participant emails
+      %th Status
+      %th
+      %th
+
+  %tbody
+    - @meetings.each do |meeting|
+      %tr
+        %td
+          = link_to meeting.name, meeting
+        %td= meeting.start_time
+        %td= meeting.participant_emails
+        %td= meeting.status
+        %td= link_to 'Edit', edit_meeting_path(meeting)
+        %td= link_to 'Destroy', meeting, method: :delete, data: { confirm: 'Are you sure?' }
+
+%br
+
+= link_to 'New Meeting', new_meeting_path

--- a/app/views/comfy/admin/cms/partials/_navigation_inner.haml
+++ b/app/views/comfy/admin/cms/partials/_navigation_inner.haml
@@ -1,6 +1,7 @@
 %li{class: 'nav-item', data: { turbo: 'true'}}
   = active_link_to "Users", admin_users_path, class: 'nav-link'
   = active_link_to "Email", mailbox_path, class: 'nav-link'
+  = active_link_to "Calendar", calendars_path, class: 'nav-link'
   = active_link_to "API", api_namespaces_path, class: 'nav-link'
   = active_link_to "App Settings", edit_web_settings_path, class: 'nav-link'
   = active_link_to "Analytics", dashboard_path, class: 'nav-link'

--- a/app/views/meetings/_form.html.haml
+++ b/app/views/meetings/_form.html.haml
@@ -1,0 +1,41 @@
+= form_for @meeting do |f|
+  - if @meeting.errors.any?
+    #error_explanation
+      %h2= "#{pluralize(@meeting.errors.count, "error")} prohibited this meeting from being saved:"
+      %ul
+        - @meeting.errors.full_messages.each do |message|
+          %li= message
+
+  .field
+    = f.label :name
+    = f.text_field :name
+  .field
+    = f.label :start_time
+    = f.datetime_select :start_time
+  .field
+    = f.label :end_time
+    = f.datetime_select :end_time
+  .field
+    = f.label :participant_emails
+    = f.select :participant_emails, options_for_select([]), { include_blank: false }, { multiple: true }
+  .field
+    = f.label :description
+    = f.text_area :description
+  .field
+    = f.label :timezone
+    = f.select :timezone, ActiveSupport::TimeZone::MAPPING
+  .field
+    = f.label :location
+    = f.text_field :location
+  .actions
+    = f.submit 'Save'
+
+:javascript
+  $(document).ready( function() {
+    $("#meeting_participant_emails").select2({
+      multiple: true,
+      required: true,
+      tags: true,
+      tokenSeparators: [',', ' '],
+    })
+  });

--- a/app/views/meetings/_meeting.json.jbuilder
+++ b/app/views/meetings/_meeting.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! meeting, :id, :name, :start_time, :end_time, :participant_emails, :description, :timezone, :location, :status, :external_meeting_id, :created_at, :updated_at
+json.url meeting_url(meeting, format: :json)

--- a/app/views/meetings/edit.html.haml
+++ b/app/views/meetings/edit.html.haml
@@ -1,0 +1,7 @@
+%h1 Editing meeting
+
+= render 'form'
+
+= link_to 'Show', @meeting
+\|
+= link_to 'Back', meetings_path

--- a/app/views/meetings/index.html.haml
+++ b/app/views/meetings/index.html.haml
@@ -1,0 +1,37 @@
+%h1 Listing meetings
+
+%table
+  %thead
+    %tr
+      %th Name
+      %th Start time
+      %th End time
+      %th Participant emails
+      %th Description
+      %th Timezone
+      %th Location
+      %th Status
+      %th External meeting
+      %th
+      %th
+      %th
+
+  %tbody
+    - @meetings.each do |meeting|
+      %tr
+        %td= meeting.name
+        %td= meeting.start_time
+        %td= meeting.end_time
+        %td= meeting.participant_emails
+        %td= meeting.description
+        %td= meeting.timezone
+        %td= meeting.location
+        %td= meeting.status
+        %td= meeting.external_meeting_id
+        %td= link_to 'Show', meeting
+        %td= link_to 'Edit', edit_meeting_path(meeting)
+        %td= link_to 'Destroy', meeting, method: :delete, data: { confirm: 'Are you sure?' }
+
+%br
+
+= link_to 'New Meeting', new_meeting_path

--- a/app/views/meetings/index.json.jbuilder
+++ b/app/views/meetings/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @meetings, partial: "meetings/meeting", as: :meeting

--- a/app/views/meetings/new.html.haml
+++ b/app/views/meetings/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New meeting
+
+= render 'form'
+
+= link_to 'Back', meetings_path

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -1,0 +1,33 @@
+%p#notice= notice
+
+%p
+  %b Name:
+  = @meeting.name
+%p
+  %b Start time:
+  = @meeting.start_time
+%p
+  %b End time:
+  = @meeting.end_time
+%p
+  %b Participant emails:
+  = @meeting.participant_emails
+%p
+  %b Description:
+  = @meeting.description
+%p
+  %b Timezone:
+  = @meeting.timezone
+%p
+  %b Location:
+  = @meeting.location
+%p
+  %b Status:
+  = @meeting.status
+%p
+  %b External meeting:
+  = @meeting.external_meeting_id
+
+= link_to 'Edit', edit_meeting_path(@meeting)
+\|
+= link_to 'Back', meetings_path

--- a/app/views/meetings/show.json.jbuilder
+++ b/app/views/meetings/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "meetings/meeting", meeting: @meeting

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <%= content_tag :tr, class: calendar.tr_classes_for(week) do %>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,0 +1,39 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title">
+      <%= t('simple_calendar.week', default: 'Week') %>
+      <%= calendar.week_number %>
+      <% if calendar.number_of_weeks > 1 %>
+        - <%= calendar.end_week %>
+      <% end %>
+    </span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,10 @@ Rails.application.routes.draw do
     end
   end
 
+  # calendar / meetings functionality
+  resources :calendars, controller: 'comfy/admin/calendars'
+  resources :meetings
+
   resource :web_settings, controller: 'comfy/admin/web_settings', only: [:edit, :update]
   resources :users, controller: 'comfy/admin/users', as: :admin_users, except: [:create, :show] do
     collection do

--- a/db/migrate/20230913160600_create_meetings.rb
+++ b/db/migrate/20230913160600_create_meetings.rb
@@ -1,0 +1,19 @@
+class CreateMeetings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :meetings do |t|
+      t.string :name
+      t.datetime :start_time, null: false
+      t.datetime :end_time, null: false
+      t.text :participant_emails, array: true, default: []
+      t.text :description
+      t.string :timezone, null: false
+      t.string :location
+      t.string :status, null: false
+      t.string :external_meeting_id, null: false
+      t.jsonb :custom_properties, default: '{}'
+
+      t.timestamps
+    end
+    add_index :meetings, :external_meeting_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_16_012035) do
+ActiveRecord::Schema.define(version: 2023_09_13_160600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -427,6 +427,22 @@ ActiveRecord::Schema.define(version: 2023_05_16_012035) do
     t.integer "threads_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "meetings", force: :cascade do |t|
+    t.string "name"
+    t.datetime "start_time", null: false
+    t.datetime "end_time", null: false
+    t.text "participant_emails", default: [], array: true
+    t.text "description"
+    t.string "timezone", null: false
+    t.string "location"
+    t.string "status", null: false
+    t.string "external_meeting_id", null: false
+    t.jsonb "custom_properties", default: "{}"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["external_meeting_id"], name: "index_meetings_on_external_meeting_id", unique: true
   end
 
   create_table "message_threads", force: :cascade do |t|

--- a/test/controllers/meetings_controller_test.rb
+++ b/test/controllers/meetings_controller_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class MeetingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @meeting = meetings(:one)
+    @user = users(:public)
+    @user.update(can_manage_email: true)
+    sign_in(@user)
+  end
+
+  test "should get index" do
+    get meetings_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_meeting_url
+    assert_response :success
+  end
+
+  test "should create meeting" do
+    assert_difference('Meeting.count') do
+      post meetings_url, params: { meeting: { description: @meeting.description, end_time: @meeting.end_time, location: @meeting.location, name: @meeting.name, participant_emails: ['contact@restarone.com'], start_time: @meeting.start_time, status: @meeting.status, timezone: @meeting.timezone } }
+    end
+
+    assert_redirected_to meeting_url(Meeting.last)
+  end
+
+  test "should show meeting" do
+    get meeting_url(@meeting)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_meeting_url(@meeting)
+    assert_response :success
+  end
+
+  test "should update meeting" do
+    patch meeting_url(@meeting), params: { meeting: { description: @meeting.description, end_time: @meeting.end_time, location: @meeting.location, name: @meeting.name, participant_emails: @meeting.participant_emails, start_time: @meeting.start_time, status: "TENTATIVE", timezone: @meeting.timezone } }
+    assert_redirected_to meeting_url(@meeting)
+  end
+
+  test "should destroy meeting" do
+    assert_difference('Meeting.count', -1) do
+      delete meeting_url(@meeting)
+    end
+
+    assert_redirected_to meetings_url
+  end
+end

--- a/test/fixtures/files/email_with_calendar_invite.eml
+++ b/test/fixtures/files/email_with_calendar_invite.eml
@@ -1,0 +1,893 @@
+Delivered-To: restarone@restarone.solutions
+Received: by 2002:a9a:7443:0:b0:26d:f5c7:8136 with SMTP id m3csp3319080lkn;
+        Wed, 13 Sep 2023 06:47:41 -0700 (PDT)
+X-Received: by 2002:ad4:4446:0:b0:655:cf0f:6704 with SMTP id l6-20020ad44446000000b00655cf0f6704mr2657418qvt.5.1694612860430;
+        Wed, 13 Sep 2023 06:47:40 -0700 (PDT)
+ARC-Seal: i=1; a=rsa-sha256; t=1694612860; cv=none;
+        d=google.com; s=arc-20160816;
+        b=yajeqbL7Up6JLXkzQUXVPUt0dHRL+EDPmJ/naSDyOxG+WYTeWrgoy7QCoghbwmUl99
+         Y2FnsJoXXq7Igc/wxZhJz2u/BzDIhubb/0asmscO/98q9Dx6TeMNlBodtDyuMe99R711
+         esEWka1GaBhRHokPl7gqNn9wjhpqmGqndEpNvfDZ0Pps/iYllEsdMzX5FtndCjddtr+Q
+         ANQlvSmXBD+VS2xU3zTM0nWJmpgFNDZhF1a+WgubwyaL6qbduzoPaBZ13Vvc5vhrlzPH
+         PNXnG+Q+/7a9VI6pqYXHux4rcrrkyCUq4dgE8POXss2IeASvULVjNvPIHg0ZcGwIYgCT
+         y31w==
+ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=google.com; s=arc-20160816;
+        h=to:from:subject:date:message-id:sender:reply-to:mime-version
+         :dkim-signature:dkim-signature;
+        bh=jQjL48TRbWIpmFbKg7lGniGzhaf+TVo9+lJ67nhrZk4=;
+        fh=3YrH2AqvZR8DkO7aOt+6Qken8yFGbL96xDY6JnnMGNk=;
+        b=CGM8nMyhcs5B3t5Ha0O8sDCw0op+5YKXdxi3ooNSOcMPPFmg6KFQK5Hi+Cc4jDr8Y2
+         M9N2mqq4DCGjbxxQTGY1rsB6E1MpepXAMUX+qV/W0wKi/4WX1GBaxcRJgbxfSW1Gk6Q7
+         LDqcv7+lSAw1e+wP6syoPC/6z3xWq2NpcVUiscRHDiDzexn+nnwJE5BFutbWhzHip6yr
+         fWfDaskZMM/MUm5YG062ipqPWPaxsYD6KaJj8kfkcvRk6kPDIN6K78qc/Fr/wA2p6KR/
+         AGxrcL8tDL2kdyHvNcoFUZLEY+mM8ICKTks8L+DoWCCW+tku79npMgGFZLtem/jOQGPe
+         KhTA==
+ARC-Authentication-Results: i=1; mx.google.com;
+       dkim=pass header.i=@google.com header.s=20230601 header.b=4cb2kpAG;
+       dkim=pass header.i=@restarone.com header.s=google header.b=c9L85yhO;
+       spf=pass (google.com: domain of contact@restarone.com designates 209.85.220.73 as permitted sender) smtp.mailfrom=contact@restarone.com
+Return-Path: <contact@restarone.com>
+Received: from mail-sor-f73.google.com (mail-sor-f73.google.com. [209.85.220.73])
+        by mx.google.com with SMTPS id n6-20020a0c8c06000000b00631f654d349sor4820453qvb.5.2023.09.13.06.47.40
+        for <restarone@restarone.solutions>
+        (Google Transport Security);
+        Wed, 13 Sep 2023 06:47:40 -0700 (PDT)
+Received-SPF: pass (google.com: domain of contact@restarone.com designates 209.85.220.73 as permitted sender) client-ip=209.85.220.73;
+Authentication-Results: mx.google.com;
+       dkim=pass header.i=@google.com header.s=20230601 header.b=4cb2kpAG;
+       dkim=pass header.i=@restarone.com header.s=google header.b=c9L85yhO;
+       spf=pass (google.com: domain of contact@restarone.com designates 209.85.220.73 as permitted sender) smtp.mailfrom=contact@restarone.com
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=google.com; s=20230601; t=1694612860; x=1695217660; dara=google.com;
+        h=to:from:subject:date:message-id:sender:reply-to:mime-version:from
+         :to:cc:subject:date:message-id:reply-to;
+        bh=jQjL48TRbWIpmFbKg7lGniGzhaf+TVo9+lJ67nhrZk4=;
+        b=4cb2kpAGWYCCzwsVOEmFpeC5eH2DOe6TeebiP7ALlgSRToIQf9jZB4/9Z5TbLBn/Bz
+         /GLRwjF5RTuz9T1FKVNMokMUThUuHfQkAcyG+tkUBbqSqBDsl9rriAJJ7OzZaV1yFsH4
+         p3yHakQ/oombYRGf9iVxrMrVpVPT27Ty4uE+CYjMCHIjg8l36iAHKGErJhVHpeVvDycn
+         RIOpaSeuDgaqWJ6cZRW5TnAuGpZf7xcgSFvJE7NU6StVTgIRaQ3h4RI0HmGwUuT6eHe/
+         Gxvzh4Zyvr4jS8j0q/IaX65Mzs9y3ZAilTlcTjZhiw9ewnnlslprSXxRtAAShiXqN3DW
+         tKVQ==
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=restarone.com; s=google; t=1694612860; x=1695217660; dara=google.com;
+        h=to:from:subject:date:message-id:sender:reply-to:mime-version:from
+         :to:cc:subject:date:message-id:reply-to;
+        bh=jQjL48TRbWIpmFbKg7lGniGzhaf+TVo9+lJ67nhrZk4=;
+        b=c9L85yhO9+lWc5YL4toKAMjgB6zObypswuclLnH0ZOl1IuODTHVuDwgZY9xlzOT4w3
+         CvGGRjWe9Idks6oXDkSExHoXAA9qKrSAd8f6RW5rmeNDlTiHYMVaSNtEc1iTyKaHuA5l
+         xO4zy5OusYCEl5q5LSyWTN1I+tJJWINKVMhds=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20230601; t=1694612860; x=1695217660;
+        h=to:from:subject:date:message-id:sender:reply-to:mime-version
+         :x-gm-message-state:from:to:cc:subject:date:message-id:reply-to;
+        bh=jQjL48TRbWIpmFbKg7lGniGzhaf+TVo9+lJ67nhrZk4=;
+        b=Sb+r+Abl1na8CpV0Ixdrmk7Bk/KUOT4arNsHMNG3GFKW+qMd0inEztuxkYVppq0GFq
+         i+KzwQ0HlpCWA83Thu8SLIigPPl1VsAI+nkNbX4yuG5las+/4JtlwIaDYRpIG4h+x1t+
+         WGfcmE7QcbbHg5y803tuIqp1xgpnSZQ9JCOZECiJdHyiKhRrY3Uxyg9dotCk4xgFVv8h
+         YCA18S4qy/JsVHp3BWVqch8h6PHyhMojKCdMUzyxcChG2BnGrGcVabetzHGiqvUyERRx
+         vSq5KSF/c/D9KrWod/1Xs4pv7pYjQDE+ZU+a1gdZtmWZYUzDoJjWKqilbbaTZtMCEUqr
+         z84A==
+X-Gm-Message-State: AOJu0YwNhqeENoTe+Fj9uDXO0JKv1g2PUZphLGjx3aOEW0t/yK1FSXCf
+	qJLe+otnSEuXxViGSI2/XL416S0SX3b5lARJR2RcFyHBaqUiaHM=
+X-Google-Smtp-Source: AGHT+IEWeye6hY2V3qBxbAZLOMwHDvUCYFicSIxgxL92HWng5zyOUUxp9Ub9/xvyrUBr2ZwBi67P8XTuiQVHmUP3Y20U
+MIME-Version: 1.0
+X-Received: by 2002:a05:6214:5002:b0:64f:946a:e2a6 with SMTP id
+ jo2-20020a056214500200b0064f946ae2a6mr3252403qvb.50.1694612859853; Wed, 13
+ Sep 2023 06:47:39 -0700 (PDT)
+Reply-To: contact@restarone.com
+Sender: Google Calendar <calendar-notification@google.com>
+Message-ID: <calendar-70d3fc45-b1ba-467d-a239-bd1ffe609e32@google.com>
+Date: Wed, 13 Sep 2023 13:47:39 +0000
+Subject: Invitation: test meeting @ Wed Sep 13, 2023 12:30pm - 1:30pm (EDT) (restarone@restarone.solutions)
+From: contact@restarone.com
+To: restarone@restarone.solutions
+Content-Type: multipart/mixed; boundary="0000000000008b4dbe06053dcde8"
+
+--0000000000008b4dbe06053dcde8
+Content-Type: multipart/alternative; boundary="0000000000008b4dbd06053dcde6"
+
+--0000000000008b4dbd06053dcde6
+Content-Type: text/plain; charset="UTF-8"; format=flowed; delsp=yes
+Content-Transfer-Encoding: base64
+
+dGVzdCBtZWV0aW5nDQpXZWRuZXNkYXkgU2VwIDEzLCAyMDIzIOKLhSAxMjozMHBtIOKAkyAxOjMw
+cG0NCkVhc3Rlcm4gVGltZSAtIFRvcm9udG8NCg0KSm9pbiB3aXRoIEdvb2dsZSBNZWV0DQpodHRw
+czovL21lZXQuZ29vZ2xlLmNvbS9pb24tcmNkYy15cnE/aHM9MjI0DQoNCg0KCQ0KSm9pbiBieSBw
+aG9uZQ0KKENBKSArMSAyODktMzQ4LTc3NzENClBJTjogNDIwMTQ0NjA3DQoNCk1vcmUgcGhvbmUg
+bnVtYmVycw0KaHR0cHM6Ly90ZWwubWVldC9pb24tcmNkYy15cnE/cGluPTYxMjYxMjUyODcyMDUm
+aHM9MA0KDQoNCk9yZ2FuaXplcg0KY29udGFjdEByZXN0YXJvbmUuY29tDQpjb250YWN0QHJlc3Rh
+cm9uZS5jb20NCg0KUmVwbHkgZm9yIHNoYXNoaWtlamF5YXR1bmdlQGdtYWlsLmNvbSBhbmQgdmll
+dyBtb3JlIGRldGFpbHMgIA0KaHR0cHM6Ly9jYWxlbmRhci5nb29nbGUuY29tL2NhbGVuZGFyL2V2
+ZW50P2FjdGlvbj1WSUVXJmVpZD1OM056WVRadE0yWXlOSEpqWjJoMWJUVTVabVppZGpkeGFEUWdj
+MmhoYzJocGEyVnFZWGxoZEhWdVoyVkFiUSZ0b2s9TWpFalkyOXVkR0ZqZEVCeVpYTjBZWEp2Ym1V
+dVkyOXRaVEEwT1RKa09UQTFaR1UyTlRCbE9XSXpNR1ppTW1Vd01qVmpOV05rTmpVeE1tUTNPV1Zo
+WkEmY3R6PUFtZXJpY2ElMkZUb3JvbnRvJmhsPWVuJmVzPTENCllvdXIgYXR0ZW5kYW5jZSBpcyBv
+cHRpb25hbC4NCg0Kfn4vL35+DQpJbnZpdGF0aW9uIGZyb20gR29vZ2xlIENhbGVuZGFyOiBodHRw
+czovL2NhbGVuZGFyLmdvb2dsZS5jb20vY2FsZW5kYXIvDQoNCllvdSBhcmUgcmVjZWl2aW5nIHRo
+aXMgZW1haWwgYmVjYXVzZSB5b3UgYXJlIGFuIGF0dGVuZGVlIG9uIHRoZSBldmVudC4gVG8gIA0K
+c3RvcCByZWNlaXZpbmcgZnV0dXJlIHVwZGF0ZXMgZm9yIHRoaXMgZXZlbnQsIGRlY2xpbmUgdGhp
+cyBldmVudC4NCg0KRm9yd2FyZGluZyB0aGlzIGludml0YXRpb24gY291bGQgYWxsb3cgYW55IHJl
+Y2lwaWVudCB0byBzZW5kIGEgcmVzcG9uc2UgdG8gIA0KdGhlIG9yZ2FuaXplciwgYmUgYWRkZWQg
+dG8gdGhlIGd1ZXN0IGxpc3QsIGludml0ZSBvdGhlcnMgcmVnYXJkbGVzcyBvZiAgDQp0aGVpciBv
+d24gaW52aXRhdGlvbiBzdGF0dXMsIG9yIG1vZGlmeSB5b3VyIFJTVlAuDQoNCkxlYXJuIG1vcmUg
+aHR0cHM6Ly9zdXBwb3J0Lmdvb2dsZS5jb20vY2FsZW5kYXIvYW5zd2VyLzM3MTM1I2ZvcndhcmRp
+bmcNCg==
+--0000000000008b4dbd06053dcde6
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+<!doctype html><html xmlns=3D"http://www.w3.org/1999/xhtml" xmlns:v=3D"urn:=
+schemas-microsoft-com:vml" xmlns:o=3D"urn:schemas-microsoft-com:office:offi=
+ce"><head><title></title><!--[if !mso]><meta http-equiv=3D"X-UA-Compatible"=
+ content=3D"IE=3Dedge"><![endif]--><meta http-equiv=3D"Content-Type" conten=
+t=3D"text/html; charset=3DUTF-8"><meta name=3D"viewport" content=3D"width=
+=3Ddevice-width,initial-scale=3D1"><meta name=3D"color-scheme" content=3D"l=
+ight dark"><meta name=3D"supported-color-schemes" content=3D"light dark">
+    <style>
+      body, html {
+        font-family: Roboto, Helvetica, Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        -webkit-font-smoothing: antialiased;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+
+      #outlook a {
+        padding: 0;
+      }
+
+      .ReadMsgBody {
+        width: 100%;
+      }
+
+      .ExternalClass {
+        width: 100%;
+      }
+
+      .ExternalClass * {
+        line-height: 100%;
+      }
+
+      table,
+      td {
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+
+      img {
+        border: 0;
+        height: auto;
+        line-height: 100%;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+
+      p {
+        display: block;
+        margin: 13px 0;
+      }
+    </style>
+    <!--[if !mso]><!-->
+    <style>
+      @media only screen and (max-width:580px) {
+        @-ms-viewport {
+          width: 320px;
+        }
+
+        @viewport {
+          width: 320px;
+        }
+      }
+    </style>
+    <!--<![endif]-->
+    <!--[if mso]>
+          <xml>
+          <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+          </xml>
+          <![endif]-->
+    <!--[if lte mso 11]>
+          <style>
+            .outlook-group-fix { width:100% !important; }
+          </style>
+    <![endif]-->
+
+    <!--[if !mso]><!-- -->
+  <style>body, html {font-family:Roboto,Helvetica,Arial,sans-serif;}@font-f=
+ace {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: url(//fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu4mxP.ttf) forma=
+t('truetype');
+}
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 500;
+  src: url(//fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmEU9fBBc9.ttf) f=
+ormat('truetype');
+}
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  src: url(//fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmWUlfBBc9.ttf) f=
+ormat('truetype');
+}
+@font-face {
+  font-family: 'Material Icons Extended';
+  font-style: normal;
+  font-weight: 400;
+  src: url(//fonts.gstatic.com/s/materialiconsextended/v149/kJEjBvgX7BgnkSr=
+UwT8UnLVc38YydejYY-oE_LvM.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Google Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(//fonts.gstatic.com/s/googlematerialicons/v137/Gw6kwdfw6UnXLJCcm=
+afZyFRXb3BL9rvi0QZG3g.otf) format('opentype');
+}
+
+.google-material-icons {
+  font-family: 'Google Material Icons';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+}
+@font-face {
+  font-family: 'Google Material Icons Filled';
+  font-style: normal;
+  font-weight: 400;
+  src: url(//fonts.gstatic.com/s/googlematerialiconsfilled/v113/WWXFlimHYg6=
+HKI3TavMkbKdhBmDvgach8TVpeGsuueSZJH4.otf) format('opentype');
+}
+
+.google-material-icons-filled {
+  font-family: 'Google Material Icons Filled';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+}
+@font-face {
+  font-family: 'Google Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url(//fonts.gstatic.com/s/googlesans/v14/4UaGrENHsxJlGDuGo1OIlL3Owps=
+.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Google Sans';
+  font-style: normal;
+  font-weight: 500;
+  src: url(//fonts.gstatic.com/s/googlesans/v14/4UabrENHsxJlGDuGo1OIlLU94Yt=
+zCwM.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Google Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: url(//fonts.gstatic.com/s/googlesans/v14/4UabrENHsxJlGDuGo1OIlLV154t=
+zCwM.ttf) format('truetype');
+}
+</style><!--<![endif]-->
+      <style>
+        .body-container {
+          padding-left: 16px;
+          padding-right: 16px;
+        }
+      </style>
+ =20
+      <style>
+        u+.body .body-container,
+        body[data-outlook-cycle] .body-container,
+        #MessageViewBody .body-container {
+          padding-left: 0;
+          padding-right: 0;
+        }
+      </style>
+ =20
+    <style>
+      @media only screen and (min-width:580px) {
+        .column-per-37 {
+          width: 37% !important;
+          max-width: 37%;
+        }
+
+        .column-per-63 {
+          width: 63% !important;
+          max-width: 63%;
+        }
+      }
+    </style>
+ =20
+    <style>
+      .appointment-buttons th {
+        display: block;
+        clear: both;
+        float: left;
+        margin-top: 12px;
+      }
+
+      .appointment-buttons th a {
+        float: left;
+      }
+
+      #MessageViewBody .appointment-buttons th {
+       margin-top: 24px;
+      }
+    </style>
+ =20
+    <style>
+      @media only screen and (max-width:580px) {
+        table.full-width-mobile {
+          width: 100% !important;
+        }
+
+        td.full-width-mobile {
+          width: auto !important;
+        }
+      }
+    </style>
+    <style>
+      .main-container-inner,
+      .info-bar-inner {
+        padding: 12px 16px !important;
+      }
+
+      .main-column-table-ltr {
+        padding-right: 0 !important;
+      }
+
+      .main-column-table-rtl {
+        padding-left: 0 !important;
+      }
+
+      @media only screen and (min-width:580px) {
+        .main-container-inner {
+          padding: 24px 32px !important;
+        }
+
+        .info-bar-inner {
+          padding: 12px 32px !important;
+        }
+
+        .main-column-table-ltr {
+          padding-right: 32px !important;
+        }
+
+        .main-column-table-rtl {
+          padding-left: 32px !important;
+        }
+
+        .appointment-buttons th {
+          display: table-cell;
+          clear: none;
+        }
+      }
+
+      .primary-text {
+        color: #3c4043 !important;
+      }
+
+      .secondary-text,
+      .phone-number a {
+        color: #70757a !important;
+      }
+
+      .accent-text {
+        color: #1a73e8 !important;
+      }
+
+      .accent-text-dark {
+        color: #185abc !important;
+      }
+
+      .grey-button-text,
+      .attachment-chip a {
+        color: #5f6368 !important;
+      }
+
+      .primary-button {
+        background-color: #1a73e8 !important;
+      }
+
+      .primary-button-text {
+        color: #fff !important;
+      }
+
+      .underline-on-hover:hover {
+        text-decoration: underline !important;
+      }
+
+      .grey-infobar-text {
+        color: #202124 !important;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .primary-text:not([class^=3D"x_"]) {
+          color: #e8eaed !important;
+        }
+
+        .secondary-text:not([class^=3D"x_"]),
+        .phone-number:not([class^=3D"x_"]) a {
+          color: #9aa0a6 !important;
+        }
+
+        .grey-button-text:not([class^=3D"x_"]),
+        .attachment-chip:not([class^=3D"x_"]) a {
+          color: #bdc1c6 !important;
+        }
+
+        .accent-text:not([class^=3D"x_"]),
+        .hairline-button-text:not([class^=3D"x_"]) {
+          color: #8ab4f8 !important;
+        }
+
+        .primary-button:not([class^=3D"x_"]) {
+          background-color: #8ab4f8 !important;
+        }
+
+        .primary-button-text:not([class^=3D"x_"]) {
+          color: #202124 !important;
+        }
+      }
+    </style>
+    <style>
+      @media (prefers-color-scheme: dark) {
+        .cse-banner:not([class^=3D"x_"]) {
+          background-color: #3c4043 !important; /* Google Grey 800 */
+        }
+
+        .encryption-icon:not([class^=3D"x_"]) {
+          /* WARNING: This causes the whole style tag to get stripped in Gm=
+ail. */
+          background-image: url('https://fonts.gstatic.com/s/i/googlemateri=
+aliconsfilled/encrypted/v3/gm_grey200-24dp/2x/gm_filled_encrypted_gm_grey20=
+0_24dp.png') !important;
+        }
+      }
+    </style>
+    <!--[if !mso]><!-->
+    <style>
+      .prevent-link a {
+        color: inherit !important;
+        text-decoration: none !important;
+        font-size: inherit !important;
+        font-family: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+      }
+    </style>
+    <!--<![endif]-->
+
+    <!--[if mso | IE]>
+      <style>
+        .main-container-inner {
+          padding: 24px 32px !important;
+        }
+
+        .info-bar-inner {
+          padding: 12px 32px !important;
+        }
+
+        .cse-banner .encryption-icon {
+          /* We use the IE workaround instead. */
+          background-image: none !important;
+        }
+
+        .cse-banner .encryption-icon .ms-fallback {
+          display: block !important;
+        }
+
+        /* NB: Some MS clients ignore dark-scheme styling and apply their o=
+wn, so there's nothing we can do to help there. */
+        @media (prefers-color-scheme: dark) {
+          .cse-banner:not([class^=3D"x_"]) .encryption-icon .ms-fallback {
+            display: none !important;
+          }
+
+          .cse-banner:not([class^=3D"x_"]) .encryption-icon .ms-fallback-da=
+rk {
+            display: block !important;
+          }
+        }
+      </style>
+    <![endif]-->
+  </head><body class=3D"body"><span itemscope itemtype=3D"http://schema.org=
+/InformAction"><span style=3D"display:none" itemprop=3D"about" itemscope it=
+emtype=3D"http://schema.org/Person"><meta itemprop=3D"description" content=
+=3D"Invitation from contact@restarone.com"/></span><span itemprop=3D"object=
+" itemscope itemtype=3D"http://schema.org/Event"><meta itemprop=3D"eventSta=
+tus" content=3D"http://schema.org/EventScheduled"/><span itemprop=3D"publis=
+her" itemscope itemtype=3D"http://schema.org/Organization"><meta itemprop=
+=3D"name" content=3D"Google Calendar"/></span><meta itemprop=3D"eventId/goo=
+gleCalendar" content=3D"7ssa6m3f24rcghum59ffbv7qh4"/><span style=3D"display=
+: none; font-size: 1px; color: #fff; line-height: 1px; height: 0; max-heigh=
+t: 0; width: 0; max-width: 0; opacity: 0; overflow: hidden;" itemprop=3D"na=
+me">test meeting</span><meta itemprop=3D"url" content=3D"https://calendar.g=
+oogle.com/calendar/event?action=3DVIEW&amp;eid=3DN3NzYTZtM2YyNHJjZ2h1bTU5Zm=
+ZidjdxaDQgc2hhc2hpa2VqYXlhdHVuZ2VAbQ&amp;tok=3DMjEjY29udGFjdEByZXN0YXJvbmUu=
+Y29tZTA0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMjVjNWNkNjUxMmQ3OWVhZA&amp;ctz=3DAmeric=
+a%2FToronto&amp;hl=3Den&amp;es=3D1"/><span aria-hidden=3D"true"><time itemp=
+rop=3D"startDate" datetime=3D"20230913T163000Z"></time><time itemprop=3D"en=
+dDate" datetime=3D"20230913T173000Z"></time></span><div style=3D"display: n=
+one; font-size: 1px; color: #fff; line-height: 1px; height: 0; max-height: =
+0; width: 0; max-width: 0; opacity: 0; overflow: hidden;">Join with Google =
+Meet =E2=80=93 You have been invited by contact@restarone.com to attend an =
+event named test meeting on Wednesday Sep 13, 2023 =E2=8B=85 12:30pm =E2=80=
+=93 1:30pm (Eastern Time - Toronto).</div><table border=3D"0" cellpadding=
+=3D"0" cellspacing=3D"0" role=3D"presentation" align=3D"center" style=3D"wi=
+dth:100%;" class=3D"body-container"><tbody><tr><td style=3D"" class=3D"" al=
+ign=3D"left"><!--[if mso | IE]><table border=3D"0" cellpadding=3D"0" cellsp=
+acing=3D"0" role=3D"presentation"><tr><td height=3D"16" style=3D"height:16p=
+x;"><![endif]--><div style=3D"height:16px;" aria-hidden=3D"true"> &nbsp; </=
+div><!--[if mso | IE]></td></tr></table><![endif]--><table border=3D"0" cel=
+lpadding=3D"0" cellspacing=3D"0" role=3D"presentation" align=3D"center" sty=
+le=3D"width:100%;" class=3D""><tbody><tr><td style=3D"border: solid 1px #da=
+dce0; border-radius: 8px; direction: rtl; font-size: 0; padding: 24px 32px;=
+ text-align: left; vertical-align: top;" class=3D"main-container-inner"><!-=
+-[if mso | IE]><table border=3D"0" cellpadding=3D"0" cellspacing=3D"0" role=
+=3D"presentation"><tr><![endif]--><!--[if mso | IE]><td class=3D"" style=3D=
+"vertical-align:top;width:37%;" ><![endif]--><div class=3D"column-per-37 ou=
+tlook-group-fix" style=3D"font-size: 13px; text-align: left; direction: ltr=
+; display: inline-block; vertical-align: top; width: 100%;overflow: hidden;=
+ word-wrap: break-word;"><table border=3D"0" cellpadding=3D"0" cellspacing=
+=3D"0" role=3D"presentation" width=3D"100%"><tbody><tr><td style=3D"vertica=
+l-align:top;padding:0;"><table border=3D"0" cellpadding=3D"0" cellspacing=
+=3D"0" role=3D"presentation" width=3D"100%"><tr><td style=3D"font-size: 0; =
+padding: 0; text-align: left; word-break: break-word;;padding-bottom:28px;"=
+><a href=3D"https://meet.google.com/ion-rcdc-yrq?hs=3D224" class=3D"primary=
+-button-text" style=3D"display: inline-block;font-family: &#39;Google Sans&=
+#39;, Roboto, sans-serif;font-size: 14px; letter-spacing: 0.25px; line-heig=
+ht: 20px; mso-line-height-rule: exactly; text-decoration: none; text-transf=
+orm: none; word-wrap: break-word; white-space: nowrap;color: #fff;font-weig=
+ht: 700;white-space: normal;" target=3D"_blank"><table border=3D"0" cellpad=
+ding=3D"0" cellspacing=3D"0" role=3D"presentation" style=3D"display: inline=
+-block"><tr><td align=3D"center" role=3D"presentation" valign=3D"middle" st=
+yle=3D"background-color: #1a73e8; cursor: auto; padding: 10px 25px; border:=
+ none; border-radius: 4px; margin: 0;" class=3D"primary-button"><!--[if mso=
+]><a href=3D"https://meet.google.com/ion-rcdc-yrq?hs=3D224" class=3D"primar=
+y-button-text" target=3D"_blank"><![endif]--><span class=3D"primary-button-=
+text" style=3D"font-family: &#39;Google Sans&#39;, Roboto, sans-serif;font-=
+size: 14px; letter-spacing: 0.25px; line-height: 20px; mso-line-height-rule=
+: exactly; text-decoration: none; text-transform: none; word-wrap: break-wo=
+rd; white-space: nowrap;color: #fff;font-weight: 700;white-space: normal;">=
+Join with Google Meet</span><!--[if mso]></a><![endif]--></td></tr></table>=
+</a></td></tr><tr><td style=3D"font-size: 0; padding: 0; text-align: left; =
+word-break: break-word;;padding-bottom:24px;"><div style=3D"font-family: Ro=
+boto, sans-serif;font-size: 14px; line-height: 20px; mso-line-height-rule: =
+exactly; text-align: left;"><table border=3D"0" cellpadding=3D"0" cellspaci=
+ng=3D"0" role=3D"presentation" style=3D"padding-bottom: 4px;"><tr><td><h2 c=
+lass=3D"primary-text" style=3D"font-size: 14px;color: #3c4043; text-decorat=
+ion: none;font-weight: 700;-webkit-font-smoothing: antialiased;margin: 0; p=
+adding: 0;">Meeting link</h2></td></tr></table><!-- Use grey text for the M=
+eet link--><div><a style=3D"display: inline-block;;color: #70757a; text-dec=
+oration: none;" class=3D"secondary-text underline-on-hover" href=3D"https:/=
+/meet.google.com/ion-rcdc-yrq?hs=3D224">meet.google.com/ion-rcdc-yrq</a></d=
+iv></div></td></tr><tr><td style=3D"font-size: 0; padding: 0; text-align: l=
+eft; word-break: break-word;;padding-bottom:24px;"><div style=3D"font-famil=
+y: Roboto, sans-serif;font-size: 14px; line-height: 20px; mso-line-height-r=
+ule: exactly; text-align: left;"><table border=3D"0" cellpadding=3D"0" cell=
+spacing=3D"0" role=3D"presentation" style=3D"padding-bottom: 4px;"><tr><td>=
+<h2 class=3D"primary-text" style=3D"font-size: 14px;color: #3c4043; text-de=
+coration: none;font-weight: 700;-webkit-font-smoothing: antialiased;margin:=
+ 0; padding: 0;">Join by phone</h2></td></tr></table><span class=3D"seconda=
+ry-text" style=3D"color: #70757a; text-decoration: none;;">(CA) </span><a h=
+ref=3D"tel:+1-289-348-7771%3B420144607%23" style=3D"display: inline-block;c=
+olor: #1a73e8; text-decoration: none;" target=3D"_blank" class=3D"accent-te=
+xt underline-on-hover">+1 289-348-7771</a> <br><span class=3D"secondary-tex=
+t" style=3D"color: #70757a; text-decoration: none;;">PIN: 420144607</span><=
+br><br><a href=3D"https://tel.meet/ion-rcdc-yrq?pin=3D6126125287205&amp;hs=
+=3D0" style=3D"display: inline-block;color: #1a73e8; text-decoration: none;=
+" target=3D"_blank" class=3D"accent-text underline-on-hover">More phone num=
+bers</a><br></div></td></tr></table></td></tr></tbody></table></div><!--[if=
+ mso | IE]></td><![endif]--><!--[if mso | IE]><td class=3D"" style=3D"verti=
+cal-align:top;width:63%;padding-right:32px;" ><![endif]--><div class=3D"col=
+umn-per-63 outlook-group-fix" style=3D"font-size: 13px; text-align: left; d=
+irection: ltr; display: inline-block; vertical-align: top; width: 100%;over=
+flow: hidden; word-wrap: break-word;"><table border=3D"0" cellpadding=3D"0"=
+ cellspacing=3D"0" role=3D"presentation" width=3D"100%" class=3D"main-colum=
+n-table-ltr" style=3D"padding-right: 32px; padding-left: 0;;table-layout: f=
+ixed;"><tbody><tr><td class=3D"main-column-td" style=3D"padding:0; vertical=
+-align:top;"><table border=3D"0" cellpadding=3D"0" cellspacing=3D"0" role=
+=3D"presentation" width=3D"100%" style=3D"table-layout: fixed;"><tr><td sty=
+le=3D"font-size: 0; padding: 0; text-align: left; word-break: break-word;;p=
+adding-bottom:24px;"><div style=3D"font-family: Roboto, sans-serif;font-sty=
+le: normal; font-weight: 400; font-size: 14px; line-height: 20px; letter-sp=
+acing: 0.2px;color: #3c4043; text-decoration: none;" class=3D"primary-text"=
+ role=3D"presentation"><span aria-hidden=3D"true"><time itemprop=3D"startDa=
+te" datetime=3D"20230913T163000Z"></time><time itemprop=3D"endDate" datetim=
+e=3D"20230913T173000Z"></time></span><table border=3D"0" cellpadding=3D"0" =
+cellspacing=3D"0" role=3D"presentation" style=3D"padding-bottom: 4px;"><tr>=
+<td><h2 class=3D"primary-text" style=3D"font-size: 14px;color: #3c4043; tex=
+t-decoration: none;font-weight: 700;-webkit-font-smoothing: antialiased;mar=
+gin: 0; padding: 0;">When</h2></td></tr></table><span>Wednesday Sep 13, 202=
+3 =E2=8B=85 12:30pm =E2=80=93 1:30pm (Eastern Time - Toronto)</span></div><=
+/td></tr><tr><td style=3D"font-size: 0; padding: 0; text-align: left; word-=
+break: break-word;;padding-bottom:24px;"><div style=3D"font-family: Roboto,=
+ sans-serif;font-style: normal; font-weight: 400; font-size: 14px; line-hei=
+ght: 20px; letter-spacing: 0.2px;color: #3c4043; text-decoration: none;" cl=
+ass=3D"primary-text" role=3D"presentation"><table border=3D"0" cellpadding=
+=3D"0" cellspacing=3D"0" role=3D"presentation" style=3D"padding-bottom: 4px=
+;"><tr><td><h2 class=3D"primary-text" style=3D"font-size: 14px;color: #3c40=
+43; text-decoration: none;font-weight: 700;-webkit-font-smoothing: antialia=
+sed;margin: 0; padding: 0;">Organizer</h2></td></tr></table><div style=3D"c=
+olor: #3c4042;"><span class=3D"notranslate"><a class=3D"primary-text underl=
+ine-on-hover" style=3D"display: inline-block;;color: #3c4043; text-decorati=
+on: none;" href=3D"mailto:contact@restarone.com">contact@restarone.com</a><=
+/span><span itemprop=3D"organizer" itemscope itemtype=3D"http://schema.org/=
+Person"><meta itemprop=3D"name" content=3D"contact@restarone.com"/><meta it=
+emprop=3D"email" content=3D"contact@restarone.com"/></span></div></div></td=
+></tr><tr><td style=3D"font-size: 0; padding: 0; text-align: left; word-bre=
+ak: break-word;;padding-bottom:24px;"><div style=3D"font-family: Roboto, sa=
+ns-serif;font-style: normal; font-weight: 400; font-size: 14px; line-height=
+: 20px; letter-spacing: 0.2px;color: #3c4043; text-decoration: none;" class=
+=3D"primary-text" role=3D"presentation"><table border=3D"0" cellpadding=3D"=
+0" cellspacing=3D"0" role=3D"presentation" style=3D"padding-bottom: 4px;"><=
+tr><td><h2 class=3D"primary-text" style=3D"font-size: 14px;color: #3c4043; =
+text-decoration: none;font-weight: 700;-webkit-font-smoothing: antialiased;=
+margin: 0; padding: 0;">Guests</h2></td></tr></table>(Guest list has been h=
+idden at organizer's request)</div></td></tr><tr><td style=3D"font-size: 0;=
+ padding: 0; text-align: left; word-break: break-word;;padding-bottom:0px;"=
+><div style=3D"color: #3c4043; text-decoration: none;;font-family: Roboto, =
+sans-serif;font-size: 14px; line-height: 20px; mso-line-height-rule: exactl=
+y; text-align: left;" class=3D"primary-text"><div><span style=3D"font-weigh=
+t: 700;-webkit-font-smoothing: antialiased;">Reply</span><span class=3D"sec=
+ondary-text" style=3D"color: #70757a; text-decoration: none;"> for <a class=
+=3D"secondary-text underline-on-hover" style=3D"display: inline-block;;colo=
+r: #70757a; text-decoration: none;" href=3D"mailto:restarone@restarone.solutions.=
+com">restarone@restarone.solutions</a></span></div></div></td></tr><tr><td st=
+yle=3D"font-size: 0; padding: 0; text-align: left; word-break: break-word;;=
+padding-bottom:16px;"><div style=3D"font-family: Roboto, sans-serif;font-si=
+ze: 14px; line-height: 20px; mso-line-height-rule: exactly; text-align: lef=
+t;"><table border=3D"0" cellpadding=3D"0" cellspacing=3D"0" role=3D"present=
+ation" style=3D"border-collapse: separate;"><tr><td style=3D"padding-top: 8=
+px; padding-left: 0; padding-right: 12px;"><!-- RSVP buttons --><table bord=
+er=3D"0" cellpadding=3D"0" cellspacing=3D"0" role=3D"presentation" style=3D=
+"border: solid 1px #dadce0; border-radius: 16px; border-collapse: separate;=
+font-family: &#39;Google Sans&#39;, Roboto, sans-serif;;display: inline-blo=
+ck;;margin-right: 12px; margin-left: 0;"><tr><td align=3D"center" vertical-=
+align=3D"middle" role=3D"presentation"><span itemprop=3D"potentialaction" i=
+temscope itemtype=3D"http://schema.org/RsvpAction"><meta itemprop=3D"attend=
+ance" content=3D"http://schema.org/RsvpAttendance/Yes"/><span itemprop=3D"h=
+andler" itemscope itemtype=3D"http://schema.org/HttpActionHandler"><link it=
+emprop=3D"method" href=3D"http://schema.org/HttpRequestMethod/GET"/><span s=
+tyle=3D"color: #5f6367;"><a href=3D"https://calendar.google.com/calendar/ev=
+ent?action=3DRESPOND&amp;eid=3DN3NzYTZtM2YyNHJjZ2h1bTU5ZmZidjdxaDQgc2hhc2hp=
+a2VqYXlhdHVuZ2VAbQ&amp;rst=3D1&amp;tok=3DMjEjY29udGFjdEByZXN0YXJvbmUuY29tZT=
+A0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMjVjNWNkNjUxMmQ3OWVhZA&amp;ctz=3DAmerica%2FTo=
+ronto&amp;hl=3Den&amp;es=3D1" style=3D"font-weight: 400;font-family: &#39;G=
+oogle Sans&#39;, Roboto, sans-serif;color: #5f6368; font-size: 14px; line-h=
+eight: 120%; mso-line-height-rule: exactly; margin: 0; text-decoration: non=
+e; text-transform: none;" class=3D"grey-button-text" itemprop=3D"url" targe=
+t=3D"_blank"><table border=3D"0" cellpadding=3D"0" cellspacing=3D"0" role=
+=3D"presentation"><tr><td align=3D"center" role=3D"presentation" valign=3D"=
+middle" style=3D"padding: 6px 0; padding-left: 16px; padding-right: 12px; w=
+hite-space: nowrap;"><!--[if mso]><a href=3D"https://calendar.google.com/ca=
+lendar/event?action=3DRESPOND&amp;eid=3DN3NzYTZtM2YyNHJjZ2h1bTU5ZmZidjdxaDQ=
+gc2hhc2hpa2VqYXlhdHVuZ2VAbQ&amp;rst=3D1&amp;tok=3DMjEjY29udGFjdEByZXN0YXJvb=
+mUuY29tZTA0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMjVjNWNkNjUxMmQ3OWVhZA&amp;ctz=3DAme=
+rica%2FToronto&amp;hl=3Den&amp;es=3D1" class=3D"grey-button-text" itemprop=
+=3D"url" target=3D"_blank"><![endif]--><span class=3D"grey-button-text" sty=
+le=3D"font-weight: 400;font-family: &#39;Google Sans&#39;, Roboto, sans-ser=
+if;color: #5f6368; font-size: 14px; line-height: 120%; mso-line-height-rule=
+: exactly; margin: 0; text-decoration: none; text-transform: none;">Yes</sp=
+an><!--[if mso]></a><![endif]--></td></tr></table></a></span></span></span>=
+</td><td align=3D"center" vertical-align=3D"middle" role=3D"presentation" s=
+tyle=3D"border-left: solid 1px #dadce0; border-right: solid 1px #dadce0;"><=
+span itemprop=3D"potentialaction" itemscope itemtype=3D"http://schema.org/R=
+svpAction"><meta itemprop=3D"attendance" content=3D"http://schema.org/RsvpA=
+ttendance/No"/><span itemprop=3D"handler" itemscope itemtype=3D"http://sche=
+ma.org/HttpActionHandler"><link itemprop=3D"method" href=3D"http://schema.o=
+rg/HttpRequestMethod/GET"/><span style=3D"color: #5f6367;"><a href=3D"https=
+://calendar.google.com/calendar/event?action=3DRESPOND&amp;eid=3DN3NzYTZtM2=
+YyNHJjZ2h1bTU5ZmZidjdxaDQgc2hhc2hpa2VqYXlhdHVuZ2VAbQ&amp;rst=3D2&amp;tok=3D=
+MjEjY29udGFjdEByZXN0YXJvbmUuY29tZTA0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMjVjNWNkNjU=
+xMmQ3OWVhZA&amp;ctz=3DAmerica%2FToronto&amp;hl=3Den&amp;es=3D1" style=3D"fo=
+nt-weight: 400;font-family: &#39;Google Sans&#39;, Roboto, sans-serif;color=
+: #5f6368; font-size: 14px; line-height: 120%; mso-line-height-rule: exactl=
+y; margin: 0; text-decoration: none; text-transform: none;" class=3D"grey-b=
+utton-text" itemprop=3D"url" target=3D"_blank"><table border=3D"0" cellpadd=
+ing=3D"0" cellspacing=3D"0" role=3D"presentation"><tr><td align=3D"center" =
+role=3D"presentation" valign=3D"middle" style=3D"padding: 6px 12px; white-s=
+pace: nowrap;"><!--[if mso]><a href=3D"https://calendar.google.com/calendar=
+/event?action=3DRESPOND&amp;eid=3DN3NzYTZtM2YyNHJjZ2h1bTU5ZmZidjdxaDQgc2hhc=
+2hpa2VqYXlhdHVuZ2VAbQ&amp;rst=3D2&amp;tok=3DMjEjY29udGFjdEByZXN0YXJvbmUuY29=
+tZTA0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMjVjNWNkNjUxMmQ3OWVhZA&amp;ctz=3DAmerica%2=
+FToronto&amp;hl=3Den&amp;es=3D1" class=3D"grey-button-text" itemprop=3D"url=
+" target=3D"_blank"><![endif]--><span class=3D"grey-button-text" style=3D"f=
+ont-weight: 400;font-family: &#39;Google Sans&#39;, Roboto, sans-serif;colo=
+r: #5f6368; font-size: 14px; line-height: 120%; mso-line-height-rule: exact=
+ly; margin: 0; text-decoration: none; text-transform: none;">No</span><!--[=
+if mso]></a><![endif]--></td></tr></table></a></span></span></span></td><td=
+ align=3D"center" vertical-align=3D"middle" role=3D"presentation"><span ite=
+mprop=3D"potentialaction" itemscope itemtype=3D"http://schema.org/RsvpActio=
+n"><meta itemprop=3D"attendance" content=3D"http://schema.org/RsvpAttendanc=
+e/Maybe"/><span itemprop=3D"handler" itemscope itemtype=3D"http://schema.or=
+g/HttpActionHandler"><link itemprop=3D"method" href=3D"http://schema.org/Ht=
+tpRequestMethod/GET"/><span style=3D"color: #5f6367;"><a href=3D"https://ca=
+lendar.google.com/calendar/event?action=3DRESPOND&amp;eid=3DN3NzYTZtM2YyNHJ=
+jZ2h1bTU5ZmZidjdxaDQgc2hhc2hpa2VqYXlhdHVuZ2VAbQ&amp;rst=3D3&amp;tok=3DMjEjY=
+29udGFjdEByZXN0YXJvbmUuY29tZTA0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMjVjNWNkNjUxMmQ3=
+OWVhZA&amp;ctz=3DAmerica%2FToronto&amp;hl=3Den&amp;es=3D1" style=3D"font-we=
+ight: 400;font-family: &#39;Google Sans&#39;, Roboto, sans-serif;color: #5f=
+6368; font-size: 14px; line-height: 120%; mso-line-height-rule: exactly; ma=
+rgin: 0; text-decoration: none; text-transform: none;" class=3D"grey-button=
+-text" itemprop=3D"url" target=3D"_blank"><table border=3D"0" cellpadding=
+=3D"0" cellspacing=3D"0" role=3D"presentation"><tr><td align=3D"center" rol=
+e=3D"presentation" valign=3D"middle" style=3D"padding: 6px 0; padding-left:=
+ 12px; padding-right: 16px; white-space: nowrap;"><!--[if mso]><a href=3D"h=
+ttps://calendar.google.com/calendar/event?action=3DRESPOND&amp;eid=3DN3NzYT=
+ZtM2YyNHJjZ2h1bTU5ZmZidjdxaDQgc2hhc2hpa2VqYXlhdHVuZ2VAbQ&amp;rst=3D3&amp;to=
+k=3DMjEjY29udGFjdEByZXN0YXJvbmUuY29tZTA0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMjVjNWN=
+kNjUxMmQ3OWVhZA&amp;ctz=3DAmerica%2FToronto&amp;hl=3Den&amp;es=3D1" class=
+=3D"grey-button-text" itemprop=3D"url" target=3D"_blank"><![endif]--><span =
+class=3D"grey-button-text" style=3D"font-weight: 400;font-family: &#39;Goog=
+le Sans&#39;, Roboto, sans-serif;color: #5f6368; font-size: 14px; line-heig=
+ht: 120%; mso-line-height-rule: exactly; margin: 0; text-decoration: none; =
+text-transform: none;">Maybe</span><!--[if mso]></a><![endif]--></td></tr><=
+/table></a></span></span></span></td></tr></table><!-- More options --><a h=
+ref=3D"https://calendar.google.com/calendar/event?action=3DVIEW&amp;eid=3DN=
+3NzYTZtM2YyNHJjZ2h1bTU5ZmZidjdxaDQgc2hhc2hpa2VqYXlhdHVuZ2VAbQ&amp;tok=3DMjE=
+jY29udGFjdEByZXN0YXJvbmUuY29tZTA0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMjVjNWNkNjUxMm=
+Q3OWVhZA&amp;ctz=3DAmerica%2FToronto&amp;hl=3Den&amp;es=3D1" style=3D"displ=
+ay: inline-block;;font-weight: 400;font-family: &#39;Google Sans&#39;, Robo=
+to, sans-serif;color: #5f6368; font-size: 14px; line-height: 120%; mso-line=
+-height-rule: exactly; margin: 0; text-decoration: none; text-transform: no=
+ne;" class=3D"grey-button-text" target=3D"_blank"><table border=3D"0" cellp=
+adding=3D"0" cellspacing=3D"0" role=3D"presentation" style=3D"border: solid=
+ 1px #dadce0; border-radius: 16px; border-collapse: separate;font-family: &=
+#39;Google Sans&#39;, Roboto, sans-serif;"><tr><td align=3D"center" vertica=
+l-align=3D"middle" role=3D"presentation" style=3D"padding: 6px 0; padding-l=
+eft: 16px; padding-right: 12px; white-space: nowrap;;color: #5f6367;"><!--[=
+if mso]><a href=3D"https://calendar.google.com/calendar/event?action=3DVIEW=
+&amp;eid=3DN3NzYTZtM2YyNHJjZ2h1bTU5ZmZidjdxaDQgc2hhc2hpa2VqYXlhdHVuZ2VAbQ&a=
+mp;tok=3DMjEjY29udGFjdEByZXN0YXJvbmUuY29tZTA0OTJkOTA1ZGU2NTBlOWIzMGZiMmUwMj=
+VjNWNkNjUxMmQ3OWVhZA&amp;ctz=3DAmerica%2FToronto&amp;hl=3Den&amp;es=3D1" cl=
+ass=3D"grey-button-text" target=3D"_blank"><![endif]--><span class=3D"grey-=
+button-text" style=3D"font-weight: 400;font-family: &#39;Google Sans&#39;, =
+Roboto, sans-serif;color: #5f6368; font-size: 14px; line-height: 120%; mso-=
+line-height-rule: exactly; margin: 0; text-decoration: none; text-transform=
+: none;">More options</span><!--[if mso]></a><![endif]--></td></tr></table>=
+</a></td></tr></table></div></td></tr></table></td></tr></tbody></table></d=
+iv><!--[if mso | IE]></td><![endif]--><!--[if mso | IE]></tr></table><![end=
+if]--></td></tr></tbody></table><table border=3D"0" cellpadding=3D"0" cells=
+pacing=3D"0" role=3D"presentation" align=3D"center" style=3D"width:100%;" c=
+lass=3D""><tbody><tr><td style=3D"font-size: 0; padding: 0; text-align: lef=
+t; word-break: break-word;;padding:4px 12px;" class=3D"" align=3D"left"><di=
+v class=3D"secondary-text" style=3D"color: #70757a; text-decoration: none;f=
+ont-family: Roboto, sans-serif;font-size: 12px; line-height: 16px; mso-line=
+-height-rule: exactly; text-align: left;"><p>Invitation from <a href=3D"htt=
+ps://calendar.google.com/calendar/" class=3D"accent-text underline-on-hover=
+" style=3D"font-family: Roboto, sans-serif;font-size: 12px; line-height: 16=
+px; mso-line-height-rule: exactly;;color: #1a73e8; text-decoration: none;" =
+target=3D"_blank">Google Calendar</a></p><p>You are receiving this email be=
+cause you are subscribed to calendar notifications. To stop receiving these=
+ emails, go to <a href=3D"https://calendar.google.com/calendar/r/settings" =
+class=3D"accent-text underline-on-hover" style=3D"font-family: Roboto, sans=
+-serif;font-size: 12px; line-height: 16px; mso-line-height-rule: exactly;;c=
+olor: #1a73e8; text-decoration: none;" target=3D"_blank">Calendar settings<=
+/a>, select this calendar, and change "Other notifications".</p><p>Forwardi=
+ng this invitation could allow any recipient to send a response to the orga=
+nizer, be added to the guest list, invite others regardless of their own in=
+vitation status, or modify your RSVP. <a class=3D"accent-text underline-on-=
+hover" style=3D"font-family: Roboto, sans-serif;font-size: 12px; line-heigh=
+t: 16px; mso-line-height-rule: exactly;;color: #1a73e8; text-decoration: no=
+ne;" href=3D"https://support.google.com/calendar/answer/37135#forwarding">L=
+earn more</a></p></div></td></tr></tbody></table></td></tr></tbody></table>=
+</span></span></body></html>
+--0000000000008b4dbd06053dcde6
+Content-Type: text/calendar; charset="UTF-8"; method=REQUEST
+Content-Transfer-Encoding: 7bit
+
+BEGIN:VCALENDAR
+PRODID:-//Google Inc//Google Calendar 70.9054//EN
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:America/Toronto
+X-LIC-LOCATION:America/Toronto
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=America/Toronto:20230913T123000
+DTEND;TZID=America/Toronto:20230913T133000
+DTSTAMP:20230913T134739Z
+ORGANIZER;CN=contact@restarone.com:mailto:contact@restarone.com
+UID:7ssa6m3f24rcghum59ffbv7qh4@google.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;CN=restarone@restarone.solutions;X-NUM-GUESTS=0:mailto:restarone
+ @gmail.com
+X-GOOGLE-CONFERENCE:https://meet.google.com/ion-rcdc-yrq
+X-MICROSOFT-CDO-OWNERAPPTID:556337145
+CREATED:20230913T134737Z
+DESCRIPTION:-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~
+ :~:~:~:~:~:~:~:~::~:~::-\nJoin with Google Meet: https://meet.google.com/io
+ n-rcdc-yrq\nOr dial: (CA) +1 289-348-7771 PIN: 420144607#\nMore phone numbe
+ rs: https://tel.meet/ion-rcdc-yrq?pin=6126125287205&hs=7\n\nLearn more abou
+ t Meet at: https://support.google.com/a/users/answer/9282720\n\nPlease do n
+ ot edit this section.\n-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:
+ ~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
+LAST-MODIFIED:20230913T134737Z
+LOCATION:
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:test meeting
+TRANSP:OPAQUE
+END:VEVENT
+END:VCALENDAR
+
+--0000000000008b4dbd06053dcde6--
+--0000000000008b4dbe06053dcde8
+Content-Type: application/ics; name="invite.ics"
+Content-Disposition: attachment; filename="invite.ics"
+Content-Transfer-Encoding: base64
+
+QkVHSU46VkNBTEVOREFSDQpQUk9ESUQ6LS8vR29vZ2xlIEluYy8vR29vZ2xlIENhbGVuZGFyIDcw
+LjkwNTQvL0VODQpWRVJTSU9OOjIuMA0KQ0FMU0NBTEU6R1JFR09SSUFODQpNRVRIT0Q6UkVRVUVT
+VA0KQkVHSU46VlRJTUVaT05FDQpUWklEOkFtZXJpY2EvVG9yb250bw0KWC1MSUMtTE9DQVRJT046
+QW1lcmljYS9Ub3JvbnRvDQpCRUdJTjpEQVlMSUdIVA0KVFpPRkZTRVRGUk9NOi0wNTAwDQpUWk9G
+RlNFVFRPOi0wNDAwDQpUWk5BTUU6RURUDQpEVFNUQVJUOjE5NzAwMzA4VDAyMDAwMA0KUlJVTEU6
+RlJFUT1ZRUFSTFk7QllNT05USD0zO0JZREFZPTJTVQ0KRU5EOkRBWUxJR0hUDQpCRUdJTjpTVEFO
+REFSRA0KVFpPRkZTRVRGUk9NOi0wNDAwDQpUWk9GRlNFVFRPOi0wNTAwDQpUWk5BTUU6RVNUDQpE
+VFNUQVJUOjE5NzAxMTAxVDAyMDAwMA0KUlJVTEU6RlJFUT1ZRUFSTFk7QllNT05USD0xMTtCWURB
+WT0xU1UNCkVORDpTVEFOREFSRA0KRU5EOlZUSU1FWk9ORQ0KQkVHSU46VkVWRU5UDQpEVFNUQVJU
+O1RaSUQ9QW1lcmljYS9Ub3JvbnRvOjIwMjMwOTEzVDEyMzAwMA0KRFRFTkQ7VFpJRD1BbWVyaWNh
+L1Rvcm9udG86MjAyMzA5MTNUMTMzMDAwDQpEVFNUQU1QOjIwMjMwOTEzVDEzNDczOVoNCk9SR0FO
+SVpFUjtDTj1jb250YWN0QHJlc3Rhcm9uZS5jb206bWFpbHRvOmNvbnRhY3RAcmVzdGFyb25lLmNv
+bQ0KVUlEOjdzc2E2bTNmMjRyY2dodW01OWZmYnY3cWg0QGdvb2dsZS5jb20NCkFUVEVOREVFO0NV
+VFlQRT1JTkRJVklEVUFMO1JPTEU9UkVRLVBBUlRJQ0lQQU5UO1BBUlRTVEFUPU5FRURTLUFDVElP
+TjtSU1ZQPQ0KIFRSVUU7Q049c2hhc2hpa2VqYXlhdHVuZ2VAZ21haWwuY29tO1gtTlVNLUdVRVNU
+Uz0wOm1haWx0bzpzaGFzaGlrZWpheWF0dW5nZQ0KIEBnbWFpbC5jb20NClgtR09PR0xFLUNPTkZF
+UkVOQ0U6aHR0cHM6Ly9tZWV0Lmdvb2dsZS5jb20vaW9uLXJjZGMteXJxDQpYLU1JQ1JPU09GVC1D
+RE8tT1dORVJBUFBUSUQ6NTU2MzM3MTQ1DQpDUkVBVEVEOjIwMjMwOTEzVDEzNDczN1oNCkRFU0NS
+SVBUSU9OOi06On46fjo6fjp+On46fjp+On46fjp+On46fjp+On46fjp+On46fjp+On46fjp+On46
+fjp+On46fjp+On46fg0KIDp+On46fjp+On46fjp+On46On46fjo6LVxuSm9pbiB3aXRoIEdvb2ds
+ZSBNZWV0OiBodHRwczovL21lZXQuZ29vZ2xlLmNvbS9pbw0KIG4tcmNkYy15cnFcbk9yIGRpYWw6
+IChDQSkgKzEgMjg5LTM0OC03NzcxIFBJTjogNDIwMTQ0NjA3I1xuTW9yZSBwaG9uZSBudW1iZQ0K
+IHJzOiBodHRwczovL3RlbC5tZWV0L2lvbi1yY2RjLXlycT9waW49NjEyNjEyNTI4NzIwNSZocz03
+XG5cbkxlYXJuIG1vcmUgYWJvdQ0KIHQgTWVldCBhdDogaHR0cHM6Ly9zdXBwb3J0Lmdvb2dsZS5j
+b20vYS91c2Vycy9hbnN3ZXIvOTI4MjcyMFxuXG5QbGVhc2UgZG8gbg0KIG90IGVkaXQgdGhpcyBz
+ZWN0aW9uLlxuLTo6fjp+Ojp+On46fjp+On46fjp+On46fjp+On46fjp+On46fjp+On46fjp+On46
+fjp+Og0KIH46fjp+On46fjp+On46fjp+On46fjp+On46fjo6fjp+OjotDQpMQVNULU1PRElGSUVE
+OjIwMjMwOTEzVDEzNDczN1oNCkxPQ0FUSU9OOg0KU0VRVUVOQ0U6MA0KU1RBVFVTOkNPTkZJUk1F
+RA0KU1VNTUFSWTp0ZXN0IG1lZXRpbmcNClRSQU5TUDpPUEFRVUUNCkVORDpWRVZFTlQNCkVORDpW
+Q0FMRU5EQVINCg==
+--0000000000008b4dbe06053dcde8--

--- a/test/fixtures/meetings.yml
+++ b/test/fixtures/meetings.yml
@@ -1,0 +1,23 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  start_time: 2023-09-13 16:06:00
+  end_time: 2023-09-13 16:06:00
+  participant_emails: []
+  description: MyText
+  timezone: MyString
+  location: MyString
+  status: CONFIRMED
+  external_meeting_id: MyString
+
+two:
+  name: MyString
+  start_time: 2023-09-13 16:06:00
+  end_time: 2023-09-13 16:06:00
+  participant_emails: []
+  description: MyText
+  timezone: MyString
+  location: MyString
+  status: CONFIRMED
+  external_meeting_id: MyString2

--- a/test/mailboxes/e_mailbox_test.rb
+++ b/test/mailboxes/e_mailbox_test.rb
@@ -378,4 +378,15 @@ class EMailboxTest < ActionMailbox::TestCase
   test "new message in thread sets thread unread: true" do
     #  todo test https://github.com/restarone/violet_rails/blob/57739a34ea8927ba222a42d372908a82e35de8cf/app/mailboxes/e_mailbox.rb
   end
+
+  test "when sent with calendar invite" do
+    Apartment::Tenant.switch @restarone_subdomain do      
+      assert_difference "Message.all.reload.size", +1 do
+        assert_difference "Meeting.all.reload.size", +1 do
+          email = create_inbound_email_from_fixture('email_with_calendar_invite.eml')
+          email.tap(&:route)
+        end  
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Calendar and Meetings 
addresses: https://github.com/restarone/violet_rails/issues/1597
This release adds the ability for Violet to handle your calendar. Incoming emails with .ics attachments will automatically be added to your calendar as meetings.

## Calendar UI
![Screenshot from 2023-09-14 00-25-19](https://github.com/restarone/violet_rails/assets/35935196/d6ab2626-85e1-49d3-83d3-f2aadfc34eeb)

## Outgoing Meeting request RSVP controls

![IMG_7264](https://github.com/restarone/violet_rails/assets/35935196/bae81b61-32e4-4970-a9b8-60b787366f11)


todo: 

1. include .vcs file for outlook
2. add validations to meeting model

further reading: 

1. icalendar syncing events: https://joshfrankel.me/blog/lemme-pencil-you-in-using-icalendar-and-rails-to-sync-calendar-events/
2. all the options: https://blog.corsego.com/icalendar-ruby
3. publish? https://stackoverflow.com/questions/55927263/what-does-icalendar-publish-method-do
4. dealing with email client quirkyness when displaying RSVP buttons: https://stackoverflow.com/questions/66102584/when-i-add-method-request-to-icalendar-gmail-stops-recognizing-as-event