### PR TITLE
[observability] print errors when page creation fails

### DIFF
--- a/app/controllers/comfy/admin/cms/pages_controller.rb
+++ b/app/controllers/comfy/admin/cms/pages_controller.rb
@@ -42,7 +42,7 @@ class Comfy::Admin::Cms::PagesController < Comfy::Admin::Cms::BaseController
     flash[:success] = I18n.t("comfy.admin.cms.pages.created")
     redirect_to action: :edit, id: @page
   rescue ActiveRecord::RecordInvalid
-    flash.now[:danger] = I18n.t("comfy.admin.cms.pages.creation_failure")
+    flash.now[:danger] = "#{I18n.t("comfy.admin.cms.pages.creation_failure")} because: #{@page.errors.full_messages.to_sentence}"
     render action: :new
   end
 


### PR DESCRIPTION
The problem: 
detailed Errors are not showing on referrals.restarone.com
 
![Screenshot from 2023-10-11 16-16-16](https://github.com/restarone/violet_rails/assets/35935196/417bdfb4-f9bc-4881-ba72-15df3b4b2702)



print detailed errors when page creation fails

![Screenshot from 2023-10-11 16-09-45](https://github.com/restarone/violet_rails/assets/35935196/65b70163-abe9-4538-846b-04fb086da325)