### PR TITLE
fix Dockerfile (post-2024) & GHA CI (deprecated actions 2025)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Run Tests
       run: bin/rails test -f
     - name: Save code coverage report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report(Ruby - ${{ matrix.ruby_version }}, Node.js - ${{ matrix.node_version }})
         path: coverage/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   development:
   test:
@@ -36,7 +35,7 @@ services:
     depends_on:
       - solutions_db
       - solutions_redis
-    image: violet_rails_solutions_app
+    image: violet_rails-solutions_app
     container_name: solutions_sidekiq
     command: sidekiq -c 1
     volumes:
@@ -82,7 +81,7 @@ services:
       - solutions_db
       - solutions_redis
   solutions_test:
-    image: violet_rails_solutions_app
+    image: violet_rails-solutions_app
     container_name: solutions_test
     volumes:
       - .:/var/app


### PR DESCRIPTION
adjust image name for docker 2025, where: WARN[0000] /Users/restarone/Documents/violet_rails/docker-compose.yml: the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion