### PR TITLE
Create Email Templates (#1706)

### DIFF
--- a/app/controllers/mailbox/email_templates_controller.rb
+++ b/app/controllers/mailbox/email_templates_controller.rb
@@ -1,7 +1,7 @@
 class Mailbox::EmailTemplatesController < Mailbox::BaseController
 
   def index
-
+    @email_templates = EmailTemplate.all
   end
 
   def new
@@ -13,17 +13,55 @@ class Mailbox::EmailTemplatesController < Mailbox::BaseController
   def create
     html_doc = params[:htmldoc]
     re_doc = params[:redoc]
+    name = params[:name]
+    
+    email_template = EmailTemplate.create!(html: html_doc, template: re_doc, name: name)
 
-
-    render json: { id: 1 }
+    render json: { id: email_template.id }
   end
 
   def edit
+    @email_template = EmailTemplate.find(params[:id])
+  end
+
+  def update
+    email_template = EmailTemplate.find(params[:id])
     html_doc = params[:htmldoc]
     re_doc = params[:redoc]
+    name = params[:name]
+    email_template.update!(html: html_doc, template: re_doc, name: name)
+
+    render json: { id: email_template.id }
+  end
+
+  def test_send
+    email_template = EmailTemplate.find(params[:id])
+    dynamic_segments = email_template.dynamic_segments
+    symbol_mapping = ActiveSupport::HashWithIndifferentAccess.new
+    dynamic_segments.each do |segment|
+      symbol_mapping[segment] = params[segment]
+    end
+
+    email_body = email_template.inject_dynamic_segments(symbol_mapping)
+    from_address = "#{Apartment::Tenant.current}@#{ENV['APP_HOST']}"
+    email_subject = "#{email_template.name} test email"
+    email_thread = MessageThread.create!(recipients: [current_user.email], subject: email_subject)
+    email_body.encode!('UTF-16', 'UTF-8', :invalid => :replace, :replace => '')
+    email_body.encode!('UTF-8', 'UTF-16')
+    email_message = email_thread.messages.create!(
+      content: email_body,
+      from: from_address
+    )
+    EMailer.with(message: email_message, message_thread: email_thread).ship.deliver_later
+
+    flash.notice = "Template test email sent to #{current_user.email}"
+    redirect_to edit_mailbox_email_template_path(email_template.id)
   end
 
   def destroy
-
+    email_template = EmailTemplate.find(params[:id])
+    flash.notice = "#{email_template.name} destroyed!"
+    email_template.destroy!
+    redirect_to mailbox_email_templates_path
   end
 end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,2 +1,38 @@
 module MessagesHelper
+  # Extract the visible email content from HTML, removing meta tags, style tags, etc.
+  # This is used to display email content in the message thread view and email sending
+  def render_email_content(message)
+    return '' if message.content.blank?
+    
+    # Use to_s to preserve ActionText attachments
+    html_content = message.content.to_s
+    
+    # Parse the HTML
+    doc = Nokogiri::HTML.fragment(html_content)
+    
+    # Remove the trix-content wrapper div if present (do this first)
+    trix_div = doc.at_css('div.trix-content')
+    if trix_div
+      # Replace the trix-content div with its children
+      trix_div.replace(trix_div.children.to_html)
+      # Re-parse after removing trix wrapper
+      doc = Nokogiri::HTML.fragment(doc.to_html)
+    end
+    
+    # Remove meta tags, style tags, title, and link tags
+    doc.css('meta').remove
+    doc.css('style').remove
+    doc.css('title').remove
+    doc.css('link').remove
+    
+    # Get the HTML string
+    result = doc.to_html
+    
+    # Remove leading text nodes that appear before the first HTML tag
+    # This handles orphaned text like "My Email" from the title tag
+    # Match any text at the beginning that comes before the first < character
+    result = result.sub(/\A([^<]*?)(<)/, '\2')
+    
+    result.html_safe
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
+  helper MessagesHelper
+  
   default from: "#{Apartment::Tenant.current}@#{ENV['APP_HOST']}"
   default "Message-ID" => lambda {"#{Digest::SHA2.hexdigest(Time.now.to_i.to_s)}@#{ENV['APP_HOST']}"}
 end

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -1,0 +1,45 @@
+class EmailTemplate < ApplicationRecord
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+  validates :name, presence: true
+
+  SYMBOL_CAPTURE_PATTERN = /(?<=\{\{)[a-z]+(?:\.[a-z]+)*(?=\}\})/
+
+  def dynamic_segments
+    html_doc = Base64.decode64(self.html)
+    html_doc.scan(SYMBOL_CAPTURE_PATTERN)
+  end
+
+  def inject_dynamic_segments(properties_obj = {})
+  # pass a hash of properties or a API Resource instance and get dynamic HTML
+  # usage option 1: EmailTemplate.last.inject_dynamic_segments({name: 'hideo kojima', link: "https://mgs.snake"})
+  # usage option 2: EmailTemplate.last.inject_dynamic_segments(ApiResource.last)
+  # works by extracting any variable defined between: {{}} 
+  # example of including a variable called 'name': {{name}}
+    
+    html_doc = Base64.decode64(self.html)
+    symbols = self.dynamic_segments
+    symbol_mapping = ActiveSupport::HashWithIndifferentAccess.new
+    output = html_doc
+
+    if properties_obj.class == ApiResource
+      api_resource = properties_obj
+      symbols.each do |symbol|
+        symbol_mapping[symbol] = api_resource.properties[symbol]
+      end
+    elsif properties_obj.class == Hash || properties_obj.class == ActiveSupport::HashWithIndifferentAccess
+      symbols.each do |symbol|
+        symbol_mapping[symbol] = properties_obj.with_indifferent_access[symbol]
+      end
+    else
+      raise "dynamic segment mapping for Email Template is unrecognized. Please pass a hash of properties or API Resource instance"
+    end
+    
+    symbols.each do |symbol|
+      mapped_value = symbol_mapping[symbol]
+      raise "dynamic segment token has no value, please ensure a value is provided" if mapped_value.nil? || mapped_value.empty?
+      output = output.gsub("{{#{symbol}}}", mapped_value)
+    end
+    return output
+  end
+end

--- a/app/views/e_mailer/ship.html.erb
+++ b/app/views/e_mailer/ship.html.erb
@@ -7,7 +7,7 @@
       <% tracking_link = "#{root_url(subdomain: @subdomain.subdomain_name)}email_tracking/open/?emails=#{@recipients.join(',')}&message_id=#{@message.id}&email_uuid=#{@message.email_message_id}" %>
       <img src='<%= tracking_link %>' width="1" height="1">
     <% end %>
-    <%= @message.content %>
+    <%= render_email_content(@message).html_safe %>
     <% if @subdomain.email_signature.present? %>
       <div style="margin-top: 20px">
         <%= @subdomain.email_signature %>

--- a/app/views/mailbox/email_templates/edit.html.haml
+++ b/app/views/mailbox/email_templates/edit.html.haml
@@ -1,0 +1,78 @@
+.page-header
+  .h2
+    = link_to 'Email Templates', mailbox_email_templates_path
+.container.my-2
+  = label_tag "name"
+  = text_field_tag "name", @email_template.name, id: 'email_template_name'
+.container.my-2
+  = label_tag "Slug: "
+  = @email_template.slug
+.container.my-2
+  = label_tag "Dynamic segments ( defined as {{}} ): "
+  = @email_template.dynamic_segments.join(', ')
+.container.my-2
+  = label_tag "Test send: "
+  = form_tag(test_send_mailbox_email_template_path(@email_template.id), method: "POST", class: 'form-group') do
+    - @email_template.dynamic_segments.each do |segment|
+      = label_tag(segment.to_sym, "#{segment}:")
+      = text_field_tag(segment.to_sym, nil, class: 'form-control', required: true)
+    = submit_tag("Email me this template!", class: 'btn btn-secondary my-2')
+.container.my-2
+  = label_tag "Copy HTML: "
+  = button_tag "Copy to clipboard", id: 'copyRevolvHtml' 
+
+.container
+  #VioletEmailEditor
+
+  %button#VioletEmailEditorSubmit.btn.btn-primary.my-2
+    = "Save"
+  = link_to "Delete", mailbox_email_template_path(@email_template.id), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure?' }
+    
+:javascript
+  let template = "#{escape_javascript(@email_template.template)}"
+  let id = "#{@email_template.id}"
+  const app = Revolvapp('#VioletEmailEditor', {
+    editor: {
+      path: '/revolvapp-2-3-10/',   
+    },
+    content: template
+  });
+
+  $('#copyRevolvHtml').click(function() {
+    let htmldoc = app.editor.getHtml()
+
+    navigator.clipboard.writeText(htmldoc);
+
+    // Alert the copied text
+    alert("Copied html");
+  });
+
+  $('#VioletEmailEditorSubmit').click(function() {
+    $("#VioletEmailEditorSubmit").prop("disabled", true)
+    let authenticityToken = $('meta[name="csrf-token"]').attr('content');
+
+    let htmldoc = app.editor.getHtml()
+    let redoc = app.editor.getTemplate(true)
+    let name = $('#email_template_name').val()
+    const endpoint = "#{mailbox_email_template_path}"
+
+    if (name && htmldoc) {
+      $.ajax({
+        url: endpoint,
+        type: 'PATCH',
+        headers: {
+            'X-CSRF-Token': authenticityToken
+        },
+        data: JSON.stringify({ htmldoc: btoa(htmldoc), redoc: redoc, name: name, id: id }),
+        contentType: "application/json; charset=utf-8",
+        success: function(response) {
+          window.location.href = `${endpoint}/${response.id}/edit`
+          window.location.reload()
+        }
+      });
+    } else {
+      window.alert('Please give your template a name and set its content')
+    }
+
+    $("#VioletEmailEditorSubmit").prop("disabled", false)
+  });

--- a/app/views/mailbox/email_templates/index.html.haml
+++ b/app/views/mailbox/email_templates/index.html.haml
@@ -1,0 +1,9 @@
+.page-header
+  = link_to 'New Email Template', new_mailbox_email_template_path, class: 'btn btn-secondary float-right mx-1'
+  %h2 
+    = link_to "Email", mailbox_path 
+    Templates
+%ol
+  - @email_templates.each do |email_template|
+    %li
+      = link_to email_template.name, edit_mailbox_email_template_path(email_template.id)

--- a/app/views/mailbox/email_templates/new.html.haml
+++ b/app/views/mailbox/email_templates/new.html.haml
@@ -3,6 +3,11 @@
     = 'Email Templates'
   .container.m-2
     .h3
+      = "Docs:"
+    %a{href: "https://imperavi.com/legacy/revolvapp/docs/syntax/tags/", target: '_blank'}
+      Imperavi Revolvapp
+  .container.m-2
+    .h3
       = "AI prompt:"
     .p
       = "this is re-html, used by revolvapp,"
@@ -10,10 +15,14 @@
       = "... copy pasted editor code"
     .p
       = "using the above markup language create me a..."
+.container.my-2
+  = label_tag "name"
+  = text_field_tag "name", nil, id: 'email_template_name'
+
 .container
   #VioletEmailEditor
 
-%button#VioletEmailEditorSubmit
+%button#VioletEmailEditorSubmit.btn.btn-primary.my-2
   = "Save"
 
 :javascript
@@ -23,7 +32,6 @@
       template: '/revolvapp-2-3-10/templates/index.html',
     }
   });
-  app.start()
 
   $('#VioletEmailEditorSubmit').click(function() {
     $("#VioletEmailEditorSubmit").prop("disabled", true)
@@ -31,18 +39,24 @@
 
     let htmldoc = app.editor.getHtml()
     let redoc = app.editor.getTemplate(true)
+    let name = $('#email_template_name').val()
     const endpoint = "#{mailbox_email_templates_path}"
+    if (name && htmldoc) {
+      $.ajax({
+        url: endpoint,
+        type: 'POST',
+        headers: {
+            'X-CSRF-Token': authenticityToken
+        },
+        data: JSON.stringify({ htmldoc: btoa(htmldoc), redoc: redoc, name: name }),
+        contentType: "application/json; charset=utf-8",
+        success: function(response) {
+          window.location.href = `${endpoint}/${response.id}/edit`
+        }
+      });
+    } else {
+      window.alert('Please give your template a name and set its content')
+    }
 
-    $.ajax({
-      url: endpoint,
-      type: 'POST',
-      headers: {
-          'X-CSRF-Token': authenticityToken
-      },
-      data: JSON.stringify({ htmldoc: htmldoc, redoc: redoc }),
-      contentType: "application/json; charset=utf-8",
-      success: function(response) {
-        window.location.href = `${endpoint}/${response.id}`
-      }
-    });
+    $("#VioletEmailEditorSubmit").prop("disabled", false)
   });

--- a/app/views/mailbox/mailbox/show.html.haml
+++ b/app/views/mailbox/mailbox/show.html.haml
@@ -3,7 +3,7 @@
 
 .page-header
   = link_to I18n.t('views.mailbox.index.header.actions.new'), new_mailbox_message_thread_path, class: 'btn btn-success float-right mx-1'
-  = link_to 'Email Templates', new_mailbox_email_template_path, class: 'btn btn-secondary float-right mx-1'
+  = link_to 'Email Templates', mailbox_email_templates_path, class: 'btn btn-secondary float-right mx-1'
   .h2
     = I18n.t('views.mailbox.index.header.title')
     = Subdomain.current.mailing_address

--- a/app/views/mailbox/message_threads/show.html.haml
+++ b/app/views/mailbox/message_threads/show.html.haml
@@ -9,17 +9,19 @@
   = render partial: 'messages/form', locals: { f: f, render_submit: true }
 - @message_thread.messages.each do |message|
   .card.my-3
-    .card-body 
+    .card-body
       .card-subtitle.mb-2.text-muted
         = message.from
       - if !message.from && Subdomain.current.track_email_opens
         .card-subtitle.mb-2.text-muted
           = message.opened ? 'opened' : 'not opened yet'
       .card-text.bg-light.px-2.py-3
-        = message.content
+        = render_email_content(message)
       - if message.attachments.any?
         .card-text.bg-dark.px-2.py-3.text-white
           Attachments
           %ul{class: 'list-group'}
             - message.attachments.each do |attachment|
               = link_to attachment.filename, rails_blob_path(attachment, disposition: 'attachment')
+
+

--- a/config/initializers/action_text.rb
+++ b/config/initializers/action_text.rb
@@ -1,0 +1,25 @@
+# Configure ActionText to allow style tags and attributes
+# This is necessary for email templates (e.g., Revolvapp) that include CSS styles and tables
+Rails.application.config.to_prepare do
+  # Allow the style attribute on all tags
+  ActionText::ContentHelper.allowed_attributes.add('style')
+  ActionText::ContentHelper.allowed_attributes.add('cellpadding')
+  ActionText::ContentHelper.allowed_attributes.add('cellspacing')
+  ActionText::ContentHelper.allowed_attributes.add('border')
+  ActionText::ContentHelper.allowed_attributes.add('width')
+  ActionText::ContentHelper.allowed_attributes.add('align')
+  ActionText::ContentHelper.allowed_attributes.add('valign')
+  ActionText::ContentHelper.allowed_attributes.add('bgcolor')
+  
+  # Allow the style tag itself
+  ActionText::ContentHelper.allowed_tags.add('style')
+  
+  # Allow table-related tags for email templates
+  ActionText::ContentHelper.allowed_tags.add('table')
+  ActionText::ContentHelper.allowed_tags.add('tbody')
+  ActionText::ContentHelper.allowed_tags.add('thead')
+  ActionText::ContentHelper.allowed_tags.add('tfoot')
+  ActionText::ContentHelper.allowed_tags.add('tr')
+  ActionText::ContentHelper.allowed_tags.add('td')
+  ActionText::ContentHelper.allowed_tags.add('th')
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,11 @@ Rails.application.routes.draw do
         patch 'add_categories'
       end
     end
-    resources :email_templates, controller: 'mailbox/email_templates'
+    resources :email_templates, controller: 'mailbox/email_templates' do
+      member do
+        post 'test_send'
+      end
+    end
   end
 
   # email tracking

--- a/db/migrate/20251122174516_create_email_templates.rb
+++ b/db/migrate/20251122174516_create_email_templates.rb
@@ -1,0 +1,12 @@
+class CreateEmailTemplates < ActiveRecord::Migration[6.1]
+  def change
+    create_table :email_templates do |t|
+      t.text :html
+      t.text :template
+      t.string :name
+      t.string :slug
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -403,6 +403,15 @@ ActiveRecord::Schema.define(version: 2025_11_23_170133) do
     t.index ["page_id"], name: "index_comfy_cms_translations_on_page_id"
   end
 
+  create_table "email_templates", force: :cascade do |t|
+    t.text "html"
+    t.text "template"
+    t.string "name"
+    t.string "slug"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "external_api_clients", force: :cascade do |t|
     t.bigint "api_namespace_id", null: false
     t.string "slug", null: false

--- a/test/controllers/mailbox/message_threads_controller_test.rb
+++ b/test/controllers/mailbox/message_threads_controller_test.rb
@@ -225,4 +225,47 @@ class Mailbox::MessageThreadsControllerTest < ActionDispatch::IntegrationTest
   test 'viewing unread thread sets unread:true' do
     # todo test https://github.com/restarone/violet_rails/blob/9476c661537a1688a81c95802d5f49a6617f0678/app/controllers/mailbox/message_threads_controller.rb
   end
+
+  test 'renders email content with style tags properly' do
+    sign_in(@user)
+    
+    # Create a message with HTML content including meta, style, and title tags (like Revolvapp templates)
+    html_content = <<~HTML
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+      <title>My Email</title>
+      <style type="text/css">
+        .test-class { color: red; }
+      </style>
+      <div class="test-class">Test content</div>
+    HTML
+    
+    Apartment::Tenant.switch @subdomain.name do
+      message_thread = MessageThread.create!(
+        unread: true, 
+        subject: 'Test Email with Styles', 
+        recipients: [@user.email]
+      )
+      message = message_thread.messages.create!(content: html_content)
+      
+      get mailbox_message_thread_url(subdomain: @subdomain.name, id: message_thread.id)
+      assert_response :success
+      
+      # Extract the message content area from the response
+      # The message content is rendered in a div with class 'card-text bg-light px-2 py-3'
+      message_content_match = response.body.match(/<div class='card-text bg-light px-2 py-3'>(.*?)<\/div>/m)
+      assert message_content_match, "Could not find message content in response"
+      message_content = message_content_match[1]
+      
+      # Verify that meta, style, title tags are NOT present in the message content
+      refute_match(/<meta/, message_content, "Meta tags should be removed from message content")
+      refute_match(/<style/, message_content, "Style tags should be removed from message content")
+      refute_match(/<title/, message_content, "Title tags should be removed from message content")
+      
+      # Verify that the actual content IS present
+      assert_match(/Test content/, message_content, "Message content should be present")
+      
+      # Verify that style tag content is not displayed as text
+      refute_match(/\.test-class \{ color: red; \}/, message_content, "CSS code should not be visible as text")
+    end
+  end
 end

--- a/test/fixtures/email_templates.yml
+++ b/test/fixtures/email_templates.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  html: MyText
+  template: MyText
+  name: MyString
+  slug: MyString
+
+two:
+  html: MyText
+  template: MyText
+  name: MyString
+  slug: MyString

--- a/test/helpers/messages_helper_test.rb
+++ b/test/helpers/messages_helper_test.rb
@@ -1,0 +1,371 @@
+require 'test_helper'
+
+class MessagesHelperTest < ActionView::TestCase
+  setup do
+    @subdomain = subdomains(:public)
+    Apartment::Tenant.switch @subdomain.name do
+      @message_thread = MessageThread.create!(
+        unread: true,
+        subject: 'Test Email',
+        recipients: ['test@example.com']
+      )
+    end
+  end
+
+  # Test: Normal case with meta, style, title, and link tags
+  test 'removes meta, style, title, and link tags from email content' do
+    html_content = <<~HTML
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>My Email</title>
+      <link href="https://fonts.googleapis.com/css?family=Inter:400" rel="stylesheet">
+      <style type="text/css">
+        .test-class { color: red; }
+      </style>
+      <div class="test-class">Test content</div>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify meta, style, title, and link tags are removed
+      refute_match(/<meta/, result)
+      refute_match(/<style/, result)
+      refute_match(/<title/, result)
+      refute_match(/<link/, result)
+
+      # Verify the actual content is present
+      assert_match(/Test content/, result)
+      assert_match(/<div/, result)
+    end
+  end
+
+  # Test: Content with only body HTML (no head tags)
+  test 'returns content as-is when no head tags are present' do
+    html_content = <<~HTML
+      <div class="email-body">
+        <h1>Welcome</h1>
+        <p>This is a test email.</p>
+      </div>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify content is present
+      assert_match(/Welcome/, result)
+      assert_match(/This is a test email/, result)
+      assert_match(/<div/, result)
+      assert_match(/<h1/, result)
+      assert_match(/<p/, result)
+    end
+  end
+
+  # Test: Empty message content
+  test 'returns empty string when message content is blank' do
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: '')
+      result = render_email_content(message)
+
+      assert_equal '', result
+    end
+  end
+
+  # Test: Message with nil content
+  test 'returns empty string when message content is nil' do
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.new
+      # Don't set content, it will be nil
+      message.save(validate: false)
+      
+      result = render_email_content(message)
+
+      assert_equal '', result
+    end
+  end
+
+  # Test: Complex email with tables and inline styles
+  test 'preserves tables and inline styles while removing head tags' do
+    html_content = <<~HTML
+      <meta charset="utf-8">
+      <style>body { margin: 0; }</style>
+      <table cellpadding="0" cellspacing="0" border="0" width="100%">
+        <tr>
+          <td align="center" style="background-color: #ffffff;">
+            <h1 style="color: #333;">Hello World</h1>
+          </td>
+        </tr>
+      </table>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify meta and style tags are removed
+      refute_match(/<meta/, result)
+      refute_match(/<style/, result)
+
+      # Verify table structure is preserved
+      assert_match(/<table/, result)
+      assert_match(/<tr/, result)
+      assert_match(/<td/, result)
+
+      # Verify inline styles are preserved (ActionText may remove spaces in CSS)
+      assert_match(/background-color:#ffffff/, result)
+      assert_match(/color:#333/, result)
+
+      # Verify content is present
+      assert_match(/Hello World/, result)
+    end
+  end
+
+  # Test: Multiple style tags
+  test 'removes all style tags when multiple are present' do
+    html_content = <<~HTML
+      <style>body { margin: 0; }</style>
+      <div>Content 1</div>
+      <style>.class1 { color: blue; }</style>
+      <div>Content 2</div>
+      <style>.class2 { color: green; }</style>
+      <div>Content 3</div>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify all style tags are removed
+      refute_match(/<style/, result)
+      refute_match(/body \{ margin: 0; \}/, result)
+      refute_match(/\.class1/, result)
+      refute_match(/\.class2/, result)
+
+      # Verify content is present
+      assert_match(/Content 1/, result)
+      assert_match(/Content 2/, result)
+      assert_match(/Content 3/, result)
+    end
+  end
+
+  # Test: Nested tags (style inside other tags)
+  test 'removes style tags even when nested' do
+    html_content = <<~HTML
+      <div>
+        <style>.nested { color: red; }</style>
+        <p>Nested content</p>
+      </div>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify style tag is removed
+      refute_match(/<style/, result)
+      refute_match(/\.nested/, result)
+
+      # Verify content and structure are preserved
+      assert_match(/Nested content/, result)
+      assert_match(/<div/, result)
+      assert_match(/<p/, result)
+    end
+  end
+
+  # Test: Email with images and links
+  test 'preserves images and links while removing head tags' do
+    html_content = <<~HTML
+      <meta name="viewport" content="width=device-width">
+      <style>img { max-width: 100%; }</style>
+      <a href="https://example.com">
+        <img src="https://example.com/logo.png" alt="Logo" width="100">
+      </a>
+      <p>Click the logo above</p>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify meta and style tags are removed
+      refute_match(/<meta/, result)
+      refute_match(/<style/, result)
+
+      # Verify images and links are preserved
+      assert_match(/<a href="https:\/\/example\.com"/, result)
+      assert_match(/<img/, result)
+      assert_match(/src="https:\/\/example\.com\/logo\.png"/, result)
+      assert_match(/alt="Logo"/, result)
+      assert_match(/width="100"/, result)
+
+      # Verify content is present
+      assert_match(/Click the logo above/, result)
+    end
+  end
+
+  # Test: Real Revolvapp-style email
+  test 'handles Revolvapp-style email with all head tags' do
+    html_content = <<~HTML
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Newsletter</title>
+      <link href="https://fonts.googleapis.com/css?family=Inter:400,700" rel="stylesheet">
+      <style type="text/css">
+        #outlook a{padding:0}
+        .ExternalClass{width:100%}
+        body{margin:0;padding:0}
+      </style>
+      <table cellpadding="0" cellspacing="0" border="0" width="600">
+        <tr>
+          <td align="center" style="padding: 40px;">
+            <h1>Newsletter Title</h1>
+            <p>Newsletter content goes here.</p>
+          </td>
+        </tr>
+      </table>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify all head tags are removed
+      refute_match(/<meta/, result)
+      refute_match(/<title/, result)
+      refute_match(/<link/, result)
+      refute_match(/<style/, result)
+
+      # Verify CSS content is not visible
+      refute_match(/#outlook a\{padding:0\}/, result)
+      refute_match(/ExternalClass/, result)
+
+      # Verify email structure is preserved
+      assert_match(/<table/, result)
+      assert_match(/Newsletter Title/, result)
+      assert_match(/Newsletter content goes here/, result)
+
+      # Verify inline styles are preserved (ActionText may remove spaces in CSS)
+      assert_match(/padding:40px/, result)
+    end
+  end
+
+  # Test: HTML with special characters
+  test 'handles HTML with special characters correctly' do
+    html_content = <<~HTML
+      <style>.special { content: "< > & \""; }</style>
+      <div>
+        <p>Special chars: &lt; &gt; &amp; &quot;</p>
+        <p>Symbols: © ® ™</p>
+      </div>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify style tag is removed
+      refute_match(/<style/, result)
+
+      # Verify special characters are preserved (Nokogiri decodes some entities)
+      assert_match(/&lt;/, result)
+      assert_match(/&gt;/, result)
+      assert_match(/&amp;/, result)
+      # Note: Nokogiri decodes &quot; to " when parsing, so we check for the actual character
+      assert_match(/"/, result)
+      assert_match(/©/, result)
+      assert_match(/®/, result)
+      assert_match(/™/, result)
+    end
+  end
+
+  # Test: Return value is html_safe
+  test 'returns html_safe string' do
+    html_content = '<div>Test</div>'
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      assert result.html_safe?
+    end
+  end
+
+  # Test: Whitespace handling
+  test 'handles whitespace correctly' do
+    html_content = <<~HTML
+      <meta charset="utf-8">
+      
+      <style>
+        body { margin: 0; }
+      </style>
+      
+      <div>
+        <p>Content with whitespace</p>
+      </div>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify tags are removed
+      refute_match(/<meta/, result)
+      refute_match(/<style/, result)
+
+      # Verify content is present
+      assert_match(/Content with whitespace/, result)
+    end
+  end
+
+  # Test: Self-closing tags
+  test 'handles self-closing meta and link tags' do
+    html_content = <<~HTML
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width" />
+      <link rel="stylesheet" href="style.css" />
+      <div>Content</div>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify self-closing tags are removed
+      refute_match(/<meta/, result)
+      refute_match(/<link/, result)
+
+      # Verify content is present
+      assert_match(/Content/, result)
+    end
+  end
+
+  # Test: Comments in HTML
+  # Note: ActionText strips HTML comments by default, so we only verify content is preserved
+  test 'handles HTML with comments (ActionText strips comments)' do
+    html_content = <<~HTML
+      <meta charset="utf-8">
+      <!-- This is a comment -->
+      <style>.test { color: red; }</style>
+      <div>
+        <!-- Another comment -->
+        <p>Content</p>
+      </div>
+    HTML
+
+    Apartment::Tenant.switch @subdomain.name do
+      message = @message_thread.messages.create!(content: html_content)
+      result = render_email_content(message)
+
+      # Verify head tags are removed
+      refute_match(/<meta/, result)
+      refute_match(/<style/, result)
+
+      # Verify content is present (comments are stripped by ActionText)
+      assert_match(/Content/, result)
+      assert_match(/<div/, result)
+      assert_match(/<p/, result)
+    end
+  end
+end

--- a/test/models/email_template_test.rb
+++ b/test/models/email_template_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EmailTemplateTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
✅ CRUD Email Templates 
✅ Inject dynamic content (copy, names, links) via dynamic segments  ✅ Click to copy email HTML
✅ Test send (with or without dynamic content injection)

<img width="975" height="845" alt="Screenshot 2025-11-26 at 9 15 01 AM" src="https://github.com/user-attachments/assets/59393d6b-4e4e-447a-b14f-1ea7322fbac1" />

## programmatic API

send email templates with dynamically injected segments: 

``` ruby
subject = "Support request: #{Time.now.strftime("%A, %B #{Time.now.day.ordinalize} %Y at%l:%M%p %Z")}"
email_content = EmailTemplate.find_by(slug: 'support_request').inject_dynamic_segments({email: api_resource.properties['email'], product: api_resource.properties['product'][0]})

# Sending email report
email_thread = MessageThread.create!(recipients: ['contact@restarone.com'], subject: subject)
email_message = email_thread.messages.create!(
  content: email_content.html_safe,
)
```


* basic crud scaffold. up next: delete + dynamic content injection

* dynamic segments, deleting templates and testing template

* debug email encoding/rendering

* attempt 2 for html integrity

* fix broken fixtures

* add inline documentation

* fix in revolapp email template

* fix email templates show in message threads, added render function in a helper to show as html

* fix ship right format

* fix render function, added validations and remove trix-content div

* fix inline images, show templates and fix render function, fix the tests

---------