### PR TITLE
fix: remove TODO comment and test field from GraphQL mutation type

### DIFF
--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,10 +1,4 @@
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
   end
 end


### PR DESCRIPTION
- Remove test field that was added by generator
- Clean up TODO comment indicating removal
- Simplify MutationType class to prepare for production use

This addresses code quality issues identified in the GraphQL schema.