### PR TITLE
fix: replace broad exception handling with specific exceptions

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -107,9 +107,11 @@ class Ahoy::Event < ApplicationRecord
 
         { success: true, message: message }
       end
-    rescue => e
+    rescue ActiveRecord::StatementInvalid => e
       error_message = delete_events ? "Deleting specific events failed due to: #{e.message}" : "Deleting associated visits of specific events failed due to: #{e.message}"
-
+      { success: false, message: "Database Error: #{e.message}" }
+    rescue StandardError => e
+      error_message = delete_events ? "Deleting specific events failed due to: #{e.message}" : "Deleting associated visits of specific events failed due to: #{e.message}"
       { success: false, message: e.message }
     end
   end

--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -212,14 +212,15 @@ class ApiNamespace < ApplicationRecord
               new_executed_api_action.save!
             end
           end
-        end
+end
 
         { success: true, data: new_api_namespace }
       end
-    rescue => e
+    rescue ActiveRecord::RecordInvalid => e
+      { success: false, message: "Validation Error: #{e.message}" }
+    rescue StandardError => e
       { success: false, message: e.message }
     end
-  end
 
   def export_as_json(include_associations: false)
     if include_associations
@@ -355,7 +356,11 @@ class ApiNamespace < ApplicationRecord
 
         { success: true, data: new_api_namespace }
       end
-    rescue => e
+    rescue ActiveRecord::RecordInvalid => e
+      { success: false, message: "Validation Error: #{e.message}" }
+    rescue JSON::ParserError => e
+      { success: false, message: "JSON Parse Error: #{e.message}" }
+    rescue StandardError => e
       { success: false, message: e.message }
     end
   end


### PR DESCRIPTION
- Replace 'rescue => e' with specific exception types in api_action.rb
- Replace 'rescue Exception => e' with specific exceptions for email sending
- Add specific HTTP and SMTP error handling in api_action.rb
- Replace broad rescues in api_namespace.rb with ActiveRecord::RecordInvalid and JSON::ParserError
- Replace broad rescue in ahoy/event.rb with ActiveRecord::StatementInvalid
- Improve error messages to be more descriptive for debugging

This improves error handling precision and debugging capabilities.