### PR TITLE
fix: optimize database queries to use find_each instead of all.each

### DIFF
--- a/app/models/api_namespace.rb
+++ b/app/models/api_namespace.rb
@@ -146,7 +146,7 @@ class ApiNamespace < ApplicationRecord
   end
 
   def rerun_api_actions
-    executed_api_actions.where(lifecycle_stage: 'failed').each(&:execute_action)
+    executed_api_actions.where(lifecycle_stage: 'failed').find_each(&:execute_action)
   end
 
   def discard_failed_actions

--- a/app/models/subdomain.rb
+++ b/app/models/subdomain.rb
@@ -235,8 +235,8 @@ class Subdomain < ApplicationRecord
 
   def purge_stored_files
     Apartment::Tenant.switch(self.name) do
-      ActiveStorage::Attachment.all.each { |attachment| attachment.purge }
-      ActiveStorage::Blob.all.each { |blob| blob.purge }
+      ActiveStorage::Attachment.find_each { |attachment| attachment.purge }
+      ActiveStorage::Blob.find_each { |blob| blob.purge }
     end
   end
 


### PR DESCRIPTION
- Replace ActiveStorage::Attachment.all.each with find_each in subdomain.rb
- Replace ActiveStorage::Blob.all.each with find_each in subdomain.rb
- Replace executed_api_actions.where(...).each with find_each in api_namespace.rb
- Improves memory efficiency for large datasets by processing records in batches
- Prevents memory exhaustion when dealing with large numbers of attachments/blobs

This addresses performance issues with large dataset processing.